### PR TITLE
Replace ClusterRole from Helm chart with dependent Role to allow Pod annotation updates when the operator is not running

### DIFF
--- a/charts/hivemq-platform-operator/templates/NOTES.txt
+++ b/charts/hivemq-platform-operator/templates/NOTES.txt
@@ -5,7 +5,18 @@ Documentation can be found here: https://docs.hivemq.com/hivemq-platform-operato
 {{- if ne .Values.serviceAccount.create true }}
 
 *** Warning ***
-The service account {{ .Values.serviceAccount.name }} should have correct permissions for the Operator to work correctly.
+The ServiceAccount {{ .Values.serviceAccount.name }} should have sufficient permissions for the Operator to work correctly.
+{{- end }}
+{{- if ne .Values.hivemqPlatformServiceAccount.create true }}
 
+*** Warning ***
+The Operator is not configured to create a ServiceAccount for the HiveMQ Platform Pods.
+Please make sure that you configure a valid custom ServiceAccount in the HiveMQ Platform Helm charts values.yaml (see nodes.serviceAccountName).
+{{- end }}
+{{- if ne .Values.hivemqPlatformServiceAccount.permissions.create true }}
+
+*** Warning ***
+The Operator is not configured to create the RBAC permissions (Role and RoleBinding) for the ServiceAccount of the HiveMQ Platform Pods.
+Please make sure the HiveMQ Platform Helm charts values.yaml configures a ServiceAccount (see nodes.serviceAccountName) with sufficient RBAC permissions to list, get and watch Pods.
 {{- end }}
 -----

--- a/charts/hivemq-platform-operator/templates/deployment.yml
+++ b/charts/hivemq-platform-operator/templates/deployment.yml
@@ -75,8 +75,9 @@ spec:
             - name: hivemq.platform.operator.serviceaccount.create
               value: "{{ .Values.hivemqPlatformServiceAccount.create }}"
             - name: hivemq.platform.operator.serviceaccount.validate
-              value: "{{ .Values.platformServiceAccount.validate }}"
               value: "{{ .Values.hivemqPlatformServiceAccount.validate }}"
+            - name: hivemq.platform.operator.serviceaccount.name
+              value: "{{ .Values.hivemqPlatformServiceAccount.name }}"
             - name: hivemq.platform.operator.serviceaccount.permissions.create
               value: "{{ .Values.hivemqPlatformServiceAccount.permissions.create }}"
             - name: hivemq.platform.operator.serviceaccount.permissions.validate

--- a/charts/hivemq-platform-operator/templates/deployment.yml
+++ b/charts/hivemq-platform-operator/templates/deployment.yml
@@ -71,6 +71,16 @@ spec:
             # additional option to show the configuration details in the log
             - name: hivemq.platform.operator.log.configuration
               value: "{{ .Values.logConfiguration | default "false"}}"
+            # additional options for service accounts and permission functionality
+            - name: hivemq.platform.operator.serviceaccount.create
+              value: "{{ .Values.hivemqPlatformServiceAccount.create }}"
+            - name: hivemq.platform.operator.serviceaccount.validate
+              value: "{{ .Values.platformServiceAccount.validate }}"
+              value: "{{ .Values.hivemqPlatformServiceAccount.validate }}"
+            - name: hivemq.platform.operator.serviceaccount.permissions.create
+              value: "{{ .Values.hivemqPlatformServiceAccount.permissions.create }}"
+            - name: hivemq.platform.operator.serviceaccount.permissions.validate
+              value: "{{ .Values.hivemqPlatformServiceAccount.permissions.validate }}"
             # additional options for fine-grained logging
             - name: hivemq.platform.operator.quarkus.log.level
               value: "{{ .Values.quarkusLogLevel | default "INFO" }}"

--- a/charts/hivemq-platform-operator/templates/rbac.yml
+++ b/charts/hivemq-platform-operator/templates/rbac.yml
@@ -104,8 +104,8 @@ rules:
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
+      - roles
       - rolebindings
-      - clusterroles
     verbs:
       - get
       - list
@@ -114,19 +114,14 @@ rules:
       - patch
       - update
       - delete
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: "hivemq-platform-operator-pod-resource-role-{{.Release.Name}}"
-rules:
   - apiGroups:
-      - ""
+      - rbac.authorization.k8s.io
     resources:
-      - pods
+      - clusterroles
+      - clusterrolebindings
     verbs:
       - get
-      - patch
-      - update
+      - list
+      - watch
 ---
 {{- end }}

--- a/charts/hivemq-platform-operator/templates/rbac.yml
+++ b/charts/hivemq-platform-operator/templates/rbac.yml
@@ -97,10 +97,12 @@ rules:
       - get
       - list
       - watch
+      {{- if .Values.hivemqPlatformServiceAccount.create }}
       - create
       - patch
       - update
       - delete
+      {{- end }}
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -110,10 +112,13 @@ rules:
       - get
       - list
       - watch
+      {{- if .Values.hivemqPlatformServiceAccount.permissions.create }}
       - create
       - patch
       - update
       - delete
+      {{- end }}
+  {{- if .Values.hivemqPlatformServiceAccount.permissions.validate }}
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -123,5 +128,6 @@ rules:
       - get
       - list
       - watch
+  {{- end }}
 ---
 {{- end }}

--- a/charts/hivemq-platform-operator/tests/hivemq_operator_deployment_test.yaml
+++ b/charts/hivemq-platform-operator/tests/hivemq_operator_deployment_test.yaml
@@ -292,6 +292,11 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: hivemq.platform.operator.serviceaccount.name
+            value: ""
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: hivemq.platform.operator.serviceaccount.permissions.create
             value: "true"
       - contains:
@@ -327,6 +332,20 @@ tests:
           content:
             name: hivemq.platform.operator.serviceaccount.validate
             value: "false"
+
+  - it: with platform service account name set
+    set:
+      hivemqPlatformServiceAccount.name: "my-serviceaccount-name"
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0]
+      - exists:
+          path: spec.template.spec.containers[0].env
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: hivemq.platform.operator.serviceaccount.name
+            value: "my-serviceaccount-name"
 
   - it: with platform service account permissions create disabled
     set:

--- a/charts/hivemq-platform-operator/tests/hivemq_operator_deployment_test.yaml
+++ b/charts/hivemq-platform-operator/tests/hivemq_operator_deployment_test.yaml
@@ -272,3 +272,86 @@ tests:
             effect: NoSchedule
             key: my-key
             operator: Exists
+
+  - it: with default platform service account settings
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0]
+      - exists:
+          path: spec.template.spec.containers[0].env
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: hivemq.platform.operator.serviceaccount.create
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: hivemq.platform.operator.serviceaccount.validate
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: hivemq.platform.operator.serviceaccount.permissions.create
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: hivemq.platform.operator.serviceaccount.permissions.validate
+            value: "true"
+
+  - it: with platform service account create disabled
+    set:
+      hivemqPlatformServiceAccount.create: false
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0]
+      - exists:
+          path: spec.template.spec.containers[0].env
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: hivemq.platform.operator.serviceaccount.create
+            value: "false"
+
+  - it: with platform service account validate disabled
+    set:
+      hivemqPlatformServiceAccount.validate: false
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0]
+      - exists:
+          path: spec.template.spec.containers[0].env
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: hivemq.platform.operator.serviceaccount.validate
+            value: "false"
+
+  - it: with platform service account permissions create disabled
+    set:
+      hivemqPlatformServiceAccount.permissions.create: false
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0]
+      - exists:
+          path: spec.template.spec.containers[0].env
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: hivemq.platform.operator.serviceaccount.permissions.create
+            value: "false"
+
+  - it: with platform service account permissions validate disabled
+    set:
+      hivemqPlatformServiceAccount.permissions.validate: false
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0]
+      - exists:
+          path: spec.template.spec.containers[0].env
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: hivemq.platform.operator.serviceaccount.permissions.validate
+            value: "false"

--- a/charts/hivemq-platform-operator/tests/hivemq_operator_rbac_test.yaml
+++ b/charts/hivemq-platform-operator/tests/hivemq_operator_rbac_test.yaml
@@ -1,0 +1,167 @@
+suite: test HiveMQ Platform Operator RBAC
+templates:
+  - rbac.yml
+tests:
+
+  - it: with disabled RBAC creation
+    set:
+      rbac.create: false
+    asserts:
+      - notFailedTemplate: { "rbac.yml" }
+      - hasDocuments:
+          count: 0
+
+  - it: with default platform service account settings
+    asserts:
+      - exists:
+          path: rules
+      - contains:
+          path: rules
+          content:
+            apiGroups: [ "" ]
+            resources: [ "serviceaccounts" ]
+            verbs: [ "get", "list", "watch", "create", "patch", "update", "delete" ]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [ "rbac.authorization.k8s.io" ]
+            resources: [ "roles", "rolebindings" ]
+            verbs: [ "get", "list", "watch", "create", "patch", "update", "delete" ]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [ "rbac.authorization.k8s.io" ]
+            resources: [ "clusterroles", "clusterrolebindings" ]
+            verbs: [ "get", "list", "watch" ]
+
+  - it: with platform service account create and validate enabled
+    set:
+      hivemqPlatformServiceAccount.create: true
+      hivemqPlatformServiceAccount.validate: true
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [ "" ]
+            resources: [ "serviceaccounts" ]
+            verbs: [ "get", "list", "watch", "create", "patch", "update", "delete" ]
+
+  - it: with platform service account create disabled
+    set:
+      hivemqPlatformServiceAccount.create: false
+      hivemqPlatformServiceAccount.validate: true
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [ "" ]
+            resources: [ "serviceaccounts" ]
+            verbs: [ "get", "list", "watch" ]
+
+  - it: with platform service account validate disabled
+    set:
+      hivemqPlatformServiceAccount.create: true
+      hivemqPlatformServiceAccount.validate: false
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [ "" ]
+            resources: [ "serviceaccounts" ]
+            verbs: [ "get", "list", "watch", "create", "patch", "update", "delete" ]
+
+  - it: with platform service account create and validate disabled
+    set:
+      hivemqPlatformServiceAccount.create: false
+      hivemqPlatformServiceAccount.validate: false
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [ "" ]
+            resources: [ "serviceaccounts" ]
+            verbs: [ "get", "list", "watch" ]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [ "" ]
+            resources: [ "serviceaccounts" ]
+            verbs: [ "get", "list", "watch", "create", "patch", "update", "delete" ]
+
+  - it: with platform service account permissions create and validate enabled
+    set:
+      hivemqPlatformServiceAccount.permissions.create: true
+      hivemqPlatformServiceAccount.permissions.validate: true
+    asserts:
+        - contains:
+            path: rules
+            content:
+              apiGroups: [ "rbac.authorization.k8s.io" ]
+              resources: [ "roles", "rolebindings" ]
+              verbs: [ "get", "list", "watch", "create", "patch", "update", "delete" ]
+        - contains:
+            path: rules
+            content:
+              apiGroups: [ "rbac.authorization.k8s.io" ]
+              resources: [ "clusterroles", "clusterrolebindings" ]
+              verbs: [ "get", "list", "watch" ]
+
+  - it: with platform service account permissions create disabled
+    set:
+      hivemqPlatformServiceAccount.permissions.create: false
+      hivemqPlatformServiceAccount.permissions.validate: true
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [ "rbac.authorization.k8s.io" ]
+            resources: [ "roles", "rolebindings" ]
+            verbs: [ "get", "list", "watch" ]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [ "rbac.authorization.k8s.io" ]
+            resources: [ "clusterroles", "clusterrolebindings" ]
+            verbs: [ "get", "list", "watch" ]
+
+  - it: with platform service account permissions validate disabled
+    set:
+      hivemqPlatformServiceAccount.permissions.create: true
+      hivemqPlatformServiceAccount.permissions.validate: false
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [ "rbac.authorization.k8s.io" ]
+            resources: [ "roles", "rolebindings" ]
+            verbs: [ "get", "list", "watch", "create", "patch", "update", "delete" ]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [ "rbac.authorization.k8s.io" ]
+            resources: [ "clusterroles", "clusterrolebindings" ]
+            verbs: [ "get", "list", "watch" ]
+
+  - it: with platform service account permissions create and validate disabled
+    set:
+      hivemqPlatformServiceAccount.permissions.create: false
+      hivemqPlatformServiceAccount.permissions.validate: false
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [ "rbac.authorization.k8s.io" ]
+            resources: [ "roles", "rolebindings" ]
+            verbs: [ "get", "list", "watch", "create", "patch", "update", "delete" ]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [ "rbac.authorization.k8s.io" ]
+            resources: [ "roles", "rolebindings" ]
+            verbs: [ "get", "list", "watch" ]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [ "rbac.authorization.k8s.io" ]
+            resources: [ "clusterroles", "clusterrolebindings" ]
+            verbs: [ "get", "list", "watch" ]

--- a/charts/hivemq-platform-operator/tests/hivemq_operator_release_notes_test.yaml
+++ b/charts/hivemq-platform-operator/tests/hivemq_operator_release_notes_test.yaml
@@ -29,5 +29,37 @@ tests:
             Documentation can be found here: https://docs.hivemq.com/hivemq-platform-operator/index.html
             
             *** Warning ***
-            The service account foo-bar-sa should have correct permissions for the Operator to work correctly.
+            The ServiceAccount foo-bar-sa should have sufficient permissions for the Operator to work correctly.
+            -----
+
+  - it: with platform service account create disabled, shows warning
+    set:
+      hivemqPlatformServiceAccount.create: false
+    asserts:
+      - equalRaw:
+          value: |
+            -----
+            HiveMQ Platform Operator release "hivemq-platform-operator-release" installed in namespace "hivemq-platform-operator-namespace"
+            
+            Documentation can be found here: https://docs.hivemq.com/hivemq-platform-operator/index.html
+            
+            *** Warning ***
+            The Operator is not configured to create a ServiceAccount for the HiveMQ Platform Pods.
+            Please make sure that you configure a valid custom ServiceAccount in the HiveMQ Platform Helm charts values.yaml (see nodes.serviceAccountName).
+            -----
+
+  - it: with platform service account create and validate disabled
+    set:
+      hivemqPlatformServiceAccount.permissions.create: false
+    asserts:
+      - equalRaw:
+          value: |
+            -----
+            HiveMQ Platform Operator release "hivemq-platform-operator-release" installed in namespace "hivemq-platform-operator-namespace"
+            
+            Documentation can be found here: https://docs.hivemq.com/hivemq-platform-operator/index.html
+            
+            *** Warning ***
+            The Operator is not configured to create the RBAC permissions (Role and RoleBinding) for the ServiceAccount of the HiveMQ Platform Pods.
+            Please make sure the HiveMQ Platform Helm charts values.yaml configures a ServiceAccount (see nodes.serviceAccountName) with sufficient RBAC permissions to list, get and watch Pods.
             -----

--- a/charts/hivemq-platform-operator/values.schema.json
+++ b/charts/hivemq-platform-operator/values.schema.json
@@ -156,6 +156,29 @@
         }
       }
     },
+    "hivemqPlatformServiceAccount" : {
+      "type" : "object",
+      "properties" : {
+        "create" : {
+          "type" : "boolean"
+        },
+        "validate" : {
+          "type" : "boolean"
+        },
+        "permissions" : {
+          "type" : "object",
+          "properties" : {
+            "create" : {
+              "type" : "boolean"
+            },
+            "validate" : {
+              "type" : "boolean"
+            }
+          }
+        }
+      }
+    },
+
     "rbac" : {
       "type" : "object",
       "properties" : {

--- a/charts/hivemq-platform-operator/values.schema.json
+++ b/charts/hivemq-platform-operator/values.schema.json
@@ -165,6 +165,9 @@
         "validate" : {
           "type" : "boolean"
         },
+        "name" : {
+          "type" : "string"
+        },
         "permissions" : {
           "type" : "object",
           "properties" : {

--- a/charts/hivemq-platform-operator/values.yaml
+++ b/charts/hivemq-platform-operator/values.yaml
@@ -10,8 +10,8 @@ image:
   pullPolicy: IfNotPresent
   pullSecretName: ""
 
-# Resources, limits and requests are set to equal values
-# Note: Increase resources depending on how many HiveMQ Platforms this operator manages.
+# Resources, limits and requests are set to equal values.
+# Note: Increase resources depending on how many HiveMQ Platforms the Operator manages.
 resources:
   cpu: 512m
   memory: 512M
@@ -31,20 +31,32 @@ javaOpts: "-XX:+UnlockExperimentalVMOptions -XX:InitialRAMPercentage=75 -XX:MaxR
 # Selector name that is used to watch HiveMQ Platforms with a matching selector.
 selector: nil
 
-# Configures whether Kubernetes RBAC permissions should be created.
+# Configures whether Kubernetes RBAC permissions for the Operator should be created.
 rbac:
   create: true
 
-# Configures the service account for Kubernetes RBAC permissions.
+# Configures the ServiceAccount for the Operator.
 serviceAccount:
-  # Specifies whether a service account should be created.
+  # Specifies whether a ServiceAccount should be created for the Operator.
   create: true
-  # The service account name to be used, or "hivemq-<release name>" if not set.
+  # The ServiceAccount name that is used. Defaults to "hivemq-<release name>" if not set.
   name: ""
 
-# Configures how the operator pod should be scheduled on the Kubernetes cluster nodes.
+# Configures the ServiceAccount and RBAC permissions (Role, RoleBinding) the Operator creates for the HiveMQ Platform Pods.
+hivemqPlatformServiceAccount:
+  # Specifies whether a ServiceAccount should be created for all HiveMQ Platforms.
+  create: true
+  # Specifies whether the ServiceAccount for all HiveMQ Platforms should be validated.
+  validate: true
+  permissions:
+    # Specifies whether the RBAC permissions for the ServiceAccount should be created for all HiveMQ Platforms.
+    create: true
+    # Specifies whether the RBAC permissions for the ServiceAccount for all HiveMQ Platforms should be validated.
+    validate: true
+
+# Configures how the Operator Pod should be scheduled on the Kubernetes cluster nodes.
 podScheduling:
-  # Configures the affinity for the Operator pod
+  # Configures the affinity for the Operator Pod.
   affinity:
   # podAffinity:
   #    requiredDuringSchedulingIgnoredDuringExecution:
@@ -56,19 +68,19 @@ podScheduling:
   #                - my-app
   #        topologyKey: "kubernetes.io/hostname"
 
-  # Configures the tolerations for the Operator pod
+  # Configures the tolerations for the Operator Pod.
   tolerations:
   #  - key: "example-key"
   #    operator: "Exists"
   #    effect: "NoSchedule"
 
-# TLS configuration for the operator to access the Kubernetes API.
+# TLS configuration for the Operator to access the Kubernetes API.
 tls:
-  # Name of the secret that contains keystore and truststore
+  # Name of the Secret that contains keystore and truststore.
   secretName: nil
-  # The keystore password. Can also be set as "keystore.password" in the secret.
+  # The keystore password. Can also be set as "keystore.password" in the Secret.
   keystorePassword: nil
-  # The truststore password. Can also be set as "truststore.password" in the secret.
+  # The truststore password. Can also be set as "truststore.password" in the Secret.
   truststorePassword: nil
 
 # Holds pod-level security attributes and common container settings.
@@ -85,9 +97,9 @@ podSecurityContext:
   enabled: false
   runAsNonRoot: true
 
-# Specifies environment variables to be added to the operator container.
+# Specifies environment variables to be added to the Operator container.
 # Environment variables can be defined as a list of either key-value pairs or
-# using valueFrom to reference a secret or config map.
+# using valueFrom to reference a Secret or ConfigMap.
 env: []
   # - name: <ENV_VAR_NAME1>
   #   value: <value>

--- a/charts/hivemq-platform-operator/values.yaml
+++ b/charts/hivemq-platform-operator/values.yaml
@@ -48,6 +48,10 @@ hivemqPlatformServiceAccount:
   create: true
   # Specifies whether the ServiceAccount for all HiveMQ Platforms should be validated.
   validate: true
+  # The ServiceAccount name that is used for all HiveMQ Platforms.
+  # This overrides the default name "hivemq-platform-pod-<platform-name>" the Operator creates.
+  # The ServiceAccount can also be overridden in the HiveMQ Platform Helm chart (see nodes.serviceAccountName) for each specific HiveMQ Platform.
+  name: ""
   permissions:
     # Specifies whether the RBAC permissions for the ServiceAccount should be created for all HiveMQ Platforms.
     create: true

--- a/manifests/hivemq-platform-operator/deployment.yml
+++ b/manifests/hivemq-platform-operator/deployment.yml
@@ -52,6 +52,8 @@ spec:
               value: "true"
             - name: hivemq.platform.operator.serviceaccount.validate
               value: "true"
+            - name: hivemq.platform.operator.serviceaccount.name
+              value: ""
             - name: hivemq.platform.operator.serviceaccount.permissions.create
               value: "true"
             - name: hivemq.platform.operator.serviceaccount.permissions.validate

--- a/manifests/hivemq-platform-operator/deployment.yml
+++ b/manifests/hivemq-platform-operator/deployment.yml
@@ -47,6 +47,15 @@ spec:
             # additional option to show the configuration details in the log
             - name: hivemq.platform.operator.log.configuration
               value: "false"
+            # additional options for service accounts and permission functionality
+            - name: hivemq.platform.operator.serviceaccount.create
+              value: "true"
+            - name: hivemq.platform.operator.serviceaccount.validate
+              value: "true"
+            - name: hivemq.platform.operator.serviceaccount.permissions.create
+              value: "true"
+            - name: hivemq.platform.operator.serviceaccount.permissions.validate
+              value: "true"
             # additional options for fine-grained logging
             - name: hivemq.platform.operator.quarkus.log.level
               value: "INFO"

--- a/manifests/hivemq-platform-operator/rbac.yml
+++ b/manifests/hivemq-platform-operator/rbac.yml
@@ -107,8 +107,8 @@ rules:
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
+      - roles
       - rolebindings
-      - clusterroles
     verbs:
       - get
       - list
@@ -117,18 +117,12 @@ rules:
       - patch
       - update
       - delete
----
-# Source: hivemq-platform-operator/templates/rbac.yml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: "hivemq-platform-operator-pod-resource-role-my-operator"
-rules:
   - apiGroups:
-      - ""
+      - rbac.authorization.k8s.io
     resources:
-      - pods
+      - clusterroles
+      - clusterrolebindings
     verbs:
       - get
-      - patch
-      - update
+      - list
+      - watch

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/single/HelmCustomServiceAccountIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/single/HelmCustomServiceAccountIT.java
@@ -2,6 +2,12 @@ package com.hivemq.helmcharts.single;
 
 import com.hivemq.helmcharts.AbstractHelmChartIT;
 import com.hivemq.helmcharts.util.K8sUtil;
+import io.fabric8.kubernetes.api.model.rbac.PolicyRuleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder;
+import io.fabric8.kubernetes.api.model.rbac.RoleBuilder;
+import io.fabric8.kubernetes.api.model.rbac.RoleRefBuilder;
+import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -15,12 +21,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("ServiceAccount")
 class HelmCustomServiceAccountIT extends AbstractHelmChartIT {
 
+    private static final @NotNull String SERVICE_ACCOUNT_NAME = "my-custom-sa";
+
+    @Override
+    protected boolean installOperatorChart() {
+        return false;
+    }
+
     @Test
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void platformCharts_withNonExistingCustomServiceAccountThenCreate_hivemqRunning() throws Exception {
+        helmChartContainer.installOperatorChart(OPERATOR_RELEASE_NAME, "--namespace", operatorNamespace);
         helmChartContainer.installPlatformChart(PLATFORM_RELEASE_NAME,
                 "--set",
-                "nodes.serviceAccountName=my-custom-sa",
+                "nodes.serviceAccountName=" + SERVICE_ACCOUNT_NAME,
                 "--set",
                 "nodes.replicaCount=1",
                 "--namespace",
@@ -30,10 +44,106 @@ class HelmCustomServiceAccountIT extends AbstractHelmChartIT {
                 K8sUtil.waitForHiveMQPlatformState(client, platformNamespace, PLATFORM_RELEASE_NAME, "ERROR");
         //noinspection unchecked
         assertThat((Map<String, String>) hivemqCustomResource.getAdditionalProperties().get("status")).containsValues(
-                "The custom resource spec is invalid: The ServiceAccount 'my-custom-sa' does not exist",
+                String.format("The custom resource spec is invalid: The ServiceAccount '%s' does not exist",
+                        SERVICE_ACCOUNT_NAME),
                 "INVALID_CUSTOM_RESOURCE_SPEC");
 
-        K8sUtil.createServiceAccount(client, platformNamespace, "my-custom-sa");
+        // create missing ServiceAccount
+        K8sUtil.createServiceAccount(client, platformNamespace, SERVICE_ACCOUNT_NAME);
+
         K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, PLATFORM_RELEASE_NAME);
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
+    void platformCharts_withNonExistingPermissionsThenCreate_hivemqRunning() throws Exception {
+        K8sUtil.createServiceAccount(client, platformNamespace, SERVICE_ACCOUNT_NAME);
+
+        helmChartContainer.installOperatorChart(OPERATOR_RELEASE_NAME,
+                "--set",
+                "hivemqPlatformServiceAccount.create=false",
+                "--set",
+                "hivemqPlatformServiceAccount.permissions.create=false",
+                "--namespace",
+                operatorNamespace);
+        helmChartContainer.installPlatformChart(PLATFORM_RELEASE_NAME,
+                "--set",
+                "nodes.serviceAccountName=" + SERVICE_ACCOUNT_NAME,
+                "--set",
+                "nodes.replicaCount=1",
+                "--namespace",
+                platformNamespace);
+
+        final var hivemqCustomResource =
+                K8sUtil.waitForHiveMQPlatformState(client, platformNamespace, PLATFORM_RELEASE_NAME, "ERROR");
+        //noinspection unchecked
+        assertThat((Map<String, String>) hivemqCustomResource.getAdditionalProperties().get("status")).containsValues(
+                String.format(
+                        "The custom resource spec is invalid: The ServiceAccount '%s' must have the Pod resource permissions: [get, patch, update]",
+                        SERVICE_ACCOUNT_NAME),
+                "INVALID_CUSTOM_RESOURCE_SPEC");
+
+        // create missing permissions
+        createRole();
+        createRoleBinding();
+
+        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, PLATFORM_RELEASE_NAME);
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
+    void platformCharts_withCreationAndValidationDisabled_withCorrectExternalPermissions_hivemqRunning()
+            throws Exception {
+        K8sUtil.createServiceAccount(client, platformNamespace, SERVICE_ACCOUNT_NAME);
+        createRole();
+        createRoleBinding();
+
+        helmChartContainer.installOperatorChart(OPERATOR_RELEASE_NAME,
+                "--set",
+                "hivemqPlatformServiceAccount.create=false",
+                "--set",
+                "hivemqPlatformServiceAccount.validate=false",
+                "--set",
+                "hivemqPlatformServiceAccount.permissions.create=false",
+                "--set",
+                "hivemqPlatformServiceAccount.permissions.validate=false",
+                "--namespace",
+                operatorNamespace);
+        helmChartContainer.installPlatformChart(PLATFORM_RELEASE_NAME,
+                "--set",
+                "nodes.serviceAccountName=" + SERVICE_ACCOUNT_NAME,
+                "--set",
+                "nodes.replicaCount=1",
+                "--namespace",
+                platformNamespace);
+
+        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, PLATFORM_RELEASE_NAME);
+    }
+
+    private void createRole() {
+        final var role = client.resource(new RoleBuilder().withNewMetadata()
+                .withName("pod-resource-role")
+                .withNamespace(platformNamespace)
+                .endMetadata()
+                .withRules(new PolicyRuleBuilder().withApiGroups("")
+                        .withResources("pods")
+                        .withVerbs("get", "patch", "update")
+                        .build())
+                .build()).create();
+        assertThat(role).isNotNull();
+    }
+
+    private void createRoleBinding() {
+        final var roleBinding = client.resource(new RoleBindingBuilder().withNewMetadata()
+                .withName("pod-resource-role-binding")
+                .withNamespace(platformNamespace)
+                .endMetadata()
+                .withSubjects(new SubjectBuilder() //
+                        .withKind("ServiceAccount") //
+                        .withName(SERVICE_ACCOUNT_NAME) //
+                        .build())
+                .withRoleRef(new RoleRefBuilder().withName("pod-resource-role").withKind("Role").build())
+                .build()).create();
+        assertThat(roleBinding).isNotNull();
     }
 }


### PR DESCRIPTION
https://hivemq.kanbanize.com/ctrl_board/22/cards/22118/details/