### PR TITLE
Correct imagePullSecrets indentation based on deployments

### DIFF
--- a/charts/hivemq-operator/values.yaml
+++ b/charts/hivemq-operator/values.yaml
@@ -9,9 +9,9 @@ global:
       runAsNonRoot: true
       runAsUser: 1000
     allowedCapabilities: []
-    # Image pull secrets for operator, hivemq or other images.
-    imagePullSecrets: []
-    # - name: hivemq-pull-secret
+  # Image pull secrets for operator, hivemq or other images.
+  imagePullSecrets: []
+  # - name: hivemq-pull-secret
 
 operator:
   # Deploy a custom resource based on the hivemq section below. Set to false if you want to create a HiveMQCluster object yourself.
@@ -84,14 +84,15 @@ hivemq:
   # Custom init container specs to add to the HiveMQ Pod. This is an extension of the initialization field. In comparison, this field does not have any defaults but allows for more granular configuration using the full K8s Container API
   initContainers: []
   # HiveMQ Pod security context
-  podSecurityContext: {}
+  podSecurityContext:
+    {}
     # fsGroup: 10000
     # runAsNonRoot: true
     # runAsUser: 10001
     # sysctls:
-      # To ensure we don't run into port exhaustion
-      # - name: net.ipv4.ip_local_port_range
-      #   value: "1024 65535"
+    # To ensure we don't run into port exhaustion
+    # - name: net.ipv4.ip_local_port_range
+    #   value: "1024 65535"
   # HiveMQ container security context within the Pod
   containerSecurityContext:
     # runAsNonRoot: true


### PR DESCRIPTION
From the operator deployment artefact, the imagePullSecrets is directly under global as opposed to how it's enlisted on default values.