### PR TITLE
Fix deprecated usage of gradle/gradle-build-action

### DIFF
--- a/.github/workflows/hivemq-operator-integration-test.yml
+++ b/.github/workflows/hivemq-operator-integration-test.yml
@@ -50,20 +50,19 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Run HiveMQ Operator (legacy) integration tests
-        uses: gradle/gradle-build-action@e2097ccd7e8ed48671dc068ac4efa86d25745b39 # v3
-        env:
-          TEST_PLAN: ${{ matrix.test-plan }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3
         with:
-          cache-disabled: true
           gradle-home-cache-includes: |
             caches
             notifications
             jdks
           gradle-home-cache-cleanup: true
-          build-root-directory: helm-charts
-          arguments: |
-            :tests-hivemq-operator:integrationTest
+      - name: Run HiveMQ Operator (legacy) integration tests
+        env:
+          TEST_PLAN: ${{ matrix.test-plan }}
+        working-directory: helm-charts
+        run: ./gradlew :tests-hivemq-operator:integrationTest
       - name: Upload HiveMQ Operator (legacy) test results
         if: always()
         uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4

--- a/.github/workflows/hivemq-platform-operator-integration-test.yml
+++ b/.github/workflows/hivemq-platform-operator-integration-test.yml
@@ -51,20 +51,19 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Run HiveMQ Platform Operator integration tests
-        uses: gradle/gradle-build-action@e2097ccd7e8ed48671dc068ac4efa86d25745b39 # v3
-        env:
-          TEST_PLAN: ${{ matrix.test-plan }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3
         with:
-          cache-disabled: true
           gradle-home-cache-includes: |
             caches
             notifications
             jdks
           gradle-home-cache-cleanup: true
-          build-root-directory: helm-charts
-          arguments: |
-            :tests-hivemq-platform-operator:integrationTest --tests "*.compose.*"
+      - name: Run HiveMQ Platform Operator integration tests
+        env:
+          TEST_PLAN: ${{ matrix.test-plan }}
+        working-directory: helm-charts
+        run: ./gradlew :tests-hivemq-platform-operator:integrationTest --tests "*.compose.*"
       - name: Upload HiveMQ Platform Operator test results
         if: always()
         uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4
@@ -117,20 +116,19 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Run HiveMQ Platform Operator integration tests
-        uses: gradle/gradle-build-action@e2097ccd7e8ed48671dc068ac4efa86d25745b39 # v3
-        env:
-          TEST_PLAN: ${{ matrix.test-plan }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3
         with:
-          cache-disabled: true
           gradle-home-cache-includes: |
             caches
             notifications
             jdks
           gradle-home-cache-cleanup: true
-          build-root-directory: helm-charts
-          arguments: |
-            :tests-hivemq-platform-operator:integrationTest --tests "*.single.*"
+      - name: Run HiveMQ Platform Operator integration tests
+        env:
+          TEST_PLAN: ${{ matrix.test-plan }}
+        working-directory: helm-charts
+        run: ./gradlew :tests-hivemq-platform-operator:integrationTest --tests "*.single.*"
       - name: Upload HiveMQ Platform Operator test results
         if: always()
         uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -50,18 +50,17 @@ jobs:
             git fetch --all
             git checkout origin/${GITHUB_REF_NAME}
           fi
-      - name: Build HiveMQ Platform Operator and HiveMQ Platform Operator Init images
-        uses: gradle/gradle-build-action@e2097ccd7e8ed48671dc068ac4efa86d25745b39 # v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3
         with:
-          cache-disabled: true
           gradle-home-cache-includes: |
             caches
             notifications
             jdks
           gradle-home-cache-cleanup: true
-          build-root-directory: helm-charts
-          arguments: |
-            :tests-hivemq-platform-operator:build :tests-hivemq-platform-operator:saveDockerImages
+      - name: Build HiveMQ Platform Operator and HiveMQ Platform Operator Init images
+        working-directory: helm-charts
+        run: ./gradlew :tests-hivemq-platform-operator:build :tests-hivemq-platform-operator:saveDockerImages
       - name: Start up KinD cluster with local images
         working-directory: ${{ github.workspace }}/helm-charts
         run: |
@@ -142,18 +141,17 @@ jobs:
             git fetch --all
             git checkout origin/${GITHUB_REF_NAME}
           fi
-      - name: Build HiveMQ Operator (legacy) images
-        uses: gradle/gradle-build-action@e2097ccd7e8ed48671dc068ac4efa86d25745b39 # v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3
         with:
-          cache-disabled: true
           gradle-home-cache-includes: |
             caches
             notifications
             jdks
           gradle-home-cache-cleanup: true
-          build-root-directory: helm-charts
-          arguments: |
-            :tests-hivemq-operator:build :tests-hivemq-operator:saveDockerImages
+      - name: Build HiveMQ Operator (legacy) images
+        working-directory: helm-charts
+        run: ./gradlew :tests-hivemq-operator:build :tests-hivemq-operator:saveDockerImages
       - name: Start up KinD cluster with local images
         working-directory: ${{ github.workspace }}/helm-charts
         run: |


### PR DESCRIPTION
Resolves the following deprecation warnings:
* https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle
* https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated