### PR TITLE
fix: rootless mode on openshift (securityContext and RBAC)

### DIFF
--- a/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -59,7 +59,5 @@ spec:
 {{ toYaml . | indent 8 }}
       {{- end }}
       securityContext:
-        runAsGroup: 2000
-        runAsNonRoot: true
-        runAsUser: 2000
+{{ toYaml .Values.global.rbac.securityContext | indent 8 }}
 {{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -61,7 +61,5 @@ spec:
 {{ toYaml . | indent 8 }}
       {{- end }}
       securityContext:
-        runAsGroup: 2000
-        runAsNonRoot: true
-        runAsUser: 2000
+{{ toYaml .Values.global.rbac.securityContext | indent 8 }}
 {{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/operator-cluster-role.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/operator-cluster-role.yaml
@@ -114,6 +114,7 @@ rules:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions
+      - customresourcedefinitions/finalizers
     verbs:
       - list
       - get
@@ -127,6 +128,7 @@ rules:
       - hivemq-clusters
       - hivemq-clusters/status
       - hivemq-clusters/scale
+      - hivemq-clusters/finalizers
     verbs:
       - list
       - get

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -16,7 +16,7 @@ operator:
   # Deploy a custom resource based on the hivemq section below. Set to false if you want to create a HiveMQCluster object yourself.
   # By setting this to false, the operator will not start a HiveMQ cluster when deployed.
   deployCr: true
-  image: hivemq/hivemq-operator:4.6.4
+  image: hivemq/hivemq-operator:4.6.4-pre-1
   imagePullPolicy: IfNotPresent
   nodeSelector: {}
   logLevel: INFO
@@ -112,7 +112,7 @@ hivemq:
   # Annotations to apply to the service account
   serviceAccountAnnotations: {}
   # The values below apply to the HiveMQCluster object. If you are using deployCr: false, this is unused
-  image: hivemq/hivemq4:k8s-4.6.4
+  image: hivemq/hivemq4:k8s-4.6.4-pre-1
   imagePullPolicy: IfNotPresent
   nodeCount: "3"
   cpu: "4"

--- a/manifests/operator/operator-cluster-role.yaml
+++ b/manifests/operator/operator-cluster-role.yaml
@@ -116,6 +116,7 @@ rules:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions
+      - customresourcedefinitions/finalizers
     verbs:
       - list
       - get
@@ -129,6 +130,7 @@ rules:
       - hivemq-clusters
       - hivemq-clusters/status
       - hivemq-clusters/scale
+      - hivemq-clusters/finalizers
     verbs:
       - list
       - get

--- a/manifests/operator/operator-deployment.yaml
+++ b/manifests/operator/operator-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         operator: "hivemq-operator"
     spec:
       containers:
-        - image: hivemq/hivemq-operator:4.7.0-pre-1
+        - image: hivemq/hivemq-operator:4.6.4-pre-1
           imagePullPolicy: IfNotPresent
           name: operator
           env:


### PR DESCRIPTION
# Motivation

# Description

- Issues with pod security policies for the initial hooks:

When trying to deploy the helm chart on Openshift (with default configuration) the following issues occured:
<details><summary> kubectl describe job ...</summary>  

```
pods "hivemq-hivemq-operator-admission-create-" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, spec.containers[0].securityContext.runAsUser: Invalid value: 2000: must be in the ranges: [1000620000, 1000629999], provider "nonroot": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden: not usable by user or serviceaccount, provider "hostaccess": Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount]
```
</details>

Using the global rbac configuration and setting it via values.yaml resolved the issue


- Issues with missing/bad rbac permissions for the operator

When the operator finally came up, some issues were encountered related to permissions of the finalizers

<details><summary> operator logs</summary>  
  
```
09:47:36.957 [pool-1-thread-2] INFO  com.hivemq.Operator - Syncing state for cluster hivemq
Aug 23, 2021 9:47:37 AM com.google.common.util.concurrent.AggregateFuture log
SEVERE: An additional input failed after the first. Logging it after adding the first failure as a suppressed exception.
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://10.217.4.1/api/v1/namespaces/hivemq/services. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. services "hivemq-hivemq-cluster" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>.
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:639)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.assertResponseCode(OperationSupport.java:576)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:543)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:504)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleCreate(OperationSupport.java:292)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleCreate(BaseOperation.java:893)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.create(BaseOperation.java:372)
	at io.fabric8.kubernetes.client.utils.CreateOrReplaceHelper.createOrReplace(CreateOrReplaceHelper.java:56)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:419)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:86)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:401)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:86)
	at com.hivemq.util.DeploymentUtil.renderPatchedService(DeploymentUtil.java:269)
	at com.hivemq.util.DeploymentUtil.lambda$createService$5(DeploymentUtil.java:158)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:69)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)

Aug 23, 2021 9:47:37 AM com.google.common.util.concurrent.AggregateFuture log
SEVERE: An additional input failed after the first. Logging it after adding the first failure as a suppressed exception.
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://10.217.4.1/api/v1/namespaces/hivemq/services. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. services "hivemq-hivemq-mqtt" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>.
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:639)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.assertResponseCode(OperationSupport.java:576)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:543)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:504)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleCreate(OperationSupport.java:292)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleCreate(BaseOperation.java:893)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.create(BaseOperation.java:372)
	at io.fabric8.kubernetes.client.utils.CreateOrReplaceHelper.createOrReplace(CreateOrReplaceHelper.java:56)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:419)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:86)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:401)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:86)
	at com.hivemq.util.DeploymentUtil.renderPatchedService(DeploymentUtil.java:269)
	at com.hivemq.util.DeploymentUtil.lambda$createService$5(DeploymentUtil.java:158)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:69)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)

09:47:37.564 [pool-1-thread-6] WARN  c.hivemq.operations.ServiceOperable - Services did not become ready for cluster hivemq
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://10.217.4.1/api/v1/namespaces/hivemq/services. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. services "hivemq-hivemq-cc" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>.
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:639)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.assertResponseCode(OperationSupport.java:576)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:543)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:504)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleCreate(OperationSupport.java:292)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleCreate(BaseOperation.java:893)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.create(BaseOperation.java:372)
	at io.fabric8.kubernetes.client.utils.CreateOrReplaceHelper.createOrReplace(CreateOrReplaceHelper.java:56)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:419)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:86)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:401)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:86)
	at com.hivemq.util.DeploymentUtil.renderPatchedService(DeploymentUtil.java:269)
	at com.hivemq.util.DeploymentUtil.lambda$createService$5(DeploymentUtil.java:158)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:69)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
09:47:40.173 [pool-1-thread-7] INFO  com.hivemq.Operator - Syncing state for cluster hivemq
Aug 23, 2021 9:47:40 AM com.google.common.util.concurrent.AggregateFuture log
SEVERE: An additional input failed after the first. Logging it after adding the first failure as a suppressed exception.
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://10.217.4.1/api/v1/namespaces/hivemq/services. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. services "hivemq-hivemq-cc" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>.
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:639)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.assertResponseCode(OperationSupport.java:576)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:543)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:504)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleCreate(OperationSupport.java:292)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleCreate(BaseOperation.java:893)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.create(BaseOperation.java:372)
	at io.fabric8.kubernetes.client.utils.CreateOrReplaceHelper.createOrReplace(CreateOrReplaceHelper.java:56)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:419)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:86)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:401)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:86)
	at com.hivemq.util.DeploymentUtil.renderPatchedService(DeploymentUtil.java:269)
	at com.hivemq.util.DeploymentUtil.lambda$createService$5(DeploymentUtil.java:158)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:69)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)

Aug 23, 2021 9:47:40 AM com.google.common.util.concurrent.AggregateFuture log
SEVERE: An additional input failed after the first. Logging it after adding the first failure as a suppressed exception.
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://10.217.4.1/api/v1/namespaces/hivemq/services. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. services "hivemq-hivemq-cluster" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>.
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:639)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.assertResponseCode(OperationSupport.java:576)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:543)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:504)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleCreate(OperationSupport.java:292)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleCreate(BaseOperation.java:893)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.create(BaseOperation.java:372)
	at io.fabric8.kubernetes.client.utils.CreateOrReplaceHelper.createOrReplace(CreateOrReplaceHelper.java:56)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:419)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:86)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:401)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:86)
	at com.hivemq.util.DeploymentUtil.renderPatchedService(DeploymentUtil.java:269)
	at com.hivemq.util.DeploymentUtil.lambda$createService$5(DeploymentUtil.java:158)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:69)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)

09:47:40.344 [pool-1-thread-11] WARN  c.hivemq.operations.ServiceOperable - Services did not become ready for cluster hivemq
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://10.217.4.1/api/v1/namespaces/hivemq/services. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. services "hivemq-hivemq-mqtt" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>.
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:639)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.assertResponseCode(OperationSupport.java:576)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:543)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:504)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleCreate(OperationSupport.java:292)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleCreate(BaseOperation.java:893)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.create(BaseOperation.java:372)
	at io.fabric8.kubernetes.client.utils.CreateOrReplaceHelper.createOrReplace(CreateOrReplaceHelper.java:56)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:419)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:86)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:401)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.createOrReplace(BaseOperation.java:86)
	at com.hivemq.util.DeploymentUtil.renderPatchedService(DeploymentUtil.java:269)
	at com.hivemq.util.DeploymentUtil.lambda$createService$5(DeploymentUtil.java:158)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:69)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```
</details>



## Environment information

This was tested on 
```
crc version
CodeReady Containers version: 1.31.2+19538dab
OpenShift version: 4.8.4 (not embedded in executable)

k version
Client Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.3", GitCommit:"ca643a4d1f7bfe34773c74f79527be4afd95bf39", GitTreeState:"clean", BuildDate:"2021-07-15T20:58:09Z", GoVersion:"go1.16.5", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.1+38b3ecc", GitCommit:"38b3eccb7e23fd950b6c7b5ec1cc3075b630aac3", GitTreeState:"clean", BuildDate:"2021-07-29T23:59:54Z", GoVersion:"go1.16.6", Compiler:"gc", Platform:"linux/amd64"}
```

Tested with a configuration 

```
global:
  rbac:
    securityContext:
      runAsNonRoot: true
      runAsUser:

hivemq:
  nodeCount: 1
  cpu: "1"
  memory: "2Gi"
  podSecurityContext:
    runAsNonRoot: true
    runAsUser:
  containerSecurityContext:
    runAsNonRoot: true
    runAsUser:
```