### PR TITLE
fix: default configuration to enable overload protection

### DIFF
--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -250,10 +250,6 @@ hivemq:
                 <replica-count>${HIVEMQ_CLUSTER_REPLICA_COUNT}</replica-count>
             </replication>
 
-            <overload-protection>
-                <enabled>${HIVEMQ_CLUSTER_OVERLOAD_PROTECTION}</enabled>
-            </overload-protection>
-
             <failure-detection>
                 <tcp-health-check>
                     <enabled>true</enabled>
@@ -270,6 +266,9 @@ hivemq:
             </failure-detection>
 
         </cluster>
+        <overload-protection>
+            <enabled>${HIVEMQ_CLUSTER_OVERLOAD_PROTECTION}</enabled>
+        </overload-protection>
         <restrictions>
             <max-client-id-length>${HIVEMQ_MAX_CLIENT_ID_LENGTH}</max-client-id-length>
             <max-topic-length>${HIVEMQ_MAX_TOPIC_LENGTH}</max-topic-length>


### PR DESCRIPTION
# Motivation

Have a valid default configuration  for the helm chart

# Description

Fixes the overload protection configuration - according to [our documentation](https://www.hivemq.com/docs/hivemq/4.6/user-guide/overload-protection.html) the overload protection needs to be defined in the `<hivemq></hivemq>` tag and not in `<cluster></cluster>`