### PR TITLE
Add affinity for HiveMQ operator deployment

### DIFF
--- a/charts/hivemq-operator/CHANGELOG.md
+++ b/charts/hivemq-operator/CHANGELOG.md
@@ -1,3 +1,7 @@
+# chart 0.10.4
+
+- Added ability to specify `affinity` for the operator 
+
 # chart 0.10.3
 
 - Fixed blocking deployment on version 1.22 using a newer cert-gen webhook from nginx

--- a/charts/hivemq-operator/templates/hivemq-operator/operator-deployment.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/operator-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       {{- end }}
       {{- with .Values.operator.affinity }}
       affinity:
-      {{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - image: {{ .Values.operator.image }}

--- a/charts/hivemq-operator/templates/hivemq-operator/operator-deployment.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/operator-deployment.yaml
@@ -24,6 +24,10 @@ spec:
       nodeSelector:
       {{ toYaml . | indent 8 }}
       {{- end }}
+      {{- with .Values.operator.affinity }}
+      affinity:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
         - image: {{ .Values.operator.image }}
           imagePullPolicy: {{ .Values.operator.imagePullPolicy }}

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -18,7 +18,19 @@ operator:
   deployCr: true
   image: hivemq/hivemq-operator:4.7.1
   imagePullPolicy: IfNotPresent
+
+
+
+  ## Nodeselector for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  ##
   nodeSelector: {}
+
+  ## Affinity for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+
   logLevel: INFO
   # Let the operator verify all HiveMQCluster objects before accepting them.
   # Not using the validation hook can result in erroneous cluster configurations which are hard to debug.


### PR DESCRIPTION
# Motivation

Using `affinity` helps to schedule pods in kubernetes cluster (see also: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity ).

# Descriptions

The change adds `affinity` to the hivemq-operator to be able to perform advanced scheduling (i.e. on specific nodegroups in specific regions/zones)