### PR TITLE
Support custom labels for the HiveMQ Platform

### DIFF
--- a/charts/hivemq-platform-operator/templates/deployment.yml
+++ b/charts/hivemq-platform-operator/templates/deployment.yml
@@ -82,6 +82,9 @@ spec:
               value: "{{ .Values.hivemqPlatformServiceAccount.permissions.create }}"
             - name: hivemq.platform.operator.serviceaccount.permissions.validate
               value: "{{ .Values.hivemqPlatformServiceAccount.permissions.validate }}"
+            # additional options for StatefulSet reconciliation
+            - name: hivemq.platform.operator.statefulset.rolling-restart-on-template-metadata-change
+              value: "{{ .Values.hivemqPlatformStatefulSet.rollingRestartOnTemplateMetadataChange }}"
             # additional options for fine-grained logging
             - name: hivemq.platform.operator.quarkus.log.level
               value: "{{ .Values.quarkusLogLevel | default "INFO" }}"

--- a/charts/hivemq-platform-operator/tests/hivemq_operator_deployment_test.yaml
+++ b/charts/hivemq-platform-operator/tests/hivemq_operator_deployment_test.yaml
@@ -374,3 +374,31 @@ tests:
           content:
             name: hivemq.platform.operator.serviceaccount.permissions.validate
             value: "false"
+
+  - it: with platform statefulset rolling-restart-on-template-metadata-change enabled
+    set:
+      hivemqPlatformStatefulSet.rollingRestartOnTemplateMetadataChange: true
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0]
+      - exists:
+          path: spec.template.spec.containers[0].env
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: hivemq.platform.operator.statefulset.rolling-restart-on-template-metadata-change
+            value: "true"
+
+  - it: with platform statefulset rolling-restart-on-template-metadata-change disabled
+    set:
+      hivemqPlatformStatefulSet.rollingRestartOnTemplateMetadataChange: false
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0]
+      - exists:
+          path: spec.template.spec.containers[0].env
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: hivemq.platform.operator.statefulset.rolling-restart-on-template-metadata-change
+            value: "false"

--- a/charts/hivemq-platform-operator/values.schema.json
+++ b/charts/hivemq-platform-operator/values.schema.json
@@ -138,11 +138,11 @@
         }
       }
     },
-    "env": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true
+    "env" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "additionalProperties" : true
       }
     },
     "serviceAccount" : {
@@ -181,7 +181,14 @@
         }
       }
     },
-
+    "hivemqPlatformStatefulSet" : {
+      "type" : "object",
+      "properties" : {
+        "rollingRestartOnTemplateMetadataChange" : {
+          "type" : "boolean"
+        }
+      }
+    },
     "rbac" : {
       "type" : "object",
       "properties" : {

--- a/charts/hivemq-platform-operator/values.yaml
+++ b/charts/hivemq-platform-operator/values.yaml
@@ -58,6 +58,12 @@ hivemqPlatformServiceAccount:
     # Specifies whether the RBAC permissions for the ServiceAccount for all HiveMQ Platforms should be validated.
     validate: true
 
+# Configures how the Operator reconciles the HiveMQ Platform StatefulSet.
+hivemqPlatformStatefulSet:
+  # Specifies whether a change of the StatefulSet template metadata should trigger a rolling restart.
+  # If this is disabled the rollout of updated annotations and labels to the HiveMQ Platform Pods will be delayed until the next rolling restart occurs.
+  rollingRestartOnTemplateMetadataChange: false
+
 # Configures how the Operator Pod should be scheduled on the Kubernetes cluster nodes.
 podScheduling:
   # Configures the affinity for the Operator Pod.

--- a/charts/hivemq-platform/templates/hivemq-custom-resource.yml
+++ b/charts/hivemq-platform/templates/hivemq-custom-resource.yml
@@ -24,10 +24,16 @@ spec:
     spec:
       replicas: {{.Values.nodes.replicaCount}}
       template:
-        {{- if and (typeIsLike "map[string]interface {}" .Values.nodes.annotations) (.Values.nodes.annotations) }}
+        {{- if or .Values.nodes.annotations .Values.nodes.labels }}
         metadata:
+          {{- with .Values.nodes.annotations }}
           annotations:
-          {{- .Values.nodes.annotations | toYaml | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nodes.labels }}
+          labels:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
         spec:
           {{- if .Values.image.pullSecretName }}
@@ -207,9 +213,13 @@ spec:
     {{- if and $val.exposed }}
     - metadata:
         name: {{ (include "hivemq-platform.range-service-name" (dict "releaseName" $.Release.Name "type" .type "port" .port "containerPort" .containerPort)) | trimAll "-" | trunc 63 | trimSuffix "-" |  trim }}
-        {{- if and (typeIsLike "map[string]interface {}" $val.annotations) ($val.annotations) }}
+        {{- with $val.annotations }}
         annotations:
-          {{- $val.annotations | toYaml | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $val.labels }}
+        labels:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
       spec:
         {{- if and $val.serviceType (or (eq $val.serviceType "NodePort") (eq $val.serviceType "LoadBalancer")) }}

--- a/charts/hivemq-platform/tests/hivemq_platform_test.yaml
+++ b/charts/hivemq-platform/tests/hivemq_platform_test.yaml
@@ -187,6 +187,68 @@ tests:
                     name: mysecretname
                     key: mysecretkey
 
+  - it: with custom annotations for the HiveMQ container
+    set:
+      nodes.annotations:
+         annotation-key-1: annotation-value-1
+         annotation-key-2: annotation-value-2
+    asserts:
+      - exists:
+          path: spec.statefulSet.spec.template.metadata
+      - exists:
+          path: spec.statefulSet.spec.template.metadata.annotations
+      - notExists:
+          path: spec.statefulSet.spec.template.metadata.labels
+      - equal:
+          path: spec.statefulSet.spec.template.metadata.annotations
+          value:
+            annotation-key-1: annotation-value-1
+            annotation-key-2: annotation-value-2
+
+  - it: with custom labels for the HiveMQ container
+    set:
+      nodes.labels:
+        label-key-1: label-value-1
+        label-key-2: label-value-2
+    asserts:
+      - exists:
+          path: spec.statefulSet.spec.template.metadata
+      - notExists:
+          path: spec.statefulSet.spec.template.metadata.annotations
+      - exists:
+          path: spec.statefulSet.spec.template.metadata.labels
+      - equal:
+          path: spec.statefulSet.spec.template.metadata.labels
+          value:
+            label-key-1: label-value-1
+            label-key-2: label-value-2
+
+  - it: with custom annotations and labels for the HiveMQ container
+    set:
+      nodes.annotations:
+        annotation-key-1: annotation-value-1
+        annotation-key-2: annotation-value-2
+      nodes.labels:
+        label-key-1: label-value-1
+        label-key-2: label-value-2
+    asserts:
+      - exists:
+          path: spec.statefulSet.spec.template.metadata
+      - exists:
+          path: spec.statefulSet.spec.template.metadata.annotations
+      - exists:
+          path: spec.statefulSet.spec.template.metadata.labels
+      - equal:
+          path: spec.statefulSet.spec.template.metadata.annotations
+          value:
+            annotation-key-1: annotation-value-1
+            annotation-key-2: annotation-value-2
+      - equal:
+          path: spec.statefulSet.spec.template.metadata.labels
+          value:
+            label-key-1: label-value-1
+            label-key-2: label-value-2
+
   - it: with custom environment variables for the HiveMQ container
     values:
       - custom-env-vars-values.yaml

--- a/charts/hivemq-platform/tests/hivemq_services_test.yaml
+++ b/charts/hivemq-platform/tests/hivemq_services_test.yaml
@@ -87,7 +87,8 @@ tests:
           exposed: true
           containerPort: 1884
           annotations:
-            test-annotation-key: test-annotation-value
+            annotation-key-1: annotation-value-1
+            annotation-key-2: annotation-value-2
     asserts:
       - exists:
           path: spec.services
@@ -97,7 +98,66 @@ tests:
             metadata:
               name: hivemq-test-hivemq-platform-mqtt-1884
               annotations:
-                test-annotation-key: test-annotation-value
+                annotation-key-1: annotation-value-1
+                annotation-key-2: annotation-value-2
+            spec:
+              ports:
+                - name: mqtt-1884
+                  targetPort: mqtt-1884
+                  port: 1884
+
+  - it: with additional labels
+    set:
+      services:
+        - type: mqtt
+          exposed: true
+          containerPort: 1884
+          labels:
+            label-key-1: label-value-1
+            label-key-2: label-value-2
+    asserts:
+      - exists:
+          path: spec.services
+      - contains:
+          path: spec.services
+          content:
+            metadata:
+              name: hivemq-test-hivemq-platform-mqtt-1884
+              labels:
+                label-key-1: label-value-1
+                label-key-2: label-value-2
+            spec:
+              ports:
+                - name: mqtt-1884
+                  targetPort: mqtt-1884
+                  port: 1884
+
+  - it: with additional annotations and labels
+    set:
+      services:
+        - type: mqtt
+          exposed: true
+          containerPort: 1884
+          annotations:
+            annotation-key-1: annotation-value-1
+            annotation-key-2: annotation-value-2
+          labels:
+            label-key-1: label-value-1
+            label-key-2: label-value-2
+    asserts:
+      - exists:
+          path: spec.services
+      - contains:
+          path: spec.services
+          content:
+            metadata:
+              name: hivemq-test-hivemq-platform-mqtt-1884
+              annotations:
+                annotation-key-1: annotation-value-1
+                annotation-key-2: annotation-value-2
+              labels:
+                label-key-1: label-value-1
+                label-key-2: label-value-2
             spec:
               ports:
                 - name: mqtt-1884

--- a/charts/hivemq-platform/values.schema.json
+++ b/charts/hivemq-platform/values.schema.json
@@ -134,6 +134,10 @@
             "type": "object",
             "additionalProperties": true
           },
+          "labels": {
+            "type": "object",
+            "additionalProperties": true
+          },
           "serviceType": {
             "type" : "string",
             "enum" : [
@@ -317,6 +321,10 @@
         },
         "annotations" : {
           "type" : "object",
+          "additionalProperties": true
+        },
+        "labels": {
+          "type": "object",
           "additionalProperties": true
         },
         "podSecurityContext" : {

--- a/charts/hivemq-platform/values.yaml
+++ b/charts/hivemq-platform/values.yaml
@@ -18,6 +18,8 @@ nodes:
 
   # Annotations to add to the HiveMQ Pods
   annotations: {}
+  # Labels to add to the HiveMQ Pods
+  labels: {}
 
   # Resources, limits and requests are set to equal values.
   # Note: For production use-cases HiveMQ requires a minimum of 4 CPUs and 4G of memory.
@@ -173,6 +175,8 @@ services:
     # serviceType: NodePort
     # Annotations to add to the service
     annotations: {}
+    # Labels to add to the service
+    labels: {}
   # Secure MQTT service configuration
   - type: mqtt
     exposed: false

--- a/manifests/hivemq-platform-operator/deployment.yml
+++ b/manifests/hivemq-platform-operator/deployment.yml
@@ -58,6 +58,9 @@ spec:
               value: "true"
             - name: hivemq.platform.operator.serviceaccount.permissions.validate
               value: "true"
+            # additional options for StatefulSet reconciliation
+            - name: hivemq.platform.operator.statefulset.rolling-restart-on-template-metadata-change
+              value: "false"
             # additional options for fine-grained logging
             - name: hivemq.platform.operator.quarkus.log.level
               value: "INFO"


### PR DESCRIPTION
https://hivemq.kanbanize.com/ctrl_board/22/cards/22802/details/

Example CR when all annotations and labels are set:
```yaml
---
# Source: hivemq-platform/templates/hivemq-custom-resource.yml
apiVersion: hivemq.com/v1
kind: HiveMQPlatform
metadata:
  name: "my-platform"
  annotations:
    global-annotation-key-1: value # <--- not configurable via Helm chart
    global-annotation-key-2: value # <--- not configurable via Helm chart
  labels:
    app.kubernetes.io/name: "hivemq-platform"
    app.kubernetes.io/instance: "my-platform"
    app.kubernetes.io/version: "4.30.0"
    global-label-key-1: value # <--- not configurable via Helm chart
    global-label-key-2: value # <--- not configurable via Helm chart
spec:
  configMapName: hivemq-configuration-my-platform
  logLevel: INFO
  operatorRestApiPort: 7979
  healthApiPort: 8889
  metricsPort: 9399
  metricsPath: /
  statefulSet:
    spec:
      replicas: 2
      template:
        metadata:
          annotations:
            pod-annotation-key-1: value # <--- NODES
            pod-annotation-key-2: value # <--- NODES
          labels:
            pod-label-key-1: value # <--- NODES
            pod-label-key-2: value # <--- NODES
        spec:
          containers:
            - name: hivemq
              image: "docker.io/hivemq/hivemq4:4.30.0"
              imagePullPolicy: IfNotPresent
              ports:
                - name: mqtt-1883
                  containerPort: 1883
                - name: cc-8080
                  containerPort: 8080
                  # Metric container ports are not configurable right now
                - name: metrics-9399
                  containerPort: 9399
              resources:
                limits:
                  cpu: "1024m"
                  memory: "2048M"
                requests:
                  cpu: "1024m"
                  memory: "2048M"
  services:
    - metadata:
        name: hivemq-my-platform-mqtt-1883
        annotations:
          service-annotation-key-1: value # <--- SERVICES
          service-annotation-key-2: value # <--- SERVICES
        labels:
          service-label-key-1: value # <--- SERVICES
          service-label-key-2: value # <--- SERVICES
      spec:
        ports:
          - name: mqtt-1883
            targetPort: mqtt-1883
            port: 1883
    - metadata:
        name: hivemq-my-platform-cc-8080
      spec:
        sessionAffinity: ClientIP
        ports:
          - name: cc-8080
            targetPort: cc-8080
            port: 8080
    # Metric service ports are not configurable right now
    - metadata:
        name: hivemq-my-platform-metrics-9399
      spec:
        ports:
          - name: metrics-9399
            targetPort: metrics-9399
            port: 9399
  extensions:
    - id: hivemq-allow-all-extension
      enabled: true
      supportsHotReload: false
      extensionUri: "preinstalled"
```