### PR TITLE
Release HiveMQ Platform Operator 1.5.0

### DIFF
--- a/charts/hivemq-platform/Chart.yaml
+++ b/charts/hivemq-platform/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hivemq-platform
 description: HiveMQ Platform Helm Chart (new)
 type: application
-version: 0.2.18
+version: 0.2.19
 appVersion: 4.30.0
 maintainers:
   - email: support@hivemq.com


### PR DESCRIPTION
https://hivemq.kanbanize.com/ctrl_board/22/cards/23888/details/

Added the missing version bump on the `hivemq-platform` Helm chart.