### PR TITLE
Fix env value templating

### DIFF
--- a/charts/hivemq-operator/CHANGELOG.md
+++ b/charts/hivemq-operator/CHANGELOG.md
@@ -1,3 +1,15 @@
+# chart 0.8.4
+
+- Fix custom env templating by using correct YAML block scalar string syntax
+
+# chart 0.8.3
+
+- Regular version bump through CI
+
+# chart 0.8.2
+
+- Regular version bump through CI
+
 # chart 0.8.1
 
 - fix templating of the image pull secrets into the HiveMQ ServiceAccount

--- a/charts/hivemq-operator/Chart.yaml
+++ b/charts/hivemq-operator/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - messaging
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.8.3
+version: 0.8.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 4.5.2

--- a/charts/hivemq-operator/operator-tmpls/cluster-deployment.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-deployment.yaml
@@ -248,7 +248,7 @@ spec:
           value: /opt/hivemq/dumps
         {% for env in spec.env %}
         - name: {{ env.name }}
-          value: |
+          value: |-
             {{ util:indentCustom(12, 0, env.value) }}
         {% endfor %}
         image: "{{ util:getTaggedImage(spec) }}"


### PR DESCRIPTION
single-line env values had a trailing newline in them when rendered, this fixes that issue by using the appropriate YAML block scalar syntax