### PR TITLE
Chore: update operator and HiveMQ to 4.7.1

### DIFF
--- a/charts/hivemq-operator/CHANGELOG.md
+++ b/charts/hivemq-operator/CHANGELOG.md
@@ -1,3 +1,7 @@
+# chart 0.9.2
+
+- Fix an issue where the operator would not properly sync the `-dynamic-state` ConfigMap
+
 # chart 0.9.1
 
 - Fix overload protection configuration

--- a/charts/hivemq-operator/Chart.yaml
+++ b/charts/hivemq-operator/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - messaging
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.1
+version: 0.9.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 4.7.0

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -16,7 +16,7 @@ operator:
   # Deploy a custom resource based on the hivemq section below. Set to false if you want to create a HiveMQCluster object yourself.
   # By setting this to false, the operator will not start a HiveMQ cluster when deployed.
   deployCr: true
-  image: hivemq/hivemq-operator:4.7.0
+  image: hivemq/hivemq-operator:4.7.1
   imagePullPolicy: IfNotPresent
   nodeSelector: {}
   logLevel: INFO
@@ -112,7 +112,7 @@ hivemq:
   # Annotations to apply to the service account
   serviceAccountAnnotations: {}
   # The values below apply to the HiveMQCluster object. If you are using deployCr: false, this is unused
-  image: hivemq/hivemq4:k8s-4.7.0
+  image: hivemq/hivemq4:k8s-4.7.1
   imagePullPolicy: IfNotPresent
   nodeCount: "3"
   cpu: "4"

--- a/manifests/operator/operator-deployment.yaml
+++ b/manifests/operator/operator-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         operator: "hivemq-operator"
     spec:
       containers:
-        - image: hivemq/hivemq-operator:4.7.0
+        - image: hivemq/hivemq-operator:4.7.1
           imagePullPolicy: IfNotPresent
           name: operator
           env:


### PR DESCRIPTION
Updates to current operator version which contains a bugfix and bumps the HiveMQ version to 4.7.1 as well.