### PR TITLE
Use docker instead of Quarkus specific Gradle task

### DIFF
--- a/tests-hivemq-platform-operator/build.gradle.kts
+++ b/tests-hivemq-platform-operator/build.gradle.kts
@@ -132,7 +132,7 @@ val listIntegrationTests by tasks.registering(JavaExec::class) {
 val savePlatformOperatorDockerImage by tasks.registering(Exec::class) {
     group = "container"
     description = "Save HiveMQ Platform Operator Docker image"
-    dependsOn(gradle.includedBuild("hivemq-platform-operator").task(":quarkusBuild"))
+    dependsOn(gradle.includedBuild("hivemq-platform-operator").task(":docker"))
     workingDir(layout.buildDirectory)
     commandLine("docker", "save", "-o", "hivemq-platform-operator.tar", "hivemq/hivemq-platform-operator-test:snapshot")
 }


### PR DESCRIPTION
https://hivemq.kanbanize.com/ctrl_board/22/cards/28731/details/

This is a test if we can already use the `docker` task from the Quarkus based operator, so the Quarkus removal is a bit easier to merge.