### PR TITLE
Update prometheus operator Helm repo reference, add ArtifactHub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HiveMQ Helm charts
 
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/hivemq)](https://artifacthub.io/packages/search?repo=hivemq)
+
 This repository contains HiveMQ Helm charts.
 
 **NOTE** Every merge to master must imply an increased minor version of the chart to indicate that the templating has changed.
-
-**WARNING** Every push to master is released to the public chart repository. As we do not have CI tests for the charts yet, make absolutely sure the charts work before merging.

--- a/charts/hivemq-operator/Chart.lock
+++ b/charts/hivemq-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 11.0.4
-digest: sha256:1fe4733f309e794b64a03ae68bf14b58e85ba6ba0dc922bcc583d1a4d1b0bd1e
-generated: "2020-11-09T10:41:11.038029+01:00"
+  version: 11.1.4
+digest: sha256:5de12000a037565f7f26b6683b0d9862d0942606815ea615196200e134014655
+generated: "2020-11-16T17:11:51.268667+01:00"

--- a/charts/hivemq-operator/Chart.lock
+++ b/charts/hivemq-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: prometheus-operator
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 8.15.*
-digest: sha256:1c391dc9c1d96bcaee7fa582084799e0683f7d683bd1f50e67db7fda4824ed51
-generated: "2020-07-17T12:04:23.043220407+02:00"
+- name: kube-prometheus-stack
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 11.0.4
+digest: sha256:1fe4733f309e794b64a03ae68bf14b58e85ba6ba0dc922bcc583d1a4d1b0bd1e
+generated: "2020-11-09T10:41:11.038029+01:00"

--- a/charts/hivemq-operator/Chart.yaml
+++ b/charts/hivemq-operator/Chart.yaml
@@ -7,6 +7,7 @@ keywords:
   - IoT
   - Java
   - distributed
+  - messaging
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 version: 0.6.3

--- a/charts/hivemq-operator/Chart.yaml
+++ b/charts/hivemq-operator/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.6.2
 appVersion: 4.4.2
 icon: https://www.hivemq.com/img/svg/hivemq-bee.svg
 dependencies:
-  - name: prometheus-operator
-    repository: https://kubernetes-charts.storage.googleapis.com/
+  - name: kube-prometheus-stack
+    repository: https://prometheus-community.github.io/helm-charts
     condition: monitoring.dedicated, monitoring.enabled
-    version: 8.15.*
+    version: 11.*

--- a/charts/hivemq-operator/Chart.yaml
+++ b/charts/hivemq-operator/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - distributed
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.6.2
+version: 0.6.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 4.4.2


### PR DESCRIPTION
so we don't break with the depreciation of the original helm stable repo