### PR TITLE
chore: Add new enterprise extensions

### DIFF
--- a/charts/hivemq-operator/Chart.yaml
+++ b/charts/hivemq-operator/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - messaging
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.11.7
+version: 0.12.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 4.8.4

--- a/charts/hivemq-operator/Chart.yaml
+++ b/charts/hivemq-operator/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - messaging
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.11.6
+version: 0.11.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 4.8.4

--- a/charts/hivemq-operator/Chart.yaml
+++ b/charts/hivemq-operator/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - messaging
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.12.0
+version: 0.11.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 4.8.4

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -172,6 +172,9 @@ hivemq:
       name: hivemq-kafka-extension
       extensionUri: preinstalled
       enabled: false
+    - name: hivemq-google-cloud-pubsub-extension
+      extensionUri: preinstalled
+      enabled: false
     - name: hivemq-bridge-extension
       extensionUri: preinstalled
       enabled: false
@@ -187,9 +190,6 @@ hivemq:
 
         [[ ! -f drivers/postgres-jdbc.jar ]] &&
         curl -L https://jdbc.postgresql.org/download/postgresql-42.2.14.jar --output drivers/jdbc/postgres.jar
-    - name: hivemq-google-cloud-pubsub-extension
-      extensionUri: preinstalled
-      enabled: false
     - name: hivemq-distributed-tracing-extension
       extensionUri: preinstalled
       enabled: false

--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -16,7 +16,7 @@ operator:
   # Deploy a custom resource based on the hivemq section below. Set to false if you want to create a HiveMQCluster object yourself.
   # By setting this to false, the operator will not start a HiveMQ cluster when deployed.
   deployCr: true
-  image: hivemq/hivemq-operator:4.7.5
+  image: hivemq/hivemq-operator:4.7.6
   imagePullPolicy: IfNotPresent
 
   # Whether the operator should handle HiveMQCluster resources across all namespaces
@@ -187,6 +187,12 @@ hivemq:
 
         [[ ! -f drivers/postgres-jdbc.jar ]] &&
         curl -L https://jdbc.postgresql.org/download/postgresql-42.2.14.jar --output drivers/jdbc/postgres.jar
+    - name: hivemq-google-cloud-pubsub-extension
+      extensionUri: preinstalled
+      enabled: false
+    - name: hivemq-distributed-tracing-extension
+      extensionUri: preinstalled
+      enabled: false
   ## Feel free to add other extensions as well. You should keep the blocks above to maintain control over the platform extensions though.
   #- name: hivemq-mqtt-message-log-extension
   #  extensionUri: https://www.hivemq.com/releases/extensions/hivemq-mqtt-message-log-extension-1.1.0.zip


### PR DESCRIPTION
- Add new enterprise extensions into the values as they are preinstalled
  - hivemq-google-cloud-pubsub-extension
  - hivemq-distributed-tracing-extension
- Bump operator version with multi-namespace fix