### PR TITLE
fix: daemonset/statefulset template not rendering

### DIFF
--- a/charts/hivemq-operator/operator-tmpls/cluster-daemon-set.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-daemon-set.yaml
@@ -215,23 +215,23 @@ spec:
             periodSeconds: 30
             failureThreshold: 240
           volumeMounts:
-          - name: shared-data
-            mountPath: /hivemq-data
-            readOnly: false
-          - name: conf-override
-            mountPath: /conf-override
-            readOnly: false
-          - name: live-info
-            mountPath: /etc/podinfo
-          - name: backup
-            mountPath: /opt/hivemq/backup
-            readOnly: false
-          - name: log
-            mountPath: /opt/hivemq/log
-            readOnly: false
-          - name: audit
-            mountPath: /opt/hivemq/audit
-            readOnly: false
+            - name: shared-data
+              mountPath: /hivemq-data
+              readOnly: false
+            - name: conf-override
+              mountPath: /conf-override
+              readOnly: false
+            - name: live-info
+              mountPath: /etc/podinfo
+            - name: backup
+              mountPath: /opt/hivemq/backup
+              readOnly: false
+            - name: log
+              mountPath: /opt/hivemq/log
+              readOnly: false
+            - name: audit
+              mountPath: /opt/hivemq/audit
+              readOnly: false
             {% for map in spec.configMaps %}
             - name: {{ map.name }}
               mountPath: {{ util:stringReplace(map.path, "/opt/hivemq/", "/conf-override/") }}

--- a/charts/hivemq-operator/operator-tmpls/cluster-stateful-set.yaml
+++ b/charts/hivemq-operator/operator-tmpls/cluster-stateful-set.yaml
@@ -242,23 +242,23 @@ spec:
             periodSeconds: 30
             failureThreshold: 240
           volumeMounts:
-          - name: shared-data
-            mountPath: /hivemq-data
-            readOnly: false
-          - name: conf-override
-            mountPath: /conf-override
-            readOnly: false
-          - name: live-info
-            mountPath: /etc/podinfo
-          - name: backup
-            mountPath: /opt/hivemq/backup
-            readOnly: false
-          - name: log
-            mountPath: /opt/hivemq/log
-            readOnly: false
-          - name: audit
-            mountPath: /opt/hivemq/audit
-            readOnly: false
+            - name: shared-data
+              mountPath: /hivemq-data
+              readOnly: false
+            - name: conf-override
+              mountPath: /conf-override
+              readOnly: false
+            - name: live-info
+              mountPath: /etc/podinfo
+            - name: backup
+              mountPath: /opt/hivemq/backup
+              readOnly: false
+            - name: log
+              mountPath: /opt/hivemq/log
+              readOnly: false
+            - name: audit
+              mountPath: /opt/hivemq/audit
+              readOnly: false
             {% for map in spec.configMaps %}
             - name: {{ map.name }}
               mountPath: {{ util:stringReplace(map.path, "/opt/hivemq/", "/conf-override/") }}


### PR DESCRIPTION
Due to an indentation error, the operator was not rendering a correct yaml template
for daemonsets/statefulsets when secrets/configmaps where defined

Errors from the operator log:

```
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 08:27:13.300 [pool-1-thread-2] ERROR com.hivemq.util.TemplateUtil - Error operating on stream
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.MarkedYAMLException: while parsing a block mapping
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator  in 'reader', line 415, column 13:
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator               - name: audit
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator                 ^
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator expected <block end>, but found '-'
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator  in 'reader', line 419, column 13:
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator                 - na
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator                 ^
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator  at [Source: (ByteArrayInputStream); line: 417, column: 28]
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.MarkedYAMLException.from(MarkedYAMLException.java:28)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.dataformat.yaml.YAMLParser.nextToken(YAMLParser.java:407)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.core.JsonParser.nextFieldName(JsonParser.java:891)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer.deserializeObject(JsonNodeDeserializer.java:269)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer.deserializeArray(JsonNodeDeserializer.java:456)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer.deserializeObject(JsonNodeDeserializer.java:280)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer.deserializeArray(JsonNodeDeserializer.java:456)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer.deserializeObject(JsonNodeDeserializer.java:280)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer.deserializeObject(JsonNodeDeserializer.java:277)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer.deserializeObject(JsonNodeDeserializer.java:277)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer.deserializeObject(JsonNodeDeserializer.java:277)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.databind.deser.std.JsonNodeDeserializer.deserialize(JsonNodeDeserializer.java:69)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.databind.deser.std.JsonNodeDeserializer.deserialize(JsonNodeDeserializer.java:16)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:322)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.databind.ObjectMapper._readTreeAndClose(ObjectMapper.java:4633)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.databind.ObjectMapper.readTree(ObjectMapper.java:3023)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.hivemq.util.TemplateUtil.loadCluster(TemplateUtil.java:110)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.hivemq.operations.DeploymentOperable.syncState(DeploymentOperable.java:108)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.hivemq.operations.DeploymentOperable.syncState(DeploymentOperable.java:57)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.hivemq.Operator.syncState(Operator.java:207)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.hivemq.Operator.lambda$applyCluster$4(Operator.java:193)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:69)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at java.base/java.lang.Thread.run(Thread.java:834)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator Caused by: org.yaml.snakeyaml.parser.ParserException: while parsing a block mapping
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator  in 'reader', line 415, column 13:
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator               - name: audit
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator                 ^
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator expected <block end>, but found '-'
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator  in 'reader', line 419, column 13:
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator                 - na
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator                 ^
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at org.yaml.snakeyaml.parser.ParserImpl$ParseBlockMappingKey.produce(ParserImpl.java:570)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at org.yaml.snakeyaml.parser.ParserImpl.peekEvent(ParserImpl.java:158)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at org.yaml.snakeyaml.parser.ParserImpl.getEvent(ParserImpl.java:168)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	at com.fasterxml.jackson.dataformat.yaml.YAMLParser.nextToken(YAMLParser.java:403)
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 	... 26 common frames omitted
hivemq-hivemq-operator-operator-74b5764647-tvqgh operator 08:27:13.301 [pool-1-thread-2] ERROR c.h.operations.DeploymentOperable - Could not load template, cannot apply modifications
```