### PR TITLE
[crd] Switch to non-deprecated apiVersion

### DIFF
--- a/charts/hivemq-operator/Chart.yaml
+++ b/charts/hivemq-operator/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - messaging
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.8.7
+version: 0.9.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 4.6.0

--- a/charts/hivemq-operator/crds/hivemq-cluster.yaml
+++ b/charts/hivemq-operator/crds/hivemq-cluster.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: "apiextensions.k8s.io/v1beta1"
+apiVersion: "apiextensions.k8s.io/v1"
 kind: "CustomResourceDefinition"
 metadata:
   name: "hivemq-clusters.hivemq.com"


### PR DESCRIPTION
In this commit, we switch CRD resource to the latest stable
apiVersion so to surpass warning messages on deploying and also prepare
chart for future k8s version where apiextensions.k8s.io/v1beta1
will be removed (1.22+).

Signed-off-by: dntosas <ntosas@gmail.com>