### PR TITLE
Fix tests disk space in GitHub

### DIFF
--- a/.github/workflows/hivemq-platform-operator-integration-test.yml
+++ b/.github/workflows/hivemq-platform-operator-integration-test.yml
@@ -18,7 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         test-plan: [
-          Extensions,
+          Extensions1,
+          Extensions2,
           PodSecurityContext,
           Upgrade,
           Other

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/AbstractHelmChartIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/AbstractHelmChartIT.java
@@ -6,7 +6,6 @@ import com.hivemq.helmcharts.testcontainer.LogWaiterUtil;
 import com.hivemq.helmcharts.util.K8sUtil;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.awaitility.Awaitility;
-import org.awaitility.Durations;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -14,11 +13,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -41,6 +41,8 @@ public abstract class AbstractHelmChartIT {
 
     protected static final @NotNull String PLATFORM_LOG_WAITER_PREFIX = PLATFORM_RELEASE_NAME + "-0";
     protected static final @NotNull String OPERATOR_LOG_WAITER_PREFIX = "hivemq-" + OPERATOR_RELEASE_NAME + "-.*";
+
+    private static final @NotNull Logger LOG = LoggerFactory.getLogger(AbstractHelmChartIT.class);
 
     @RegisterExtension
     private static final @NotNull HelmChartContainerExtension HELM_CHART_CONTAINER_EXTENSION =
@@ -97,8 +99,12 @@ public abstract class AbstractHelmChartIT {
                 helmChartContainer.uninstallRelease(PLATFORM_RELEASE_NAME, platformNamespace, true);
             }
         } finally {
-            if (uninstallOperatorChart()) {
-                helmChartContainer.uninstallRelease(OPERATOR_RELEASE_NAME, operatorNamespace, true);
+            try {
+                if (uninstallOperatorChart()) {
+                    helmChartContainer.uninstallRelease(OPERATOR_RELEASE_NAME, operatorNamespace, true);
+                }
+            } finally {
+                cleanupK3s();
             }
         }
     }
@@ -186,6 +192,42 @@ public abstract class AbstractHelmChartIT {
             return Files.readString(Path.of(resource.toURI()));
         } catch (final Exception e) {
             throw new AssertionError(String.format("Could not read resource file '%s'", filename), e);
+        }
+    }
+
+    // free disk space in K3s
+    private void cleanupK3s() throws Exception {
+        final var pruneContainerResult = helmChartContainer.execInContainer("sh", "-c", """
+                for ID in $(ctr container ls --quiet); do \
+                TASK=$(ctr task ls | grep $ID); \
+                if [ -z "$TASK" ]; then \
+                continue; \
+                fi; \
+                STATUS=$(echo $TASK | awk '{print $3}' | tr -d '[:space:]'); \
+                if [ "$STATUS" != "RUNNING" ]; then \
+                echo "Removing container $ID (status: $STATUS)"; \
+                ctr container rm $ID; \
+                fi; \
+                done""");
+        LOG.info("Removed unused containers:\n{}", pruneContainerResult.getStdout());
+        if (pruneContainerResult.getExitCode() != 0) {
+            LOG.warn("Error during removal of containers:\n{}", pruneContainerResult.getStderr());
+        }
+        // the removal will fail if the snapshot has children, so we just print a warning
+        final var pruneSnapshots = helmChartContainer.execInContainer("sh", "-c", """
+                for ID in $(ctr snapshot ls | awk '{print $1}'); do \
+                if [ "$ID" == "KEY" ]; then \
+                continue; \
+                fi; \
+                SNAPSHOT=$(ctr snapshot ls | grep $ID);\
+                if echo "$SNAPSHOT" | grep -q "Committed"; then \
+                echo "Removing snapshot $ID"; \
+                ctr snapshot rm $ID; \
+                fi; \
+                done""");
+        LOG.info("Removed unused snapshots:\n{}", pruneSnapshots.getStdout());
+        if (pruneSnapshots.getExitCode() != 0) {
+            LOG.warn("Error during removal of snapshots:\n{}", pruneSnapshots.getStderr());
         }
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/AbstractHelmPodSecurityContextIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/AbstractHelmPodSecurityContextIT.java
@@ -43,7 +43,7 @@ public class AbstractHelmPodSecurityContextIT extends AbstractHelmChartIT {
         });
     }
 
-    protected Stream<Arguments> chartValues() {
+    protected @NotNull Stream<Arguments> chartValues() {
         return Stream.of(arguments(new ChartValues(new Values(0, 0, operatorChartRootUserValuesFile()),
                         new Values(0, 0, platformChartRootUserValuesFile()))),
                 // Default Operator non-root UID is 185 and GID is 0

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/compose/HelmBridgeExtensionIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/compose/HelmBridgeExtensionIT.java
@@ -21,6 +21,7 @@ import static com.hivemq.helmcharts.util.MqttUtil.getBlockingClient;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Tag("Extensions")
+@Tag("Extensions1")
 @Testcontainers
 class HelmBridgeExtensionIT extends AbstractHelmChartIT {
 

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/compose/HelmCustomExtensionIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/compose/HelmCustomExtensionIT.java
@@ -19,6 +19,7 @@ import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.ONE_MINUTE;
 
 @Tag("Extensions")
+@Tag("Extensions1")
 class HelmCustomExtensionIT extends AbstractHelmChartIT {
 
     @TempDir

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/compose/HelmExtensionPriorityIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/compose/HelmExtensionPriorityIT.java
@@ -28,6 +28,7 @@ import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.ONE_MINUTE;
 
 @Tag("Extensions")
+@Tag("Extensions1")
 class HelmExtensionPriorityIT extends AbstractHelmChartIT {
 
     private static final @NotNull String MQTT_SERVICE_NAME = "hivemq-test-hivemq-platform-mqtt-1884";

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/compose/HelmUpgradeExtensionIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/compose/HelmUpgradeExtensionIT.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 @Tag("Extensions")
+@Tag("Extensions2")
 @Testcontainers
 @SuppressWarnings("DuplicatedCode")
 class HelmUpgradeExtensionIT extends AbstractHelmChartIT {


### PR DESCRIPTION
We are failing to run integration tests as we fail to pull out container images when running out space in the GitHub runners.

For that, I just redistributed some of the failing tests such as `Extensions` tests for the compose GitHub workflow to reduce space disk usage and clean up containers and snapshots in the K3s container for all of the tests. This change is making the GitHub checks to not be fulfilled for this PR. 
