### PR TITLE
fix: allow to specify initBusyboxImage and initDnsWaitImage for default hivemq cluster

### DIFF
--- a/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
@@ -90,4 +90,6 @@ spec:
   {{- if .Values.hivemq.operatorHints }}
   operatorHints: {{ toYaml .Values.hivemq.operatorHints | nindent 4 }}
   {{- end }}
+  initBusyboxImage: {{ .Values.hivemq.initBusyboxImage }}
+  initDnsWaitImage: {{ .Values.hivemq.initDnsWaitImage }}
 {{- end }}

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -136,6 +136,8 @@ hivemq:
   #   args:
   #   - |
   #     echo "mycustomfile" >> /hivemq-data/conf/test.cfg
+  initBusyboxImage: busybox:latest
+  initDnsWaitImage: hivemq/init-dns-wait:1.0.0
   extensions:
     - # Default platform extensions starting from 4.4.0. Add a configMap and enable them if you want to use either
       name: hivemq-kafka-extension


### PR DESCRIPTION
# Motivation

Some customers require to use images from a trusted registry (or a pull through registry) i.e. artifactory.

# Description

The operator and the the hivemq cluster CRD already has the `initBusyboxImage` and `initDnsWaitImage` parameters for this scenario.
When using the helm-charts, the default value for these fields was not yet exposed