### PR TITLE
Allow to pass additional environment variables 

### DIFF
--- a/charts/hivemq-operator/CHANGELOG.md
+++ b/charts/hivemq-operator/CHANGELOG.md
@@ -1,5 +1,6 @@
-# chart 0.10.4
+# chart 0.10.5
 
+- Added ability to pass arbitrary environment variables to the operator pod
 - Added ability to specify `affinity` for the operator 
 
 # chart 0.10.3

--- a/charts/hivemq-operator/Chart.yaml
+++ b/charts/hivemq-operator/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - messaging
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.10.4
+version: 0.10.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 4.7.5

--- a/charts/hivemq-operator/templates/hivemq-operator/operator-deployment.yaml
+++ b/charts/hivemq-operator/templates/hivemq-operator/operator-deployment.yaml
@@ -51,6 +51,10 @@ spec:
             {{- end }}
             - name: SSL_FQDN
               value: "{{ include "hivemq.name" . }}-operator.{{ template "hivemq.namespace" . }}.svc"
+            {{- range $key, $value := .Values.operator.env }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
           resources: {{ toYaml .Values.operator.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.global.rbac.securityContext | nindent 12 }}

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -58,6 +58,10 @@ operator:
       tolerations: []
   # Set this string to a name of a externally managed ConfigMap containing the templates for the operator if you want to customize them.
   templateConfigMap: ""
+  ## Extra environment variables that will be pass to the operator in the form of
+  ## env:
+  ## MY_CUSTOM_ENV: MY_VALUE
+  env: {}
   resources:
     limits:
       cpu: 800m


### PR DESCRIPTION
# Motivation

We want to pass custom env variables to the operator when deploying via the helm chart

# Descriptions

Adds a variable to the helm-chart operator section and renders respective keys into the deployment