### PR TITLE
[4.5] preparation

### DIFF
--- a/charts/hivemq-operator/CHANGELOG.md
+++ b/charts/hivemq-operator/CHANGELOG.md
@@ -1,8 +1,14 @@
 # 4.5.0
 
-- Added safe sysctl settings by default to the HiveMQ Pods' security context
-- Added a separate Deployment controller template that sets some initial unsafe sysctls as well
+- Added safe sysctl settings by default to the HiveMQ Pods' security context which will extend the local port range
+- Added a separate Deployment controller template that sets some unsafe sysctls (You will have to reconfigure kubelet to use this)
 - Add support for custom sidecar containers that run alongside your HiveMQ deployment
 - Add proper templating and default example for the initContainer field.
 - Add nodeSelector support to operator deployment template
-- Increased liveness `failureThreshold` to ensure joining HiveMQ nodes don't get shut down during join
+- Increased liveness `failureThreshold` to ensure joining HiveMQ nodes don't get shut down during a long-lasting join process
+
+- Fix templating of multi-line environment variables
+- Add a default heap dump storage path and volume, to preserve heap dump files after container restarts (requires HiveMQ 4.4.3+)
+- Fix image pull secrets not being used in generated custom resource
+- Add field for adding annotations to the operator service account
+- Improve service monitor naming to exactly match the generated cluster name, for easier correlation when querying metrics

--- a/charts/hivemq-operator/CHANGELOG.md
+++ b/charts/hivemq-operator/CHANGELOG.md
@@ -15,3 +15,4 @@
 - Introduce more detailed webhook configuration option
 - Add namespace override
 - Reduce `cpuLimitRatio` default value to 1 for a more predictable CPU count seen by HiveMQ.
+- Changed default transport type to TCP. Note that if you are upgrading, you must set the transport explicitly to UDP or re-create (backup, uninstall, install) your cluster to switch to TCP transport.

--- a/charts/hivemq-operator/CHANGELOG.md
+++ b/charts/hivemq-operator/CHANGELOG.md
@@ -14,3 +14,4 @@
 - Move image pull secrets to global section
 - Introduce more detailed webhook configuration option
 - Add namespace override
+- Reduce `cpuLimitRatio` default value to 1 for a more predictable CPU count seen by HiveMQ.

--- a/charts/hivemq-operator/CHANGELOG.md
+++ b/charts/hivemq-operator/CHANGELOG.md
@@ -5,9 +5,12 @@
 - Add proper templating and default example for the initContainer field.
 - Add nodeSelector support to operator deployment template
 - Increased liveness `failureThreshold` to ensure joining HiveMQ nodes don't get shut down during a long-lasting join process
-
 - Fix templating of multi-line environment variables
 - Add a default heap dump storage path and volume, to preserve heap dump files after container restarts (requires HiveMQ 4.4.3+)
 - Fix image pull secrets not being used in generated custom resource
 - Add field for adding annotations to the operator service account
 - Improve service monitor naming to exactly match the generated cluster name, for easier correlation when querying metrics
+- Migrate validation hook TLS provisioning to webhook cert generator
+- Move image pull secrets to global section
+- Introduce more detailed webhook configuration option
+- Add namespace override

--- a/charts/hivemq-operator/CHANGELOG.md
+++ b/charts/hivemq-operator/CHANGELOG.md
@@ -1,0 +1,8 @@
+# 4.5.0
+
+- Added safe sysctl settings by default to the HiveMQ Pods' security context
+- Added a separate Deployment controller template that sets some initial unsafe sysctls as well
+- Add support for custom sidecar containers that run alongside your HiveMQ deployment
+- Add proper templating and default example for the initContainer field.
+- Add nodeSelector support to operator deployment template
+- Increased liveness `failureThreshold` to ensure joining HiveMQ nodes don't get shut down during join

--- a/charts/hivemq-operator/CHANGELOG.md
+++ b/charts/hivemq-operator/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 - Added safe sysctl settings by default to the HiveMQ Pods' security context which will extend the local port range
 - Added a separate Deployment controller template that sets some unsafe sysctls (You will have to reconfigure kubelet to use this)
-- Add support for custom sidecar containers that run alongside your HiveMQ deployment
 - Add proper templating and default example for the initContainer field.
 - Add nodeSelector support to operator deployment template
 - Increased liveness `failureThreshold` to ensure joining HiveMQ nodes don't get shut down during a long-lasting join process

--- a/charts/hivemq-operator/Chart.lock
+++ b/charts/hivemq-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 11.1.4
-digest: sha256:5de12000a037565f7f26b6683b0d9862d0942606815ea615196200e134014655
-generated: "2020-11-16T17:11:51.268667+01:00"
+  version: 11.1.7
+digest: sha256:b618c2a9d528c9cdafce27232d4b1d3d621b8ed112fddaeeed0ec1d4dd1437f3
+generated: "2020-12-07T17:29:58.21787+01:00"

--- a/charts/hivemq-operator/Chart.yaml
+++ b/charts/hivemq-operator/Chart.yaml
@@ -10,10 +10,10 @@ keywords:
   - messaging
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.7.0
+version: 0.8.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 4.4.3
+appVersion: 4.5.0
 icon: https://www.hivemq.com/img/svg/hivemq-bee.svg
 dependencies:
   - name: kube-prometheus-stack

--- a/charts/hivemq-operator/crds/hivemq-cluster.yaml
+++ b/charts/hivemq-operator/crds/hivemq-cluster.yaml
@@ -114,6 +114,14 @@ spec:
             labels:
               description: "Labels for the cluster"
               type: "object"
+            sidecars:
+              description: "Sidecar containers to run alongside the HiveMQ container"
+              items:
+                description: "A single container spec for a sidecar container, wrapped\
+                  \ in a multi-line scalar string. See Container v1 in the API spec\
+                  \ for format."
+                type: "string"
+              type: "array"
             env:
               description: "Additional environment variables for the cluster"
               items:

--- a/charts/hivemq-operator/crds/hivemq-cluster.yaml
+++ b/charts/hivemq-operator/crds/hivemq-cluster.yaml
@@ -114,14 +114,6 @@ spec:
             labels:
               description: "Labels for the cluster"
               type: "object"
-            sidecars:
-              description: "Sidecar containers to run alongside the HiveMQ container"
-              items:
-                description: "A single container spec for a sidecar container, wrapped\
-                  \ in a multi-line scalar string. See Container v1 in the API spec\
-                  \ for format."
-                type: "string"
-              type: "array"
             env:
               description: "Additional environment variables for the cluster"
               items:

--- a/charts/hivemq-operator/operator-tmpls/cluster-daemon-set.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-daemon-set.yaml
@@ -25,7 +25,7 @@ spec:
       labels:
         app: "hivemq"
         hivemq-cluster: "{{ spec.name }}"
-        hivemq.com/node-offline: "false"
+        hivemq.com/node-offline: false
     spec:
       initContainers:
       - name: "init-shared"
@@ -33,6 +33,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            mkdir -p /opt/hivemq/bin
             mkdir -p /opt/hivemq/backup
             mkdir -p /opt/hivemq/extensions
             mkdir -p /opt/hivemq/conf
@@ -108,15 +109,15 @@ spec:
             - name: JAVA_OPTS
               value: "{{ spec.javaOptions }}"
             - name: HIVEMQ_CLUSTER_PORT
-              value: "{{ util:getPort(spec, "cluster").port }}"
+              value: {{ util:getPort(spec, "cluster").port }}
             - name: HIVEMQ_MQTT_PORT
-              value: "{{ util:getPort(spec, "mqtt").port }}"
+              value: {{ util:getPort(spec, "mqtt").port }}
             - name: HIVEMQ_CONTROL_CENTER_PORT
-              value: "{{ util:getPort(spec, "cc").port }}"
+              value: {{ util:getPort(spec, "cc").port }}
             - name: HIVEMQ_REST_API_PORT
-              value: "{{ util:getPort(spec, "api").port }}"
+              value: {{ util:getPort(spec, "api").port }}
             - name: HIVEMQ_REST_API_ENABLED
-              value: "{{ util:getPort(spec, "api").port != null }}"
+              value: {{ util:getPort(spec, "api").port != null }}
             - name: HIVEMQ_CLUSTER_REPLICA_COUNT
               value: "{{ spec.clusterReplicaCount }}"
             - name: HIVEMQ_CLUSTER_OVERLOAD_PROTECTION
@@ -182,10 +183,11 @@ spec:
             - name: HIVEMQ_REST_API_CONFIGURATION
               value: |
 {{ util:indent(15, spec.restApiConfiguration) }}
-              {% for env in spec.env %}
+          {% for env in spec.env %}
             - name: {{ env.name }}
-              value: {{ env.value }}
-              {% endfor %}
+              value: |
+                {{ util:indentCustom(15, 0, env.value) }}
+          {% endfor %}
           image: "{{ util:getTaggedImage(spec) }}"
           ports:{% for portInstance in spec.ports %}
             - containerPort: {{ portInstance.port }}
@@ -213,19 +215,23 @@ spec:
             periodSeconds: 30
             failureThreshold: 240
           volumeMounts:
-            - name: shared-data
-              mountPath: /hivemq-data
-            - name: conf-override
-              mountPath: /conf-override
-              readOnly: false
-            - name: live-info
-              mountPath: /etc/podinfo
-            - name: backup
-              mountPath: /opt/hivemq/backup
-              readOnly: false
-            - name: log
-              mountPath: /opt/hivemq/log
-              readOnly: false
+          - name: shared-data
+            mountPath: /hivemq-data
+            readOnly: false
+          - name: conf-override
+            mountPath: /conf-override
+            readOnly: false
+          - name: live-info
+            mountPath: /etc/podinfo
+          - name: backup
+            mountPath: /opt/hivemq/backup
+            readOnly: false
+          - name: log
+            mountPath: /opt/hivemq/log
+            readOnly: false
+          - name: audit
+            mountPath: /opt/hivemq/audit
+            readOnly: false
             {% for map in spec.configMaps %}
             - name: {{ map.name }}
               mountPath: {{ util:stringReplace(map.path, "/opt/hivemq/", "/conf-override/") }}
@@ -241,9 +247,6 @@ spec:
               mountPath: {{ util:stringReplace(secret.path, "/opt/hivemq/", "/conf-override/") }}
             {% endif %}
             {% endfor %}
-        {% for sidecar in spec.sidecars %}
-        - {{ util:indentCustom(8, 0, sidecar) }}
-        {% endfor %}
       # Wait longer for replication tasks
       terminationGracePeriodSeconds: 3600
       volumes:
@@ -255,6 +258,8 @@ spec:
         - name: backup
           emptyDir: {}
         - name: log
+          emptyDir: {}
+        - name: audit
           emptyDir: {}
         - name: live-info
           configMap:

--- a/charts/hivemq-operator/operator-tmpls/cluster-daemon-set.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-daemon-set.yaml
@@ -109,15 +109,15 @@ spec:
             - name: JAVA_OPTS
               value: "{{ spec.javaOptions }}"
             - name: HIVEMQ_CLUSTER_PORT
-              value: {{ util:getPort(spec, "cluster").port }}
+              value: "{{ util:getPort(spec, "cluster").port }}"
             - name: HIVEMQ_MQTT_PORT
-              value: {{ util:getPort(spec, "mqtt").port }}
+              value: "{{ util:getPort(spec, "mqtt").port }}"
             - name: HIVEMQ_CONTROL_CENTER_PORT
-              value: {{ util:getPort(spec, "cc").port }}
+              value: "{{ util:getPort(spec, "cc").port }}"
             - name: HIVEMQ_REST_API_PORT
-              value: {{ util:getPort(spec, "api").port }}
+              value: "{{ util:getPort(spec, "api").port }}"
             - name: HIVEMQ_REST_API_ENABLED
-              value: {{ util:getPort(spec, "api").port != null }}
+              value: "{{ util:getPort(spec, "api").port != null }}"
             - name: HIVEMQ_CLUSTER_REPLICA_COUNT
               value: "{{ spec.clusterReplicaCount }}"
             - name: HIVEMQ_CLUSTER_OVERLOAD_PROTECTION

--- a/charts/hivemq-operator/operator-tmpls/cluster-daemon-set.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-daemon-set.yaml
@@ -89,16 +89,15 @@ spec:
       {% if spec.serviceAccountName != null %}
       serviceAccountName: "{{ spec.serviceAccountName }}"
       {% endif %}
+      securityContext:
+        sysctls:
+          - name: net.ipv4.ip_local_port_range
+            value: "1024 65535"
       containers:
         - name: "hivemq"
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
-            sysctls:
-              - name: net.core.somaxconn
-                value: "32768"
-              - name: net.ipv4.ip_local_port_range
-                value: "1024 65535"
           env:
             - name: HIVEMQ_DNS_DISCOVERY_ADDRESS
               value: "hivemq-{{ spec.name }}-cluster.{{ spec.namespace }}.svc.cluster.local."

--- a/charts/hivemq-operator/operator-tmpls/cluster-daemon-set.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-daemon-set.yaml
@@ -94,6 +94,11 @@ spec:
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
+            sysctls:
+              - name: net.core.somaxconn
+                value: "32768"
+              - name: net.ipv4.ip_local_port_range
+                value: "1024 65535"
           env:
             - name: HIVEMQ_DNS_DISCOVERY_ADDRESS
               value: "hivemq-{{ spec.name }}-cluster.{{ spec.namespace }}.svc.cluster.local."

--- a/charts/hivemq-operator/operator-tmpls/cluster-daemon-set.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-daemon-set.yaml
@@ -51,8 +51,10 @@ spec:
           mountPath: /opt/hivemq/backup
           readOnly: false
         {% for map in spec.configMaps %}
+        {% if map.path != "none" %}
         - name: {{ map.name }}
           mountPath: {{ util:stringReplace(map.path, "/opt/hivemq/", "/conf-override/") }}
+        {% endif %}
         {% endfor %}
         {% for extension in spec.extensions %}
         {% if extension.configMap != null %}
@@ -71,8 +73,10 @@ spec:
         args: {{ initContainer.args }}
         volumeMounts:
         {% for map in spec.configMaps %}
+        {% if map.path != "none" %}
         - name: {{ map.name }}
           mountPath: {{ util:stringReplace(map.path, "/opt/hivemq/", "/conf-override/") }}
+        {% endif %}
         {% endfor %}
         {% for extension in spec.extensions %}
         {% if extension.configMap != null %}
@@ -207,7 +211,7 @@ spec:
               port: {{ util:getPort(spec, "mqtt").port }}
             initialDelaySeconds: 15
             periodSeconds: 30
-            failureThreshold: 90
+            failureThreshold: 240
           volumeMounts:
             - name: shared-data
               mountPath: /hivemq-data
@@ -219,6 +223,9 @@ spec:
             - name: backup
               mountPath: /opt/hivemq/backup
               readOnly: false
+            - name: log
+              mountPath: /opt/hivemq/log
+              readOnly: false
             {% for map in spec.configMaps %}
             - name: {{ map.name }}
               mountPath: {{ util:stringReplace(map.path, "/opt/hivemq/", "/conf-override/") }}
@@ -229,9 +236,14 @@ spec:
               mountPath: /conf-override/extensions/{{ extension.name }}
             {% endif %}{% endfor %}
             {% for secret in spec.secrets %}
+            {% if secret.path != "none" %}}
             - name: {{ secret.name }}
               mountPath: {{ util:stringReplace(secret.path, "/opt/hivemq/", "/conf-override/") }}
+            {% endif %}
             {% endfor %}
+        {% for sidecar in spec.sidecars %}
+        - {{ util:indentCustom(8, 0, sidecar) }}
+        {% endfor %}
       # Wait longer for replication tasks
       terminationGracePeriodSeconds: 3600
       volumes:
@@ -241,6 +253,8 @@ spec:
         - name: conf-override
           emptyDir: {}
         - name: backup
+          emptyDir: {}
+        - name: log
           emptyDir: {}
         - name: live-info
           configMap:

--- a/charts/hivemq-operator/operator-tmpls/cluster-daemon-set.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-daemon-set.yaml
@@ -25,7 +25,7 @@ spec:
       labels:
         app: "hivemq"
         hivemq-cluster: "{{ spec.name }}"
-        hivemq.com/node-offline: false
+        hivemq.com/node-offline: "false"
     spec:
       initContainers:
       - name: "init-shared"

--- a/charts/hivemq-operator/operator-tmpls/cluster-deployment-unsafe-sysctls.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-deployment-unsafe-sysctls.yaml
@@ -58,9 +58,14 @@ spec:
         - name: backup
           mountPath: /opt/hivemq/backup
           readOnly: false
+        - name: log
+          mountPath: /opt/hivemq/log
+          readOnly: false
         {% for map in spec.configMaps %}
+        {% if map.path != "none" %}
         - name: {{ map.name }}
           mountPath: {{ util:stringReplace(map.path, "/opt/hivemq/", "/conf-override/") }}
+        {% endif %}
         {% endfor %}
         {% for extension in spec.extensions %}
         {% if extension.configMap != null %}
@@ -74,8 +79,10 @@ spec:
         args: {{ initContainer.args }}
         volumeMounts:
         {% for map in spec.configMaps %}
+        {% if map.path != "none" %}
         - name: {{ map.name }}
           mountPath: {{ util:stringReplace(map.path, "/opt/hivemq/", "/conf-override/") }}
+        {% endif %}
         {% endfor %}
         {% for extension in spec.extensions %}
         {% if extension.configMap != null %}
@@ -181,10 +188,10 @@ spec:
 {{ util:indent(12, spec.configOverride) }}
         - name: HIVEMQ_LISTENER_CONFIGURATION
           value: |
-{{ util:indent(12, spec.listenerConfiguration) }}
+            {{ util:indentCustom(12, 0, spec.listenerConfiguration) }}
         - name: HIVEMQ_REST_API_CONFIGURATION
           value: |
-{{ util:indent(12, spec.restApiConfiguration) }}
+            {{ util:indentCustom(12, 0, spec.restApiConfiguration) }}
         {% for env in spec.env %}
         - name: {{ env.name }}
           value: {{ env.value }}
@@ -214,7 +221,7 @@ spec:
             port: {{ util:getPort(spec, "mqtt").port }}
           initialDelaySeconds: 15
           periodSeconds: 30
-          failureThreshold: 90
+          failureThreshold: 240
         volumeMounts:
           - name: shared-data
             mountPath: /hivemq-data
@@ -227,18 +234,25 @@ spec:
             mountPath: /opt/hivemq/backup
             readOnly: false
           {% for map in spec.configMaps %}
+          {% if map.path != "none" %}
           - name: {{ map.name }}
             mountPath: {{ util:stringReplace(map.path, "/opt/hivemq/", "/conf-override/") }}
+          {% endif %}
           {% endfor %}
           {% for secret in spec.secrets %}
+          {% if secret.path != "none" %}
           - name: {{ secret.name }}
             mountPath: {{ util:stringReplace(secret.path, "/opt/hivemq/", "/conf-override/") }}
+          {% endif %}
           {% endfor %}
           {% for extension in spec.extensions %}
           {% if extension.configMap != null %}
           - name: {{ extension.configMap }}
             mountPath: /conf-override/extensions/{{ extension.name }}
           {% endif %}{% endfor %}
+        {% for sidecar in spec.sidecars %}
+      - {{ util:indentCustom(8, 0, sidecar) }}
+        {% endfor %}
       # Wait longer for replication tasks
       terminationGracePeriodSeconds: 3600
       affinity:
@@ -250,6 +264,8 @@ spec:
         - name: conf-override
           emptyDir: {}
         - name: backup
+          emptyDir: {}
+        - name: log
           emptyDir: {}
         - name: live-info
           configMap:

--- a/charts/hivemq-operator/operator-tmpls/cluster-deployment-unsafe-sysctls.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-deployment-unsafe-sysctls.yaml
@@ -92,36 +92,19 @@ spec:
       {% if spec.serviceAccountName != null %}
       serviceAccountName: "{{ spec.serviceAccountName }}"
       {% endif %}
+      securityContext:
+        sysctls:
+          - name: net.core.somaxconn
+            value: "32768"
+          - name: net.ipv4.ip_local_port_range
+            value: "1024 65535"
+          - name: net.ipv4.tcp_fin_timeout
+            value: "90"
       containers:
       - name: "hivemq"
         securityContext:
           privileged: false
           allowPrivilegeEscalation: false
-          sysctls:
-            - name: net.core.somaxconn
-              value: "32768"
-            - name: net.ipv4.ip_local_port_range
-              value: "1024 65535"
-            - name: net.ipv4.tcp_fin_timeout
-              value: "90"
-            - name: net.ipv4.tcp_tw_recycle
-              value: "1"
-            - name: net.ipv4.tcp_tw_reuse
-              value: "1"
-            - name: net.core.rmem_default
-              value: "524288"
-            - name: net.core.wmem_default
-              value: "524288"
-            - name: net.core.rmem_max
-              value: "67108864"
-            - name: net.core.wmem_max
-              value: "67108864"
-            - name: net.ipv4.tcp_rmem
-              value: "4096 87380 16777216"
-            - name: net.ipv4.tcp_wmem
-              value: "4096 65536 16777216"
-            - name: fs.file-max
-              value: "5097152"
         env:
         - name: HIVEMQ_DNS_DISCOVERY_ADDRESS
           value: "hivemq-{{ spec.name }}-cluster.{{ spec.namespace }}.svc.cluster.local."

--- a/charts/hivemq-operator/operator-tmpls/cluster-deployment-unsafe-sysctls.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-deployment-unsafe-sysctls.yaml
@@ -22,7 +22,7 @@ spec:
     matchLabels:
       app: "hivemq"
       hivemq-cluster: "{{ spec.name }}"
-  replicas: {{ spec.nodeCount }}
+  replicas: "{{ spec.nodeCount }}"
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -33,7 +33,7 @@ spec:
       labels:
         app: "hivemq"
         hivemq-cluster: "{{ spec.name }}"
-        hivemq.com/node-offline: "false"
+        hivemq.com/node-offline: false
     spec:
       initContainers:
       - name: "init-shared"
@@ -67,11 +67,6 @@ spec:
         - name: {{ extension.configMap }}
           mountPath: /conf-override/extensions/{{ extension.name }}
         {% endif %}{% endfor %}
-      - name: dns-wait
-        image: hivemq/init-dns-wait:1.0.0
-        volumeMounts:
-          - mountPath: /mnt/misc
-            name: dns-wait-config
       {% for initContainer in spec.initialization %}
       - name: {{ initContainer.name }}
         image: {{ initContainer.image }}
@@ -107,21 +102,41 @@ spec:
               value: "32768"
             - name: net.ipv4.ip_local_port_range
               value: "1024 65535"
+            - name: net.ipv4.tcp_fin_timeout
+              value: "90"
+            - name: net.ipv4.tcp_tw_recycle
+              value: "1"
+            - name: net.ipv4.tcp_tw_reuse
+              value: "1"
+            - name: net.core.rmem_default
+              value: "524288"
+            - name: net.core.wmem_default
+              value: "524288"
+            - name: net.core.rmem_max
+              value: "67108864"
+            - name: net.core.wmem_max
+              value: "67108864"
+            - name: net.ipv4.tcp_rmem
+              value: "4096 87380 16777216"
+            - name: net.ipv4.tcp_wmem
+              value: "4096 65536 16777216"
+            - name: fs.file-max
+              value: "5097152"
         env:
         - name: HIVEMQ_DNS_DISCOVERY_ADDRESS
           value: "hivemq-{{ spec.name }}-cluster.{{ spec.namespace }}.svc.cluster.local."
         - name: JAVA_OPTS
           value: "{{ spec.javaOptions }}"
         - name: HIVEMQ_CLUSTER_PORT
-          value: "{{ util:getPort(spec, "cluster").port }}"
+          value: {{ util:getPort(spec, "cluster").port }}
         - name: HIVEMQ_MQTT_PORT
-          value: "{{ util:getPort(spec, "mqtt").port }}"
+          value: {{ util:getPort(spec, "mqtt").port }}
         - name: HIVEMQ_CONTROL_CENTER_PORT
-          value: "{{ util:getPort(spec, "cc").port }}"
+          value: {{ util:getPort(spec, "cc").port }}
         - name: HIVEMQ_REST_API_PORT
-          value: "{{ util:getPort(spec, "api").port }}"
+          value: {{ util:getPort(spec, "api").port }}
         - name: HIVEMQ_REST_API_ENABLED
-          value: "{{ util:getPort(spec, "api").port != null }}"
+          value: {{ util:getPort(spec, "api").port != null }}
         - name: HIVEMQ_CLUSTER_REPLICA_COUNT
           value: "{{ spec.clusterReplicaCount }}"
         - name: HIVEMQ_CLUSTER_OVERLOAD_PROTECTION
@@ -256,9 +271,6 @@ spec:
         - name: live-info
           configMap:
             name: hivemq-cluster-{{ spec.name }}-dynamic-state
-        - name: dns-wait-config
-          configMap:
-            name: hivemq-cluster-{{ spec.name }}-dns-wait-config
         {% for map in spec.configMaps %}
         - name: {{ map.name }}
           configMap:

--- a/charts/hivemq-operator/operator-tmpls/cluster-deployment-unsafe-sysctls.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-deployment-unsafe-sysctls.yaml
@@ -16,13 +16,14 @@ metadata:
     name: "{{ spec.name }}"
     uid: "{{ spec.metadata.uid }}"
 spec:
+  minReadySeconds: 30
   progressDeadlineSeconds: 10800
   revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: "hivemq"
       hivemq-cluster: "{{ spec.name }}"
-  replicas: "{{ spec.nodeCount }}"
+  replicas: {{ spec.nodeCount }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -33,33 +34,50 @@ spec:
       labels:
         app: "hivemq"
         hivemq-cluster: "{{ spec.name }}"
-        hivemq.com/node-offline: false
+        hivemq.com/node-offline: "false"
     spec:
       initContainers:
       - name: "init-shared"
+        resources:
+          limits:
+            cpu: "{{ util:getCpuLimit(spec) }}"
+            memory: "{{ util:getMemoryLimit(spec) }}"
+            ephemeral-storage: "{{ util:getStorageLimit(spec) }}"
+          requests:
+            cpu: "{{ spec.cpu }}"
+            memory: "{{ spec.memory }}"
+            ephemeral-storage: "{{ spec.ephemeralStorage }}"
         image: "busybox:latest"
         command: ["/bin/sh", "-c"]
         args:
           - |
+            mkdir -p /opt/hivemq/bin
             mkdir -p /opt/hivemq/backup
             mkdir -p /opt/hivemq/extensions
             mkdir -p /opt/hivemq/conf
             mkdir -p /opt/hivemq/license
-            cp -r /opt/hivemq/* /hivemq-data/
             cp -r /opt/hivemq/* /conf-override/
+            cp -r /opt/hivemq/* /hivemq-data/
         volumeMounts:
         - name: shared-data
           mountPath: /hivemq-data
+          readOnly: false
         - name: conf-override
           mountPath: /conf-override
           readOnly: false
         - name: live-info
           mountPath: /etc/podinfo
         - name: backup
-          mountPath: /opt/hivemq/backup
+          mountPath: /conf-override/backup
           readOnly: false
         - name: log
-          mountPath: /opt/hivemq/log
+          mountPath: /conf-override/log
+          readOnly: false
+        - name: audit
+          mountPath: /conf-override/audit
+          readOnly: false
+        - name: heap-dumps
+          mountPath: /opt/hivemq/dumps
           readOnly: false
         {% for map in spec.configMaps %}
         {% if map.path != "none" %}
@@ -72,12 +90,50 @@ spec:
         - name: {{ extension.configMap }}
           mountPath: /conf-override/extensions/{{ extension.name }}
         {% endif %}{% endfor %}
+      - name: dns-wait
+        image: hivemq/init-dns-wait:1.0.0
+        resources:
+          limits:
+            cpu: "{{ util:getCpuLimit(spec) }}"
+            memory: "{{ util:getMemoryLimit(spec) }}"
+            ephemeral-storage: "{{ util:getStorageLimit(spec) }}"
+          requests:
+            cpu: "{{ spec.cpu }}"
+            memory: "{{ spec.memory }}"
+            ephemeral-storage: "{{ spec.ephemeralStorage }}"
+        volumeMounts:
+          - mountPath: /mnt/misc
+            name: dns-wait-config
       {% for initContainer in spec.initialization %}
       - name: {{ initContainer.name }}
         image: {{ initContainer.image }}
+        resources:
+          limits:
+            cpu: "{{ util:getCpuLimit(spec) }}"
+            memory: "{{ util:getMemoryLimit(spec) }}"
+            ephemeral-storage: "{{ util:getStorageLimit(spec) }}"
+          requests:
+            cpu: "{{ spec.cpu }}"
+            memory: "{{ spec.memory }}"
+            ephemeral-storage: "{{ spec.ephemeralStorage }}"
         command: {{ initContainer.command }}
         args: {{ initContainer.args }}
         volumeMounts:
+        - name: shared-data
+          mountPath: /hivemq-data
+          readOnly: false
+        - name: conf-override
+          mountPath: /conf-override
+          readOnly: false
+        - name: backup
+          mountPath: /conf-override/backup
+          readOnly: false
+        - name: log
+          mountPath: /conf-override/log
+          readOnly: false
+        - name: audit
+          mountPath: /conf-override/audit
+          readOnly: false
         {% for map in spec.configMaps %}
         {% if map.path != "none" %}
         - name: {{ map.name }}
@@ -118,15 +174,15 @@ spec:
         - name: JAVA_OPTS
           value: "{{ spec.javaOptions }}"
         - name: HIVEMQ_CLUSTER_PORT
-          value: {{ util:getPort(spec, "cluster").port }}
+          value: "{{ util:getPort(spec, "cluster").port }}"
         - name: HIVEMQ_MQTT_PORT
-          value: {{ util:getPort(spec, "mqtt").port }}
+          value: "{{ util:getPort(spec, "mqtt").port }}"
         - name: HIVEMQ_CONTROL_CENTER_PORT
-          value: {{ util:getPort(spec, "cc").port }}
+          value: "{{ util:getPort(spec, "cc").port }}"
         - name: HIVEMQ_REST_API_PORT
-          value: {{ util:getPort(spec, "api").port }}
+          value: "{{ util:getPort(spec, "api").port }}"
         - name: HIVEMQ_REST_API_ENABLED
-          value: {{ util:getPort(spec, "api").port != null }}
+          value: "{{ util:getPort(spec, "api").port != null }}"
         - name: HIVEMQ_CLUSTER_REPLICA_COUNT
           value: "{{ spec.clusterReplicaCount }}"
         - name: HIVEMQ_CLUSTER_OVERLOAD_PROTECTION
@@ -192,9 +248,12 @@ spec:
         - name: HIVEMQ_REST_API_CONFIGURATION
           value: |
             {{ util:indentCustom(12, 0, spec.restApiConfiguration) }}
+        - name: HIVEMQ_HEAPDUMP_HOME
+          value: /opt/hivemq/dumps
         {% for env in spec.env %}
         - name: {{ env.name }}
-          value: {{ env.value }}
+          value: |
+            {{ util:indentCustom(12, 0, env.value) }}
         {% endfor %}
         image: "{{ util:getTaggedImage(spec) }}"
         ports:{% for portInstance in spec.ports %}
@@ -225,6 +284,7 @@ spec:
         volumeMounts:
           - name: shared-data
             mountPath: /hivemq-data
+            readOnly: false
           - name: conf-override
             mountPath: /conf-override
             readOnly: false
@@ -232,6 +292,15 @@ spec:
             mountPath: /etc/podinfo
           - name: backup
             mountPath: /opt/hivemq/backup
+            readOnly: false
+          - name: log
+            mountPath: /opt/hivemq/log
+            readOnly: false
+          - name: audit
+            mountPath: /opt/hivemq/audit
+            readOnly: false
+          - name: heap-dumps
+            mountPath: /opt/hivemq/dumps
             readOnly: false
           {% for map in spec.configMaps %}
           {% if map.path != "none" %}
@@ -250,9 +319,6 @@ spec:
           - name: {{ extension.configMap }}
             mountPath: /conf-override/extensions/{{ extension.name }}
           {% endif %}{% endfor %}
-        {% for sidecar in spec.sidecars %}
-      - {{ util:indentCustom(8, 0, sidecar) }}
-        {% endfor %}
       # Wait longer for replication tasks
       terminationGracePeriodSeconds: 3600
       affinity:
@@ -265,11 +331,18 @@ spec:
           emptyDir: {}
         - name: backup
           emptyDir: {}
+        - name: audit
+          emptyDir: {}
         - name: log
+          emptyDir: {}
+        - name: heap-dumps
           emptyDir: {}
         - name: live-info
           configMap:
             name: hivemq-cluster-{{ spec.name }}-dynamic-state
+        - name: dns-wait-config
+          configMap:
+            name: hivemq-cluster-{{ spec.name }}-dns-wait-config
         {% for map in spec.configMaps %}
         - name: {{ map.name }}
           configMap:

--- a/charts/hivemq-operator/operator-tmpls/cluster-deployment.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-deployment.yaml
@@ -97,16 +97,15 @@ spec:
       {% if spec.serviceAccountName != null %}
       serviceAccountName: "{{ spec.serviceAccountName }}"
       {% endif %}
+      securityContext:
+        sysctls:
+          - name: net.ipv4.ip_local_port_range
+            value: "1024 65535"
       containers:
       - name: "hivemq"
         securityContext:
           privileged: false
           allowPrivilegeEscalation: false
-          sysctls:
-            - name: net.core.somaxconn
-              value: "32768"
-            - name: net.ipv4.ip_local_port_range
-              value: "1024 65535"
         env:
         - name: HIVEMQ_DNS_DISCOVERY_ADDRESS
           value: "hivemq-{{ spec.name }}-cluster.{{ spec.namespace }}.svc.cluster.local."

--- a/charts/hivemq-operator/operator-tmpls/cluster-deployment.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-deployment.yaml
@@ -58,9 +58,14 @@ spec:
         - name: backup
           mountPath: /opt/hivemq/backup
           readOnly: false
+        - name: log
+          mountPath: /opt/hivemq/log
+          readOnly: false
         {% for map in spec.configMaps %}
+        {% if map.path != "none" %}
         - name: {{ map.name }}
           mountPath: {{ util:stringReplace(map.path, "/opt/hivemq/", "/conf-override/") }}
+        {% endif %}
         {% endfor %}
         {% for extension in spec.extensions %}
         {% if extension.configMap != null %}
@@ -79,8 +84,10 @@ spec:
         args: {{ initContainer.args }}
         volumeMounts:
         {% for map in spec.configMaps %}
+        {% if map.path != "none" %}
         - name: {{ map.name }}
           mountPath: {{ util:stringReplace(map.path, "/opt/hivemq/", "/conf-override/") }}
+        {% endif %}
         {% endfor %}
         {% for extension in spec.extensions %}
         {% if extension.configMap != null %}
@@ -182,10 +189,10 @@ spec:
 {{ util:indent(12, spec.configOverride) }}
         - name: HIVEMQ_LISTENER_CONFIGURATION
           value: |
-{{ util:indent(12, spec.listenerConfiguration) }}
+            {{ util:indentCustom(12, 0, spec.listenerConfiguration) }}
         - name: HIVEMQ_REST_API_CONFIGURATION
           value: |
-{{ util:indent(12, spec.restApiConfiguration) }}
+            {{ util:indentCustom(12, 0, spec.restApiConfiguration) }}
         {% for env in spec.env %}
         - name: {{ env.name }}
           value: {{ env.value }}
@@ -215,7 +222,7 @@ spec:
             port: {{ util:getPort(spec, "mqtt").port }}
           initialDelaySeconds: 15
           periodSeconds: 30
-          failureThreshold: 90
+          failureThreshold: 240
         volumeMounts:
           - name: shared-data
             mountPath: /hivemq-data
@@ -228,18 +235,25 @@ spec:
             mountPath: /opt/hivemq/backup
             readOnly: false
           {% for map in spec.configMaps %}
+          {% if map.path != "none" %}
           - name: {{ map.name }}
             mountPath: {{ util:stringReplace(map.path, "/opt/hivemq/", "/conf-override/") }}
+          {% endif %}
           {% endfor %}
           {% for secret in spec.secrets %}
+          {% if secret.path != "none" %}
           - name: {{ secret.name }}
             mountPath: {{ util:stringReplace(secret.path, "/opt/hivemq/", "/conf-override/") }}
+          {% endif %}
           {% endfor %}
           {% for extension in spec.extensions %}
           {% if extension.configMap != null %}
           - name: {{ extension.configMap }}
             mountPath: /conf-override/extensions/{{ extension.name }}
           {% endif %}{% endfor %}
+        {% for sidecar in spec.sidecars %}
+      - {{ util:indentCustom(8, 0, sidecar) }}
+        {% endfor %}
       # Wait longer for replication tasks
       terminationGracePeriodSeconds: 3600
       affinity:
@@ -251,6 +265,8 @@ spec:
         - name: conf-override
           emptyDir: {}
         - name: backup
+          emptyDir: {}
+        - name: log
           emptyDir: {}
         - name: live-info
           configMap:

--- a/charts/hivemq-operator/operator-tmpls/cluster-deployment.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-deployment.yaml
@@ -38,6 +38,15 @@ spec:
     spec:
       initContainers:
       - name: "init-shared"
+        resources:
+          limits:
+            cpu: "{{ util:getCpuLimit(spec) }}"
+            memory: "{{ util:getMemoryLimit(spec) }}"
+            ephemeral-storage: "{{ util:getStorageLimit(spec) }}"
+          requests:
+            cpu: "{{ spec.cpu }}"
+            memory: "{{ spec.memory }}"
+            ephemeral-storage: "{{ spec.ephemeralStorage }}"
         image: "busybox:latest"
         command: ["/bin/sh", "-c"]
         args:
@@ -83,12 +92,30 @@ spec:
         {% endif %}{% endfor %}
       - name: dns-wait
         image: hivemq/init-dns-wait:1.0.0
+        resources:
+          limits:
+            cpu: "{{ util:getCpuLimit(spec) }}"
+            memory: "{{ util:getMemoryLimit(spec) }}"
+            ephemeral-storage: "{{ util:getStorageLimit(spec) }}"
+          requests:
+            cpu: "{{ spec.cpu }}"
+            memory: "{{ spec.memory }}"
+            ephemeral-storage: "{{ spec.ephemeralStorage }}"
         volumeMounts:
           - mountPath: /mnt/misc
             name: dns-wait-config
       {% for initContainer in spec.initialization %}
       - name: {{ initContainer.name }}
         image: {{ initContainer.image }}
+        resources:
+          limits:
+            cpu: "{{ util:getCpuLimit(spec) }}"
+            memory: "{{ util:getMemoryLimit(spec) }}"
+            ephemeral-storage: "{{ util:getStorageLimit(spec) }}"
+          requests:
+            cpu: "{{ spec.cpu }}"
+            memory: "{{ spec.memory }}"
+            ephemeral-storage: "{{ spec.ephemeralStorage }}"
         command: {{ initContainer.command }}
         args: {{ initContainer.args }}
         volumeMounts:
@@ -217,12 +244,12 @@ spec:
         - name: HIVEMQ_REST_API_CONFIGURATION
           value: |
             {{ util:indentCustom(12, 0, spec.restApiConfiguration) }}
-        - name: HEAPDUMP_HOME
+        - name: HIVEMQ_HEAPDUMP_HOME
           value: /opt/hivemq/dumps
         {% for env in spec.env %}
         - name: {{ env.name }}
           value: |
-{{ util:indent(12, env.value) }}
+            {{ util:indentCustom(12, 0, env.value) }}
         {% endfor %}
         image: "{{ util:getTaggedImage(spec) }}"
         ports:{% for portInstance in spec.ports %}
@@ -288,9 +315,6 @@ spec:
           - name: {{ extension.configMap }}
             mountPath: /conf-override/extensions/{{ extension.name }}
           {% endif %}{% endfor %}
-        {% for sidecar in spec.sidecars %}
-      - {{ util:indentCustom(8, 0, sidecar) }}
-        {% endfor %}
       # Wait longer for replication tasks
       terminationGracePeriodSeconds: 3600
       affinity:

--- a/charts/hivemq-operator/operator-tmpls/cluster-deployment.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-deployment.yaml
@@ -41,25 +41,30 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            mkdir -p /opt/hivemq/bin
             mkdir -p /opt/hivemq/backup
             mkdir -p /opt/hivemq/extensions
             mkdir -p /opt/hivemq/conf
             mkdir -p /opt/hivemq/license
-            cp -r /opt/hivemq/* /hivemq-data/
             cp -r /opt/hivemq/* /conf-override/
+            cp -r /opt/hivemq/* /hivemq-data/
         volumeMounts:
         - name: shared-data
           mountPath: /hivemq-data
+          readOnly: false
         - name: conf-override
           mountPath: /conf-override
           readOnly: false
         - name: live-info
           mountPath: /etc/podinfo
         - name: backup
-          mountPath: /opt/hivemq/backup
+          mountPath: /conf-override/backup
           readOnly: false
         - name: log
-          mountPath: /opt/hivemq/log
+          mountPath: /conf-override/log
+          readOnly: false
+        - name: audit
+          mountPath: /conf-override/audit
           readOnly: false
         {% for map in spec.configMaps %}
         {% if map.path != "none" %}
@@ -83,6 +88,21 @@ spec:
         command: {{ initContainer.command }}
         args: {{ initContainer.args }}
         volumeMounts:
+        - name: shared-data
+          mountPath: /hivemq-data
+          readOnly: false
+        - name: conf-override
+          mountPath: /conf-override
+          readOnly: false
+        - name: backup
+          mountPath: /conf-override/backup
+          readOnly: false
+        - name: log
+          mountPath: /conf-override/log
+          readOnly: false
+        - name: audit
+          mountPath: /conf-override/audit
+          readOnly: false
         {% for map in spec.configMaps %}
         {% if map.path != "none" %}
         - name: {{ map.name }}
@@ -226,6 +246,7 @@ spec:
         volumeMounts:
           - name: shared-data
             mountPath: /hivemq-data
+            readOnly: false
           - name: conf-override
             mountPath: /conf-override
             readOnly: false
@@ -233,6 +254,12 @@ spec:
             mountPath: /etc/podinfo
           - name: backup
             mountPath: /opt/hivemq/backup
+            readOnly: false
+          - name: log
+            mountPath: /opt/hivemq/log
+            readOnly: false
+          - name: audit
+            mountPath: /opt/hivemq/audit
             readOnly: false
           {% for map in spec.configMaps %}
           {% if map.path != "none" %}
@@ -265,6 +292,8 @@ spec:
         - name: conf-override
           emptyDir: {}
         - name: backup
+          emptyDir: {}
+        - name: audit
           emptyDir: {}
         - name: log
           emptyDir: {}

--- a/charts/hivemq-operator/operator-tmpls/cluster-deployment.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-deployment.yaml
@@ -67,6 +67,9 @@ spec:
         - name: audit
           mountPath: /conf-override/audit
           readOnly: false
+        - name: heap-dumps
+          mountPath: /opt/hivemq/dumps
+          readOnly: false
         {% for map in spec.configMaps %}
         {% if map.path != "none" %}
         - name: {{ map.name }}
@@ -214,9 +217,12 @@ spec:
         - name: HIVEMQ_REST_API_CONFIGURATION
           value: |
             {{ util:indentCustom(12, 0, spec.restApiConfiguration) }}
+        - name: HEAPDUMP_HOME
+          value: /opt/hivemq/dumps
         {% for env in spec.env %}
         - name: {{ env.name }}
-          value: {{ env.value }}
+          value: |
+{{ util:indent(12, env.value) }}
         {% endfor %}
         image: "{{ util:getTaggedImage(spec) }}"
         ports:{% for portInstance in spec.ports %}
@@ -262,6 +268,9 @@ spec:
           - name: audit
             mountPath: /opt/hivemq/audit
             readOnly: false
+          - name: heap-dumps
+            mountPath: /opt/hivemq/dumps
+            readOnly: false
           {% for map in spec.configMaps %}
           {% if map.path != "none" %}
           - name: {{ map.name }}
@@ -297,6 +306,8 @@ spec:
         - name: audit
           emptyDir: {}
         - name: log
+          emptyDir: {}
+        - name: heap-dumps
           emptyDir: {}
         - name: live-info
           configMap:

--- a/charts/hivemq-operator/operator-tmpls/cluster-deployment.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-deployment.yaml
@@ -16,6 +16,7 @@ metadata:
     name: "{{ spec.name }}"
     uid: "{{ spec.metadata.uid }}"
 spec:
+  minReadySeconds: 30
   progressDeadlineSeconds: 10800
   revisionHistoryLimit: 2
   selector:

--- a/charts/hivemq-operator/operator-tmpls/cluster-stateful-set.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-stateful-set.yaml
@@ -91,16 +91,15 @@ spec:
       {% if spec.serviceAccountName != null %}
       serviceAccountName: "{{ spec.serviceAccountName }}"
       {% endif %}
+      securityContext:
+        sysctls:
+          - name: net.ipv4.ip_local_port_range
+            value: "1024 65535"
       containers:
         - name: "hivemq"
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
-            sysctls:
-              - name: net.core.somaxconn
-                value: "32768"
-              - name: net.ipv4.ip_local_port_range
-                value: "1024 65535"
           env:
             - name: HIVEMQ_DNS_DISCOVERY_ADDRESS
               value: "hivemq-{{ spec.name }}-cluster.{{ spec.namespace }}.svc.cluster.local."

--- a/charts/hivemq-operator/operator-tmpls/cluster-stateful-set.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-stateful-set.yaml
@@ -17,6 +17,7 @@ metadata:
     uid: "{{ spec.metadata.uid }}"
 spec:
   serviceName: hivemq-{{ spec.name }}-cluster
+  replicas: {{ spec.nodeCount }}
   selector:
     matchLabels:
       app: "hivemq"
@@ -26,7 +27,7 @@ spec:
       labels:
         app: "hivemq"
         hivemq-cluster: "{{ spec.name }}"
-        hivemq.com/node-offline: false
+        hivemq.com/node-offline: "false"
     spec:
       initContainers:
       - name: "init-shared"

--- a/charts/hivemq-operator/operator-tmpls/cluster-stateful-set.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-stateful-set.yaml
@@ -96,6 +96,11 @@ spec:
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
+            sysctls:
+              - name: net.core.somaxconn
+                value: "32768"
+              - name: net.ipv4.ip_local_port_range
+                value: "1024 65535"
           env:
             - name: HIVEMQ_DNS_DISCOVERY_ADDRESS
               value: "hivemq-{{ spec.name }}-cluster.{{ spec.namespace }}.svc.cluster.local."

--- a/charts/hivemq-operator/operator-tmpls/cluster-stateful-set.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-stateful-set.yaml
@@ -16,7 +16,6 @@ metadata:
     name: "{{ spec.name }}"
     uid: "{{ spec.metadata.uid }}"
 spec:
-  replicas: {{ spec.nodeCount }}
   serviceName: hivemq-{{ spec.name }}-cluster
   selector:
     matchLabels:
@@ -27,7 +26,7 @@ spec:
       labels:
         app: "hivemq"
         hivemq-cluster: "{{ spec.name }}"
-        hivemq.com/node-offline: "false"
+        hivemq.com/node-offline: false
     spec:
       initContainers:
       - name: "init-shared"
@@ -35,6 +34,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            mkdir -p /opt/hivemq/bin
             mkdir -p /opt/hivemq/backup
             mkdir -p /opt/hivemq/extensions
             mkdir -p /opt/hivemq/conf
@@ -44,16 +44,20 @@ spec:
         volumeMounts:
         - name: shared-data
           mountPath: /hivemq-data
+          readOnly: false
         - name: conf-override
           mountPath: /conf-override
           readOnly: false
         - name: live-info
           mountPath: /etc/podinfo
         - name: backup
-          mountPath: /opt/hivemq/backup
+          mountPath: /conf-override/backup
           readOnly: false
         - name: log
-          mountPath: /opt/hivemq/log
+          mountPath: /conf-override/log
+          readOnly: false
+        - name: audit
+          mountPath: /conf-override/audit
           readOnly: false
         {% for map in spec.configMaps %}
         {% if map.path != "none" %}
@@ -77,6 +81,23 @@ spec:
         command: {{ initContainer.command }}
         args: {{ initContainer.args }}
         volumeMounts:
+        - name: shared-data
+          mountPath: /hivemq-data
+          readOnly: false
+        - name: conf-override
+          mountPath: /conf-override
+          readOnly: false
+        - name: live-info
+          mountPath: /etc/podinfo
+        - name: backup
+          mountPath: /conf-override/backup
+          readOnly: false
+        - name: log
+          mountPath: /conf-override/log
+          readOnly: false
+        - name: audit
+          mountPath: /conf-override/audit
+          readOnly: false
         {% for map in spec.configMaps %}
         {% if map.path != "none" %}
         - name: {{ map.name }}
@@ -113,15 +134,15 @@ spec:
             - name: JAVA_OPTS
               value: "{{ spec.javaOptions }}"
             - name: HIVEMQ_CLUSTER_PORT
-              value: "{{ util:getPort(spec, "cluster").port }}"
+              value: {{ util:getPort(spec, "cluster").port }}
             - name: HIVEMQ_MQTT_PORT
-              value: "{{ util:getPort(spec, "mqtt").port }}"
+              value: {{ util:getPort(spec, "mqtt").port }}
             - name: HIVEMQ_CONTROL_CENTER_PORT
-              value: "{{ util:getPort(spec, "cc").port }}"
+              value: {{ util:getPort(spec, "cc").port }}
             - name: HIVEMQ_REST_API_PORT
-              value: "{{ util:getPort(spec, "api").port }}"
+              value: {{ util:getPort(spec, "api").port }}
             - name: HIVEMQ_REST_API_ENABLED
-              value: "{{ util:getPort(spec, "api").port != null }}"
+              value: {{ util:getPort(spec, "api").port != null }}
             - name: HIVEMQ_CLUSTER_REPLICA_COUNT
               value: "{{ spec.clusterReplicaCount }}"
             - name: HIVEMQ_CLUSTER_OVERLOAD_PROTECTION
@@ -190,7 +211,8 @@ spec:
 {{ util:indent(15, spec.restApiConfiguration) }}
               {% for env in spec.env %}
             - name: {{ env.name }}
-              value: {{ env.value }}
+              value: |
+                {{ util:indentCustom(15, 0, env.value) }}
               {% endfor %}
           image: "{{ util:getTaggedImage(spec) }}"
           ports:{% for portInstance in spec.ports %}
@@ -219,16 +241,23 @@ spec:
             periodSeconds: 30
             failureThreshold: 240
           volumeMounts:
-            - name: shared-data
-              mountPath: /hivemq-data
-            - name: conf-override
-              mountPath: /conf-override
-              readOnly: false
-            - name: live-info
-              mountPath: /etc/podinfo
-            - name: backup
-              mountPath: /opt/hivemq/backup
-              readOnly: false
+          - name: shared-data
+            mountPath: /hivemq-data
+            readOnly: false
+          - name: conf-override
+            mountPath: /conf-override
+            readOnly: false
+          - name: live-info
+            mountPath: /etc/podinfo
+          - name: backup
+            mountPath: /opt/hivemq/backup
+            readOnly: false
+          - name: log
+            mountPath: /opt/hivemq/log
+            readOnly: false
+          - name: audit
+            mountPath: /opt/hivemq/audit
+            readOnly: false
             {% for map in spec.configMaps %}
             - name: {{ map.name }}
               mountPath: {{ util:stringReplace(map.path, "/opt/hivemq/", "/conf-override/") }}
@@ -244,9 +273,6 @@ spec:
               mountPath: {{ util:stringReplace(secret.path, "/opt/hivemq/", "/conf-override/") }}
             {% endif %}
             {% endfor %}
-        {% for sidecar in spec.sidecars %}
-        - {{ util:indentCustom(8, 0, sidecar) }}
-        {% endfor %}
       # Wait longer for replication tasks
       terminationGracePeriodSeconds: 3600
       volumes:
@@ -259,6 +285,8 @@ spec:
           emptyDir: {}
         - name: log
           emptyDir: {}
+        - name: audit
+          emptyDir: { }
         - name: live-info
           configMap:
             name: hivemq-cluster-{{ spec.name }}-dynamic-state

--- a/charts/hivemq-operator/operator-tmpls/cluster-stateful-set.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-stateful-set.yaml
@@ -52,9 +52,14 @@ spec:
         - name: backup
           mountPath: /opt/hivemq/backup
           readOnly: false
+        - name: log
+          mountPath: /opt/hivemq/log
+          readOnly: false
         {% for map in spec.configMaps %}
+        {% if map.path != "none" %}
         - name: {{ map.name }}
           mountPath: {{ util:stringReplace(map.path, "/opt/hivemq/", "/conf-override/") }}
+        {% endif %}
         {% endfor %}
         {% for extension in spec.extensions %}
         {% if extension.configMap != null %}
@@ -73,8 +78,10 @@ spec:
         args: {{ initContainer.args }}
         volumeMounts:
         {% for map in spec.configMaps %}
+        {% if map.path != "none" %}
         - name: {{ map.name }}
           mountPath: {{ util:stringReplace(map.path, "/opt/hivemq/", "/conf-override/") }}
+        {% endif %}
         {% endfor %}
         {% for extension in spec.extensions %}
         {% if extension.configMap != null %}
@@ -210,7 +217,7 @@ spec:
               port: {{ util:getPort(spec, "mqtt").port }}
             initialDelaySeconds: 15
             periodSeconds: 30
-            failureThreshold: 90
+            failureThreshold: 240
           volumeMounts:
             - name: shared-data
               mountPath: /hivemq-data
@@ -232,9 +239,14 @@ spec:
               mountPath: /conf-override/extensions/{{ extension.name }}
             {% endif %}{% endfor %}
             {% for secret in spec.secrets %}
+            {% if map.path != "none" %}
             - name: {{ secret.name }}
               mountPath: {{ util:stringReplace(secret.path, "/opt/hivemq/", "/conf-override/") }}
+            {% endif %}
             {% endfor %}
+        {% for sidecar in spec.sidecars %}
+        - {{ util:indentCustom(8, 0, sidecar) }}
+        {% endfor %}
       # Wait longer for replication tasks
       terminationGracePeriodSeconds: 3600
       volumes:
@@ -244,6 +256,8 @@ spec:
         - name: conf-override
           emptyDir: {}
         - name: backup
+          emptyDir: {}
+        - name: log
           emptyDir: {}
         - name: live-info
           configMap:

--- a/charts/hivemq-operator/operator-tmpls/service-monitor.yaml
+++ b/charts/hivemq-operator/operator-tmpls/service-monitor.yaml
@@ -6,7 +6,7 @@ metadata:
     {% if spec.metadata.labels.containsKey("app.kubernetes.io/instance") %}
     release: {{ spec.metadata.labels.get("app.kubernetes.io/instance") }}
     {% endif %}
-  name: {{ spec.name }}-monitoring-sm
+  name: {{ spec.name }}
   ownerReferences:
   - apiVersion: hivemq.com/v1
     kind: HiveMQCluster
@@ -16,6 +16,7 @@ metadata:
 spec:
   endpoints:
     - port: metrics
+  jobLabel: hivemq-cluster
   selector:
     matchLabels:
       hivemq-cluster: {{ spec.name }}

--- a/charts/hivemq-operator/templates/_helpers.tpl
+++ b/charts/hivemq-operator/templates/_helpers.tpl
@@ -3,7 +3,15 @@
 Expand the name of the chart.
 */}}
 {{- define "hivemq.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 50 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "hivemq.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/hivemq-operator/templates/global/hivemq-clusterrolebinding.yaml
+++ b/charts/hivemq-operator/templates/global/hivemq-clusterrolebinding.yaml
@@ -12,5 +12,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.hivemq.serviceAccountName }}
-    namespace: {{ $.Release.Namespace }}
+    namespace: {{ template "hivemq.namespace" . }}
 {{- end }}

--- a/charts/hivemq-operator/templates/global/hivemq-psp.yaml
+++ b/charts/hivemq-operator/templates/global/hivemq-psp.yaml
@@ -29,6 +29,19 @@ spec:
   hostNetwork: false
   hostIPC: false
   hostPID: false
+  {{- if .Values.global.rbac.advancedSysctls }}
+  allowedUnsafeSysctls:
+    - fs.file-max
+    - net.ipv4.tcp_fin_timeout
+    - net.ipv4.tcp_tw_recycle
+    - net.ipv4.tcp_tw_reuse
+    - net.core.rmem_default
+    - net.core.wmem_default
+    - net.core.rmem_max
+    - net.core.wmem_max
+    - net.ipv4.tcp_rmem
+    - net.ipv4.tcp_wmem
+  {{- end }}
   runAsUser:
     # Permits the container to run with root privileges as well.
     rule: 'RunAsAny'

--- a/charts/hivemq-operator/templates/global/hivemq-psp.yaml
+++ b/charts/hivemq-operator/templates/global/hivemq-psp.yaml
@@ -31,16 +31,8 @@ spec:
   hostPID: false
   {{- if .Values.global.rbac.advancedSysctls }}
   allowedUnsafeSysctls:
-    - fs.file-max
     - net.ipv4.tcp_fin_timeout
-    - net.ipv4.tcp_tw_recycle
-    - net.ipv4.tcp_tw_reuse
-    - net.core.rmem_default
-    - net.core.wmem_default
-    - net.core.rmem_max
-    - net.core.wmem_max
-    - net.ipv4.tcp_rmem
-    - net.ipv4.tcp_wmem
+    - net.core.somaxconn
   {{- end }}
   runAsUser:
     # Permits the container to run with root privileges as well.

--- a/charts/hivemq-operator/templates/global/hivemq-serviceaccount.yaml
+++ b/charts/hivemq-operator/templates/global/hivemq-serviceaccount.yaml
@@ -3,11 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: "{{ template "hivemq.fullname" . }}-hivemq"
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ template "hivemq.namespace" . }}
   labels:
     {{- include "hivemq.labels" . | nindent 4 }}
   annotations:
     {{- toYaml $.Values.hivemq.serviceAccountAnnotations | nindent 4 }}
 imagePullSecrets:
-  {{ toYaml .Values.hivemq.imagePullSecrets | indent 2 }}
+  {{ toYaml .Values.global.imagePullSecrets | indent 2 }}
 {{- end }}

--- a/charts/hivemq-operator/templates/global/hivemq-serviceaccount.yaml
+++ b/charts/hivemq-operator/templates/global/hivemq-serviceaccount.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "hivemq.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml $.Values.hivemq.serviceAccountAnnotations | nindent 4 }}
 imagePullSecrets:
   {{ toYaml .Values.hivemq.imagePullSecrets | indent 2 }}
 {{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/custom-resource-validating-hook.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/custom-resource-validating-hook.yaml
@@ -1,5 +1,5 @@
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
-{{- if .Values.operator.admissionHookEnabled }}
+{{- if .Values.operator.admissionWebhooks.enabled }}
 kind: ValidatingWebhookConfiguration
 {{- if semverCompare ">= 1.16.0-0" $kubeTargetVersion }}
 apiVersion: admissionregistration.k8s.io/v1
@@ -7,7 +7,7 @@ apiVersion: admissionregistration.k8s.io/v1
 apiVersion: admissionregistration.k8s.io/v1beta1
 {{- end }}
 metadata:
-  name: "{{ include "hivemq.fullname" . }}-admission"
+  name: {{ include "hivemq.fullname" . }}-admission
   labels:
     app: hivemq
     {{- include "hivemq.labels" . | nindent 4 }}
@@ -26,8 +26,8 @@ webhooks:
         scope: "Namespaced"
     clientConfig:
       service:
-        namespace: "{{ .Release.Namespace }}"
-        name: {{ include "hivemq.name" . }}-operator
+        namespace: "{{ template "hivemq.namespace" . }}"
+        name: {{ include "hivemq.fullname" . }}-operator
         path: /api/v1/validate/hivemq-clusters
     admissionReviewVersions:
     - "v1"

--- a/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/clusterrole.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/clusterrole.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.operator.admissionWebhooks.enabled .Values.operator.admissionWebhooks.patch.enabled .Values.global.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name:  {{ template "hivemq.fullname" . }}-admission
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: {{ include "hivemq.name" . }}-admission
+{{ include "hivemq.labels" $ | indent 4 }}
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - get
+      - update
+{{- if .Values.global.rbac.pspEnabled }}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if semverCompare "> 1.15.0-0" $kubeTargetVersion }}
+  - apiGroups: ['policy']
+{{- else }}
+  - apiGroups: ['extensions']
+{{- end }}
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+    - {{ template "hivemq.fullname" . }}-admission
+{{- end }}
+{{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.operator.admissionWebhooks.enabled .Values.operator.admissionWebhooks.patch.enabled .Values.global.rbac.create  }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  {{ template "hivemq.fullname" . }}-admission
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: {{ include "hivemq.name" . }}-admission
+{{ include "hivemq.labels" $ | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "hivemq.fullname" . }}-admission
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "hivemq.fullname" . }}-admission
+    namespace: {{ template "hivemq.namespace" . }}
+{{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -1,0 +1,65 @@
+{{- if and .Values.operator.admissionWebhooks.enabled .Values.operator.admissionWebhooks.patch.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name:  {{ template "hivemq.fullname" . }}-admission-create
+  namespace: {{ template "hivemq.namespace" . }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: {{ include "hivemq.name" $ }}-admission-create
+{{ include "hivemq.labels" $ | indent 4 }}
+spec:
+  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
+  {{- end }}
+  template:
+    metadata:
+      name:  {{ template "hivemq.fullname" . }}-admission-create
+{{- with .Values.operator.admissionWebhooks.patch.podAnnotations }}
+      annotations:
+{{ toYaml .  | indent 8 }}
+{{- end }}
+      labels:
+        app: {{ template "hivemq.name" $ }}-admission-create
+{{ include "hivemq.labels" $ | indent 8 }}
+    spec:
+      {{- if .Values.operator.admissionWebhooks.patch.priorityClassName }}
+      priorityClassName: {{ .Values.operator.admissionWebhooks.patch.priorityClassName }}
+      {{- end }}
+      containers:
+        - name: create
+          {{- if .Values.operator.admissionWebhooks.patch.image.sha }}
+          image: {{ .Values.operator.admissionWebhooks.patch.image.repository }}:{{ .Values.operator.admissionWebhooks.patch.image.tag }}@sha256:{{ .Values.operator.admissionWebhooks.patch.image.sha }}
+          {{- else }}
+          image: {{ .Values.operator.admissionWebhooks.patch.image.repository }}:{{ .Values.operator.admissionWebhooks.patch.image.tag }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.operator.admissionWebhooks.patch.image.pullPolicy }}
+          args:
+            - create
+            - --host={{ template "hivemq.fullname" . }}-operator,{{ template "hivemq.fullname" . }}-operator.{{ template "hivemq.namespace" . }}.svc
+            - --namespace={{ template "hivemq.namespace" . }}
+            - --secret-name={{ template "hivemq.fullname" . }}-admission
+          resources:
+{{ toYaml .Values.operator.admissionWebhooks.patch.resources | indent 12 }}
+      restartPolicy: OnFailure
+      serviceAccountName: {{ template "hivemq.fullname" . }}-admission
+      {{- with .Values.operator.admissionWebhooks.patch.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.operator.admissionWebhooks.patch.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.operator.admissionWebhooks.patch.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      securityContext:
+        runAsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
+{{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -1,0 +1,67 @@
+{{- if and .Values.operator.admissionWebhooks.enabled .Values.operator.admissionWebhooks.patch.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name:  {{ template "hivemq.fullname" . }}-admission-patch
+  namespace: {{ template "hivemq.namespace" . }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: {{ template "hivemq.name" $ }}-admission-patch
+{{ include "hivemq.labels" $ | indent 4 }}
+spec:
+  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
+  {{- end }}
+  template:
+    metadata:
+      name:  {{ template "hivemq.fullname" . }}-admission-patch
+{{- with .Values.operator.admissionWebhooks.patch.podAnnotations }}
+      annotations:
+{{ toYaml .  | indent 8 }}
+{{- end }}
+      labels:
+        app: {{ template "hivemq.name" $ }}-admission-patch
+{{ include "hivemq.labels" $ | indent 8 }}
+    spec:
+      {{- if .Values.operator.admissionWebhooks.patch.priorityClassName }}
+      priorityClassName: {{ .Values.operator.admissionWebhooks.patch.priorityClassName }}
+      {{- end }}
+      containers:
+        - name: patch
+          {{- if .Values.operator.admissionWebhooks.patch.image.sha }}
+          image: {{ .Values.operator.admissionWebhooks.patch.image.repository }}:{{ .Values.operator.admissionWebhooks.patch.image.tag }}@sha256:{{ .Values.operator.admissionWebhooks.patch.image.sha }}
+          {{- else }}
+          image: {{ .Values.operator.admissionWebhooks.patch.image.repository }}:{{ .Values.operator.admissionWebhooks.patch.image.tag }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.operator.admissionWebhooks.patch.image.pullPolicy }}
+          args:
+            - patch
+            - --webhook-name={{ template "hivemq.fullname" . }}-admission
+            - --namespace={{ template "hivemq.namespace" . }}
+            - --patch-mutating=false
+            - --secret-name={{ template "hivemq.fullname" . }}-admission
+            - --patch-failure-policy={{ .Values.operator.admissionWebhooks.failurePolicy }}
+          resources:
+{{ toYaml .Values.operator.admissionWebhooks.patch.resources | indent 12 }}
+      restartPolicy: OnFailure
+      serviceAccountName: {{ template "hivemq.fullname" . }}-admission
+      {{- with .Values.operator.admissionWebhooks.patch.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.operator.admissionWebhooks.patch.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.operator.admissionWebhooks.patch.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      securityContext:
+        runAsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
+{{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/psp.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/psp.yaml
@@ -1,15 +1,18 @@
-{{- if and .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
+{{- if and .Values.operator.admissionWebhooks.enabled .Values.operator.admissionWebhooks.patch.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: "{{ template "hivemq.fullname" . }}"
-  namespace: {{ template "hivemq.namespace" . }}
-  labels:
-    {{- include "hivemq.labels" . | nindent 4 }}
-  {{- if .Values.global.rbac.pspAnnotations }}
+  name: {{ template "hivemq.fullname" . }}-admission
   annotations:
-  {{ toYaml .Values.global.rbac.pspAnnotations | indent 4 }}
-  {{- end }}
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: {{ template "hivemq.name" . }}-admission
+{{- if .Values.global.rbac.pspAnnotations }}
+  annotations:
+{{ toYaml .Values.global.rbac.pspAnnotations | indent 4 }}
+{{- end }}
+{{ include "hivemq.labels" . | indent 4 }}
 spec:
   privileged: false
   # Required to prevent escalations to root.
@@ -29,11 +32,6 @@ spec:
   hostNetwork: false
   hostIPC: false
   hostPID: false
-  {{- if .Values.global.rbac.advancedSysctls }}
-  allowedUnsafeSysctls:
-    - net.ipv4.tcp_fin_timeout
-    - net.core.somaxconn
-  {{- end }}
   runAsUser:
     # Permits the container to run with root privileges as well.
     rule: 'RunAsAny'
@@ -53,8 +51,4 @@ spec:
       - min: 0
         max: 65535
   readOnlyRootFilesystem: false
-  {{- if .Values.global.rbac.allowedCapabilities }}
-  allowedCapabilities:
-  {{ toYaml .Values.global.rbac.allowedCapabilities | indent 4 }}
-  {{- end }}
-  {{- end }}
+{{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/role.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/role.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.operator.admissionWebhooks.enabled .Values.operator.admissionWebhooks.patch.enabled .Values.global.rbac.create  }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name:  {{ template "hivemq.fullname" . }}-admission
+  namespace: {{ template "hivemq.namespace" . }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: {{ template "hivemq.name" $ }}-admission
+{{ include "hivemq.labels" $ | indent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+{{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/rolebinding.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/rolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.operator.admissionWebhooks.enabled .Values.operator.admissionWebhooks.patch.enabled .Values.global.rbac.create  }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name:  {{ template "hivemq.fullname" . }}-admission
+  namespace: {{ template "hivemq.namespace" . }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: {{ template "hivemq.name" $ }}-admission
+{{ include "hivemq.labels" $ | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "hivemq.fullname" . }}-admission
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "hivemq.fullname" . }}-admission
+    namespace: {{ template "hivemq.namespace" . }}
+{{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.operator.admissionWebhooks.enabled .Values.operator.admissionWebhooks.patch.enabled .Values.global.rbac.create  }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name:  {{ template "hivemq.fullname" . }}-admission
+  namespace: {{ template "hivemq.namespace" . }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: {{ template "hivemq.name" $ }}-admission
+{{ include "hivemq.labels" $ | indent 4 }}
+imagePullSecrets:
+{{ toYaml .Values.global.imagePullSecrets | indent 2 }}
+{{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
@@ -7,15 +7,17 @@ metadata:
     app: {{ .Chart.Name | quote }}
     hivemq-cluster: {{ .Release.Name | quote }}
     {{- include "hivemq.labels" . | nindent 4 }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ template "hivemq.namespace" . }}
 spec:
   nodeCount: {{ .Values.hivemq.nodeCount }}
   image: "{{- (splitn ":" 2 .Values.hivemq.image)._0 }}"
   hivemqVersion: "{{- (splitn ":" 2 .Values.hivemq.image)._1 }}"
   imagePullPolicy: {{ .Values.hivemq.imagePullPolicy }}
+  {{- with .Values.global.rbac.imagePullSecrets }}
   imagePullSecrets:
-  {{- range .Values.hivemq.imagePullSecrets }}
+  {{- range .Values.global.rbac.imagePullSecrets }}
   - {{ .name | quote }}
+  {{- end }}
   {{- end }}
   memory: {{ .Values.hivemq.memory }}
   memoryLimitRatio: {{ .Values.hivemq.memoryLimitRatio }}
@@ -66,5 +68,4 @@ spec:
   restApiConfiguration: |{{ .Values.hivemq.restApiConfiguration | nindent 4 }}
   configOverride: |{{ .Values.hivemq.configOverride | nindent 4 }}
   initialization: {{ toYaml .Values.hivemq.initialization | nindent 4 }}
-  sidecars: {{ toYaml .Values.hivemq.sidecars | nindent 4 }}
 {{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
@@ -15,7 +15,7 @@ spec:
   imagePullPolicy: {{ .Values.hivemq.imagePullPolicy }}
   {{- with .Values.global.rbac.imagePullSecrets }}
   imagePullSecrets:
-  {{- range .Values.global.rbac.imagePullSecrets }}
+  {{- range . }}
   - {{ .name | quote }}
   {{- end }}
   {{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
@@ -62,5 +62,5 @@ spec:
   restApiConfiguration: |{{ .Values.hivemq.restApiConfiguration | nindent 4 }}
   configOverride: |{{ .Values.hivemq.configOverride | nindent 4 }}
   initialization: {{ toYaml .Values.hivemq.initialization | nindent 4 }}
-  sidecars: {{ toYaml .Values.hivemq.sidecars | nindent 2 }}
+  sidecars: {{ toYaml .Values.hivemq.sidecars | nindent 4 }}
 {{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
@@ -13,6 +13,10 @@ spec:
   image: "{{- (splitn ":" 2 .Values.hivemq.image)._0 }}"
   hivemqVersion: "{{- (splitn ":" 2 .Values.hivemq.image)._1 }}"
   imagePullPolicy: {{ .Values.hivemq.imagePullPolicy }}
+  imagePullSecrets:
+  {{- range .Values.hivemq.imagePullSecrets }}
+  - {{ .name | quote }}
+  {{- end }}
   memory: {{ .Values.hivemq.memory }}
   memoryLimitRatio: {{ .Values.hivemq.memoryLimitRatio }}
   ephemeralStorage: {{ .Values.hivemq.ephemeralStorage }}

--- a/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
@@ -61,4 +61,6 @@ spec:
   listenerConfiguration: |{{ .Values.hivemq.listenerConfiguration | nindent 4 }}
   restApiConfiguration: |{{ .Values.hivemq.restApiConfiguration | nindent 4 }}
   configOverride: |{{ .Values.hivemq.configOverride | nindent 4 }}
+  initialization: {{ toYaml .Values.hivemq.initialization | nindent 4 }}
+  sidecars: {{ toYaml .Values.hivemq.sidecars | nindent 2 }}
 {{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/operator-cluster-role.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/operator-cluster-role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: "{{ template "hivemq.fullname" . }}-operator"
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "hivemq.namespace" . }}
   labels:
     {{- include "hivemq.labels" . | nindent 4 }}
 rules:

--- a/charts/hivemq-operator/templates/hivemq-operator/operator-deployment.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/operator-deployment.yaml
@@ -20,6 +20,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
         - image: {{ .Values.operator.image }}
           imagePullPolicy: {{ .Values.operator.imagePullPolicy }}

--- a/charts/hivemq-operator/templates/hivemq-operator/operator-deployment.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/operator-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "hivemq.fullname" . }}-operator
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ template "hivemq.namespace" . }}
   labels:
     {{- include "hivemq.labels" . | nindent 4 }}
 spec:
@@ -16,7 +16,7 @@ spec:
         app: "{{ $.Chart.Name }}"
         operator: "{{ include "hivemq.fullname" . }}"
     spec:
-      {{- with .Values.operator.imagePullSecrets }}
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -36,9 +36,13 @@ spec:
             - name: CREATE_CRD
               value: "false"
             - name: MICRONAUT_SSL_ENABLED
-              value: "{{ .Values.operator.admissionHookEnabled }}"
+              value: "{{ .Values.operator.admissionWebhooks.enabled }}"
+            {{- if .Values.operator.admissionWebhooks.enabled }}
+            - name: OPERATOR_SSL_PATH
+              value: "/etc/ssl/admission"
+            {{- end }}
             - name: SSL_FQDN
-              value: "{{ include "hivemq.name" . }}-operator.{{ $.Release.Namespace }}.svc"
+              value: "{{ include "hivemq.name" . }}-operator.{{ template "hivemq.namespace" . }}.svc"
           resources: {{ toYaml .Values.operator.resources | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -46,6 +50,10 @@ spec:
           volumeMounts:
             - mountPath: /templates
               name: templates
+            {{- if .Values.operator.admissionWebhooks.enabled }}
+            - mountPath: /etc/ssl/admission
+              name: ssl-secrets
+            {{- end }}
           ports:
             - name: https
               containerPort: 443
@@ -60,3 +68,8 @@ spec:
             {{- else }}
             name: "{{ include "hivemq.fullname" . }}-operator-templates"
             {{- end }}
+        {{- if .Values.operator.admissionWebhooks.enabled }}
+        - name: ssl-secrets
+          secret:
+            secretName: {{ template "hivemq.fullname" . }}-admission
+        {{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/operator-rolebinding.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/operator-rolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
   kind: ClusterRole
 subjects:
   - name: "{{ template "hivemq.fullname" . }}-operator"
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "hivemq.namespace" . }}
     kind: ServiceAccount

--- a/charts/hivemq-operator/templates/hivemq-operator/operator-service.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/operator-service.yaml
@@ -1,8 +1,8 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ include "hivemq.name" . }}-operator
-  namespace: {{ $.Release.Namespace }}
+  name: {{ template "hivemq.fullname" . }}-operator
+  namespace: {{ template "hivemq.namespace" . }}
   labels:
     {{- include "hivemq.labels" . | nindent 4 }}
 spec:

--- a/charts/hivemq-operator/templates/hivemq-operator/operator-serviceaccount.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/operator-serviceaccount.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: "{{ template "hivemq.fullname" . }}-operator"
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "hivemq.namespace" . }}
   labels:
     {{- include "hivemq.labels" . | nindent 4 }}

--- a/charts/hivemq-operator/templates/hivemq-operator/operator-templates.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/operator-templates.yaml
@@ -4,4 +4,4 @@ data:
 kind: ConfigMap
 metadata:
   name: "{{ include "hivemq.fullname" . }}-operator-templates"
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ template "hivemq.namespace" . }}

--- a/charts/hivemq-operator/templates/hivemq/dashboard.yaml
+++ b/charts/hivemq-operator/templates/hivemq/dashboard.yaml
@@ -6,7 +6,7 @@ metadata:
     grafana_dashboard: "1"
     {{- include "hivemq.labels" . | nindent 4 }}
   name: {{ .Chart.Name }}-{{ .Release.Name }}-dashboard
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "hivemq.namespace" . }}
 data:
   hivemq.json: |-
     {

--- a/charts/hivemq-operator/templates/hivemq/license.yaml
+++ b/charts/hivemq-operator/templates/hivemq/license.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "hivemq.fullname" . }}-license
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "hivemq.namespace" . }}
   labels:
     app: {{ .Chart.Name }}
     hivemq-cluster: {{ .Release.Name }}

--- a/charts/hivemq-operator/templates/tests/test-mqtt-connection.yaml
+++ b/charts/hivemq-operator/templates/tests/test-mqtt-connection.yaml
@@ -13,7 +13,7 @@ spec:
           image: eclipse-mosquitto
           env:
             - name: MQTT_ADDRESS
-              value: hivemq-{{ .Release.Name }}-mqtt.{{ .Release.Namespace }}.svc.cluster.local
+              value: hivemq-{{ .Release.Name }}-mqtt.{{ template "hivemq.namespace" . }}.svc.cluster.local
           command: ["sh", "-c"]
           args:
             - |

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -35,10 +35,14 @@ monitoring:
   # Deploy a dedicated instance of the prometheus operator, including grafana, as sub-chart
   dedicated: false
 hivemq:
+  # Annotations to apply to the service account
+  serviceAccountAnnotations: {}
   # The values below apply to the HiveMQCluster object. If you are using deployCr: false, this is unused.
   image: hivemq/hivemq4:k8s-4.4.3
   imagePullPolicy: IfNotPresent
+  # This also applies to the generated service account
   imagePullSecrets: []
+  # - name: hivemq-pull-secret
   nodeCount: "3"
   cpu: "4"
   memory: "4Gi"

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -240,12 +240,11 @@ hivemq:
         <cluster>
             <enabled>true</enabled>
             <transport>
-                <udp>
+                <tcp>
                     <bind-address>${HIVEMQ_BIND_ADDRESS}</bind-address>
                     <bind-port>${HIVEMQ_CLUSTER_PORT}</bind-port>
-                    <multicast-enabled>false</multicast-enabled>
                     <enabled>true</enabled>
-                </udp>
+                </tcp>
             </transport>
             <discovery>
                 <extension>

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -9,17 +9,42 @@ global:
     advancedSysctls: false
     pspAnnotations: {}
     allowedCapabilities: []
+    # Image pull secrets for operator, hivemq or other images.
+    imagePullSecrets: []
+    # - name: hivemq-pull-secret
 operator:
   # Deploy a custom resource based on the hivemq section below. Set to false if you want to create a HiveMQCluster object yourself.
   # By setting this to false, the operator will not start a HiveMQ cluster when deployed.
   deployCr: true
   image: hivemq/hivemq-operator:4.4.3
   imagePullPolicy: IfNotPresent
-  imagePullSecrets: []
   nodeSelector: {}
   logLevel: INFO
-  # Verify all HiveMQCluster objects before accepting them. Not using the validation hook can result in erroneous cluster configurations which are hard to debug.
-  admissionHookEnabled: true
+  # Let the operator verify all HiveMQCluster objects before accepting them.
+  # Not using the validation hook can result in erroneous cluster configurations which are hard to debug.
+  admissionWebhooks:
+    # Enable the admission hook
+    enabled: true
+    # Reject updates to the CR when the admission hook fails
+    failurePolicy: Fail
+    ## If enabled, generate a self-signed certificate, then patch the webhook configurations with the generated data.
+    ## On chart upgrades (or if the secret exists) the cert will not be re-generated. You can use this to provide your own
+    ## certs ahead of time if you wish.
+    patch:
+      enabled: true
+      image:
+        repository: jettech/kube-webhook-certgen
+        tag: v1.5.1
+        sha: ""
+        pullPolicy: IfNotPresent
+      resources: {}
+      ## Provide a priority class name to the webhook patching job
+      ##
+      priorityClassName: ""
+      podAnnotations: {}
+      nodeSelector: {}
+      affinity: {}
+      tolerations: []
   # Set this string to a name of a externally managed ConfigMap containing the templates for the operator if you want to customize them.
   templateConfigMap: ""
   resources:
@@ -40,9 +65,6 @@ hivemq:
   # The values below apply to the HiveMQCluster object. If you are using deployCr: false, this is unused.
   image: hivemq/hivemq4:k8s-4.4.3
   imagePullPolicy: IfNotPresent
-  # This also applies to the generated service account
-  imagePullSecrets: []
-  # - name: hivemq-pull-secret
   nodeCount: "3"
   cpu: "4"
   memory: "4Gi"
@@ -346,4 +368,5 @@ hivemq:
         </security>
     </hivemq>
 nameOverride: ""
+namespaceOverride: ""
 fullnameOverride: ""

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -16,6 +16,7 @@ operator:
   image: hivemq/hivemq-operator:4.4.3
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
+  nodeSelector: {}
   logLevel: INFO
   # Verify all HiveMQCluster objects before accepting them. Not using the validation hook can result in erroneous cluster configurations which are hard to debug.
   admissionHookEnabled: true
@@ -50,6 +51,30 @@ hivemq:
   ## Add custom environment variables (e.g. for your extension) here.
   # - name: MY_CUSTOM_ENV
   #   value: some-value
+  initialization: []
+  ## Add custom initContainers here. Busybox is the default image. and /bin/sh -c the default command
+  # - name: init-cfg
+  #   image: busybox
+  #   command:
+  #   - /bin/sh
+  #   - "-c"
+  #   args:
+  #   - |
+  #     echo "mycustomfile" >> /hivemq-data/conf/test.cfg
+  sidecars: []
+  ## Add custom sidecar containers here. Must be a Container object in the regular Kubernetes API.
+  #- |
+  #  name: fluent-logging-example
+  #  args: -i tail -p path=/mnt/log/*.log -o stdout
+  #  image: fluent/fluent-bit:1.5
+  #  resources:
+  #    limits:
+  #      cpu: 100m
+  #      memory: 200Mi
+  #  volumeMounts:
+  #    - name: log
+  #      readOnly: true
+  #      mountPath: /mnt/log
   extensions:
     - # Default platform extensions starting from 4.4.0. Add a configMap and enable them if you want to use either
       name: hivemq-kafka-extension

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -133,7 +133,7 @@ hivemq:
   # Secrets to mount to the HiveMQ pods. These can be mounted to existing directories without shadowing the folder contents as well.
   #- name: hivemq-license
   #  path: /opt/hivemq/license
-  cpuLimitRatio: "2"
+  cpuLimitRatio: "1"
   memoryLimitRatio: "1"
   ephemeralStorageLimitRatio: "1"
   affinity: |

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -99,7 +99,7 @@ hivemq:
   #- name: hivemq-mqtt-message-log-extension
   #  extensionUri: https://www.hivemq.com/releases/extensions/hivemq-mqtt-message-log-extension-1.1.0.zip
   #  configMap: message-log-config
-  configMaps: {}
+  configMaps: []
   # ConfigMaps to mount to the HiveMQ pods. These can be mounted to existing directories without shadowing the folder contents as well.
   #- name: hivemq-license
   #  path: /opt/hivemq/license

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -16,7 +16,7 @@ operator:
   # Deploy a custom resource based on the hivemq section below. Set to false if you want to create a HiveMQCluster object yourself.
   # By setting this to false, the operator will not start a HiveMQ cluster when deployed.
   deployCr: true
-  image: hivemq/hivemq-operator:4.4.3
+  image: hivemq/hivemq-operator:4.5.0
   imagePullPolicy: IfNotPresent
   nodeSelector: {}
   logLevel: INFO

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -39,7 +39,6 @@ operator:
         pullPolicy: IfNotPresent
       resources: {}
       ## Provide a priority class name to the webhook patching job
-      ##
       priorityClassName: ""
       podAnnotations: {}
       nodeSelector: {}
@@ -63,7 +62,7 @@ hivemq:
   # Annotations to apply to the service account
   serviceAccountAnnotations: {}
   # The values below apply to the HiveMQCluster object. If you are using deployCr: false, this is unused.
-  image: hivemq/hivemq4:k8s-4.4.3
+  image: hivemq/hivemq4:k8s-4.5.0
   imagePullPolicy: IfNotPresent
   nodeCount: "3"
   cpu: "4"
@@ -243,7 +242,6 @@ hivemq:
                 <tcp>
                     <bind-address>${HIVEMQ_BIND_ADDRESS}</bind-address>
                     <bind-port>${HIVEMQ_CLUSTER_PORT}</bind-port>
-                    <enabled>true</enabled>
                 </tcp>
             </transport>
             <discovery>

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -3,6 +3,10 @@ global:
     create: true
     # Create a PodSecurityPolicy, cluster role, role binding and service account for the HiveMQ pods and assign the service account to them.
     pspEnabled: true
+    # Enable additional (unsafe) sysctls in the PSP to enhance performance for large deployments.
+    # Make sure to refer to https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ to enable them first, or the HiveMQ Pods will fail to launch. See https://www.hivemq.com/docs/hivemq/latest/user-guide/system-requirements.html for the full list of sysctl parameters and their effects.
+    # Also make sure to adjust hivemq.controllerTemplate to use the cluster-deployment-unsafe-sysctls.yaml, which will set the sysctls for the deployments.
+    advancedSysctls: false
     pspAnnotations: {}
     allowedCapabilities: []
 operator:

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -87,20 +87,6 @@ hivemq:
   #   args:
   #   - |
   #     echo "mycustomfile" >> /hivemq-data/conf/test.cfg
-  sidecars: []
-  ## Add custom sidecar containers here. Must be a Container object in the regular Kubernetes API.
-  #- |
-  #  name: fluent-logging-example
-  #  args: -i tail -p path=/mnt/log/*.log -o stdout
-  #  image: fluent/fluent-bit:1.5
-  #  resources:
-  #    limits:
-  #      cpu: 100m
-  #      memory: 200Mi
-  #  volumeMounts:
-  #    - name: log
-  #      readOnly: true
-  #      mountPath: /mnt/log
   extensions:
     - # Default platform extensions starting from 4.4.0. Add a configMap and enable them if you want to use either
       name: hivemq-kafka-extension


### PR DESCRIPTION
review notes:
- the unsafe sysctl deployment template is just an alternative version of the default template with more sysctls in the security context.
- the admission hook files are adapted from [prometheus operator](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch) 