### PR TITLE
Enforce documentation/comments around the overriding values.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ charts/**/charts/**.tgz
 **/.DS_Store
 .gradle
 build
+
+# Folders and files created when enabling debug mode in Helm
+.debug

--- a/charts/hivemq-platform/values.yaml
+++ b/charts/hivemq-platform/values.yaml
@@ -255,8 +255,10 @@ config:
   name: ""
   # Inlines the HiveMQ Platform configuration (config.xml) from a file:
   # --set-file config.overrideHiveMQConfig=your-config.xml
+  # WARNING: Whenever this value is set, all other values related to the HiveMQ platform configuration will be ignored.
   overrideHiveMQConfig: ""
   # Inlines the StatefulSet configuration and overrides the default StatefulSet.
+  # WARNING: Whenever this value is set, all other values related to the StatefulSet configuration will be ignored.
   overrideStatefulSet: ""
   # Inlines an init container configuration and adds it to the StatefulSet
   overrideInitContainers: ""


### PR DESCRIPTION
https://hivemq.kanbanize.com/ctrl_board/22/cards/20948/details/

We would like to reinforce and validate the different combinations of the values specially when using either the `overrideHiveMQConfig` or the `overrideStatefulSet` values, as some of other related values will be ignored.

Unfortunately, we are already setting default values in the values YAML file which are used as well for instance to configure some of the Statefuset specs. So for existing customer using the `overrideStatefulSet` throwing an error will make this a breaking change.

Another different approach I thought was to display a warning instead when installing or upgrading the charts, but again there is a problem here since we are already setting default values for some of these related values used in a Statefulset or HiveMQ ConfigMap. Even if we remove and omit these default values completely from our own custom values file, Helm will combine both values, the ones from our custom values file with the ones which are not present or set in the same and will use the default.
This will mean, that for a customer to actually avoid a warning message, would have to set all these default values to empty/null content. For example:
```
image:
  repository: ""
  name: ""
  tag: ""
  pullPolicy: ""
  pullSecretName: ""
```