### PR TITLE
Add missing claim templates field in CR

### DIFF
--- a/charts/hivemq-operator/Chart.yaml
+++ b/charts/hivemq-operator/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - messaging
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.3
+version: 0.10.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 4.7.0

--- a/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
@@ -92,6 +92,8 @@ spec:
   {{- end }}
   initBusyboxImage: {{ .Values.hivemq.initBusyboxImage }}
   initDnsWaitImage: {{ .Values.hivemq.initDnsWaitImage }}
-  volumeClaimTemplates:
-  {{ .Values.hivemq.volumeClaimTemplates }}
+  {{- if .Values.hivemq.volumeClaimTemplates }}
+  volumeClaimTemplates: {{ toYaml .Values.hivemq.volumeClaimTemplates | nindent 4 }}
+  {{- end }}
+
 {{- end }}

--- a/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/custom-resource.yaml
@@ -92,4 +92,6 @@ spec:
   {{- end }}
   initBusyboxImage: {{ .Values.hivemq.initBusyboxImage }}
   initDnsWaitImage: {{ .Values.hivemq.initDnsWaitImage }}
+  volumeClaimTemplates:
+  {{ .Values.hivemq.volumeClaimTemplates }}
 {{- end }}

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -86,7 +86,18 @@ hivemq:
   # Node selectors for the Pod spec
   nodeSelector: {}
   # StatefulSet only: Volume claim templates to use
-  volumeClaimTemplates: []
+  volumeClaimTemplates:
+    # - kind: PersistentVolumeClaim
+    #   apiVersion: v1
+    #   metadata:
+    #     name: data
+    #   spec:
+    #     accessModes:
+    #       - ReadWriteOnce
+    #     resources:
+    #       requests:
+    #         storage: 100Gi
+    #     volumeMode: Filesystem
   # RuntimeClass for the Pod spec
   runtimeClassName: ""
   # PriorityClass for the Pod spec


### PR DESCRIPTION
the custom resource template is missing the volumeClaimTemplates field, which is necessary for statefulset resources