### PR TITLE
Fix/missing 4 7 changes

### DIFF
--- a/charts/hivemq-operator/CHANGELOG.md
+++ b/charts/hivemq-operator/CHANGELOG.md
@@ -1,7 +1,7 @@
 # chart 0.9.1
 
 - Fix overload protection configuration
-- Add some missing RBAC configurations
+- Add missing RBAC configuration, so that the chart is compatible with Openshift
 - Allow customization of init images in values.yaml
 - Allow security context configuration for webhook job
 

--- a/charts/hivemq-operator/CHANGELOG.md
+++ b/charts/hivemq-operator/CHANGELOG.md
@@ -1,3 +1,10 @@
+# chart 0.9.1
+
+- Fix overload protection configuration
+- Add some missing RBAC configurations
+- Allow customization of init images in values.yaml
+- Allow security context configuration for webhook job
+
 # 4.7.0 (chart 0.9.0)
 
 The most significant changes in this release are:

--- a/charts/hivemq-operator/Chart.yaml
+++ b/charts/hivemq-operator/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - messaging
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.0
+version: 0.9.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 4.7.0

--- a/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -59,7 +59,5 @@ spec:
 {{ toYaml . | indent 8 }}
       {{- end }}
       securityContext:
-        runAsGroup: 2000
-        runAsNonRoot: true
-        runAsUser: 2000
+{{ toYaml .Values.global.rbac.securityContext | indent 8 }}
 {{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -61,7 +61,5 @@ spec:
 {{ toYaml . | indent 8 }}
       {{- end }}
       securityContext:
-        runAsGroup: 2000
-        runAsNonRoot: true
-        runAsUser: 2000
+{{ toYaml .Values.global.rbac.securityContext | indent 8 }}
 {{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
@@ -90,4 +90,6 @@ spec:
   {{- if .Values.hivemq.operatorHints }}
   operatorHints: {{ toYaml .Values.hivemq.operatorHints | nindent 4 }}
   {{- end }}
+  initBusyboxImage: {{ .Values.hivemq.initBusyboxImage }}
+  initDnsWaitImage: {{ .Values.hivemq.initDnsWaitImage }}
 {{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/operator-cluster-role.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/operator-cluster-role.yaml
@@ -114,6 +114,7 @@ rules:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions
+      - customresourcedefinitions/finalizers
     verbs:
       - list
       - get
@@ -127,6 +128,7 @@ rules:
       - hivemq-clusters
       - hivemq-clusters/status
       - hivemq-clusters/scale
+      - hivemq-clusters/finalizers
     verbs:
       - list
       - get

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -136,6 +136,8 @@ hivemq:
   #   args:
   #   - |
   #     echo "mycustomfile" >> /hivemq-data/conf/test.cfg
+  initBusyboxImage: busybox:latest
+  initDnsWaitImage: hivemq/init-dns-wait:1.0.0
   extensions:
     - # Default platform extensions starting from 4.4.0. Add a configMap and enable them if you want to use either
       name: hivemq-kafka-extension

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -309,10 +309,6 @@ hivemq:
                 <replica-count>${HIVEMQ_CLUSTER_REPLICA_COUNT}</replica-count>
             </replication>
 
-            <overload-protection>
-                <enabled>${HIVEMQ_CLUSTER_OVERLOAD_PROTECTION}</enabled>
-            </overload-protection>
-
             <failure-detection>
                 <tcp-health-check>
                     <enabled>true</enabled>
@@ -329,6 +325,9 @@ hivemq:
             </failure-detection>
 
         </cluster>
+        <overload-protection>
+            <enabled>${HIVEMQ_CLUSTER_OVERLOAD_PROTECTION}</enabled>
+        </overload-protection>
         <restrictions>
             <max-client-id-length>${HIVEMQ_MAX_CLIENT_ID_LENGTH}</max-client-id-length>
             <max-topic-length>${HIVEMQ_MAX_TOPIC_LENGTH}</max-topic-length>

--- a/manifests/operator/operator-cluster-role.yaml
+++ b/manifests/operator/operator-cluster-role.yaml
@@ -116,6 +116,7 @@ rules:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions
+      - customresourcedefinitions/finalizers
     verbs:
       - list
       - get
@@ -129,6 +130,7 @@ rules:
       - hivemq-clusters
       - hivemq-clusters/status
       - hivemq-clusters/scale
+      - hivemq-clusters/finalizers
     verbs:
       - list
       - get


### PR DESCRIPTION
Cherry picked the missing changes from the overlooked `hivemq/4.7` branch.

closes #34 