### PR TITLE
Custom annotations and labels for all platform resources along with `stringData` in License Secret

### DIFF
--- a/charts/hivemq-platform/templates/hivemq-configuration.yml
+++ b/charts/hivemq-platform/templates/hivemq-configuration.yml
@@ -4,8 +4,15 @@ kind: {{ .Values.config.createAs }}
 metadata:
   name: {{ include "hivemq-platform.configuration-name" . }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.config.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "hivemq-platform.labels" . | nindent 4 }}
+    {{- with .Values.config.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   # noinspection XmlPathReference
   config.xml: |-

--- a/charts/hivemq-platform/templates/hivemq-custom-resource.yml
+++ b/charts/hivemq-platform/templates/hivemq-custom-resource.yml
@@ -10,6 +10,10 @@ apiVersion: hivemq.com/v1
 kind: HiveMQPlatform
 metadata:
   name: "{{ .Release.Name }}"
+  {{- with .Values.operator.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "hivemq-platform.labels" . | nindent 4 }}
     {{- with .Values.operator.labels }}

--- a/charts/hivemq-platform/templates/hivemq-license.yml
+++ b/charts/hivemq-platform/templates/hivemq-license.yml
@@ -4,6 +4,14 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.license.name | default (include "hivemq-platform.default-license-name" .) }}
+  {{- with .Values.license.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.license.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   {{- if .Values.license.data }}
   license.lic: {{ .Values.license.data }}

--- a/charts/hivemq-platform/templates/hivemq-license.yml
+++ b/charts/hivemq-platform/templates/hivemq-license.yml
@@ -12,16 +12,22 @@ metadata:
   labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-data:
+{{ ternary (println "data:") (println "stringData:") (.Values.license.isLicenseBase64Encoded) }}
   {{- if .Values.license.data }}
   license.lic: {{ .Values.license.data }}
   {{- else if .Values.license.overrideLicense }}
   license.lic: |-
-    {{ range (.Values.license.overrideLicense | b64enc) | toStrings }}
-    {{ . | nindent 4 }}
-    {{ end }}
+    {{- if .Values.license.isLicenseBase64Encoded -}}
+      {{- range .Values.license.overrideLicense | b64enc | toStrings -}}
+      {{ . | nindent 6 }}
+      {{ end }}
+    {{- else -}}
+      {{- range .Values.license.overrideLicense | toStrings -}}
+      {{ . | nindent 6 }}
+      {{ end }}
+    {{- end }}
   {{- end }}
-  {{- include "hivemq-platform.generate-licenses-content" (dict "licenses" .Values.license.additionalLicenses "licenseExtension" ".lic") }}
-  {{- include "hivemq-platform.generate-licenses-content" (dict "licenses" .Values.license.extensions "licenseExtension" ".elic") }}
-  {{- include "hivemq-platform.generate-licenses-content" (dict "licenses" .Values.license.dataHub "licenseExtension" ".plic") }}
+  {{- include "hivemq-platform.generate-licenses-content" (dict "licenses" .Values.license.additionalLicenses "licenseExtension" ".lic" "isLicenseBase64Encoded" .Values.license.isLicenseBase64Encoded) }}
+  {{- include "hivemq-platform.generate-licenses-content" (dict "licenses" .Values.license.extensions "licenseExtension" ".elic" "isLicenseBase64Encoded" .Values.license.isLicenseBase64Encoded) }}
+  {{- include "hivemq-platform.generate-licenses-content" (dict "licenses" .Values.license.dataHub "licenseExtension" ".plic" "isLicenseBase64Encoded" .Values.license.isLicenseBase64Encoded) }}
 {{- end }}

--- a/charts/hivemq-platform/tests/configuration/configmap/hivemq_configuration_test.yaml
+++ b/charts/hivemq-platform/tests/configuration/configmap/hivemq_configuration_test.yaml
@@ -12,10 +12,10 @@ set:
   config.createAs: ConfigMap
 asserts:
     - containsDocument:
-      apiVersion: v1
-      kind: ConfigMap
-      name: hivemq-configuration-test-hivemq-platform
-      namespace: test-hivemq-platform-namespace
+        apiVersion: v1
+        kind: ConfigMap
+        name: hivemq-configuration-test-hivemq-platform
+        namespace: test-hivemq-platform-namespace
       template: hivemq-configuration.yml
 tests:
 
@@ -26,7 +26,8 @@ tests:
       - notExists:
           path: spec.secretName
 
-  - it: with default values, default labels created
+  - it: with default values, only default labels created
+    template: hivemq-configuration.yml
     asserts:
       - isSubset:
           path: metadata.labels
@@ -36,7 +37,66 @@ tests:
             app.kubernetes.io/instance: test-hivemq-platform
             app.kubernetes.io/version: 1.0.0
             app.kubernetes.io/managed-by: Helm
+      - notExists:
+          path: metadata.annotations
+
+  - it: with custom labels, default and custom labels created
+    set:
+      config.labels:
+        label-1: label-1
+        label-2: label-2
+    template: hivemq-configuration.yml
+    asserts:
+      - exists:
+          path: metadata.labels
+      - isSubset:
+          path: metadata.labels
+          content:
+            helm.sh/chart: hivemq-platform-0.0.1
+            app.kubernetes.io/name: hivemq-platform
+            app.kubernetes.io/instance: test-hivemq-platform
+            app.kubernetes.io/version: 1.0.0
+            app.kubernetes.io/managed-by: Helm
+            label-1: label-1
+            label-2: label-2
+      - notExists:
+          path: metadata.annotations
+
+  - it: with invalid custom label, schema validation fails
+    set:
+      config.labels: "invalid-label"
+    template: hivemq-configuration.yml
+    asserts:
+      - failedTemplate: {}
+
+  - it: with default values, no annotations created
+    asserts:
+      - notExists:
+          path: metadata.annotations
         template: hivemq-configuration.yml
+
+  - it: with custom annotations, custom annotations created
+    set:
+      config.annotations:
+        annotation-1: annotation-1
+        annotation-2: annotation-2
+    template: hivemq-configuration.yml
+    asserts:
+      - exists:
+          path: metadata.annotations
+      - isSubset:
+          path: metadata.annotations
+          content:
+            annotation-1: annotation-1
+            annotation-2: annotation-2
+        template: hivemq-configuration.yml
+
+  - it: with invalid custom annotation, schema validation fails
+    set:
+      config.annotations: "invalid-annotation"
+    template: hivemq-configuration.yml
+    asserts:
+      - failedTemplate: {}
 
   - it: with lower case configmap for createAs value, schema validation fails
     set:

--- a/charts/hivemq-platform/tests/configuration/secret/hivemq_configuration_test.yaml
+++ b/charts/hivemq-platform/tests/configuration/secret/hivemq_configuration_test.yaml
@@ -12,26 +12,88 @@ set:
   config.createAs: Secret
 asserts:
     - containsDocument:
-      apiVersion: v1
-      kind: Secret
-      name: hivemq-configuration-test-hivemq-platform
-      namespace: test-hivemq-platform-namespace
+        apiVersion: v1
+        kind: Secret
+        name: hivemq-configuration-test-hivemq-platform
+        namespace: test-hivemq-platform-namespace
       template: hivemq-configuration.yml
 tests:
-
-  - it: with default Secret values, default Secret created
-    asserts:
-      - containsDocument:
-          apiVersion: v1
-          kind: Secret
-          name: hivemq-configuration-test-hivemq-platform
-          namespace: test-hivemq-platform-namespace
-        template: hivemq-configuration.yml
 
   - it: with default Secret values, no configMapName is added to the custom resource
     asserts:
       - notExists:
           path: spec.configMapName
+
+  - it: with default values, only default labels created
+    template: hivemq-configuration.yml
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            helm.sh/chart: hivemq-platform-0.0.1
+            app.kubernetes.io/name: hivemq-platform
+            app.kubernetes.io/instance: test-hivemq-platform
+            app.kubernetes.io/version: 1.0.0
+            app.kubernetes.io/managed-by: Helm
+      - notExists:
+          path: metadata.annotations
+
+  - it: with custom labels, default and custom labels created
+    set:
+      config.labels:
+        label-1: label-1
+        label-2: label-2
+    template: hivemq-configuration.yml
+    asserts:
+      - exists:
+          path: metadata.labels
+      - isSubset:
+          path: metadata.labels
+          content:
+            helm.sh/chart: hivemq-platform-0.0.1
+            app.kubernetes.io/name: hivemq-platform
+            app.kubernetes.io/instance: test-hivemq-platform
+            app.kubernetes.io/version: 1.0.0
+            app.kubernetes.io/managed-by: Helm
+            label-1: label-1
+            label-2: label-2
+      - notExists:
+          path: metadata.annotations
+
+  - it: with invalid custom label, schema validation fails
+    set:
+      config.labels: "invalid-label"
+    template: hivemq-configuration.yml
+    asserts:
+      - failedTemplate: {}
+
+  - it: with default values, no annotations created
+    asserts:
+      - notExists:
+          path: metadata.annotations
+        template: hivemq-configuration.yml
+
+  - it: with custom annotations, custom annotations created
+    set:
+      config.annotations:
+        annotation-1: annotation-1
+        annotation-2: annotation-2
+    template: hivemq-configuration.yml
+    asserts:
+      - exists:
+          path: metadata.annotations
+      - isSubset:
+          path: metadata.annotations
+          content:
+            annotation-1: annotation-1
+            annotation-2: annotation-2
+
+  - it: with invalid custom annotation, schema validation fails
+    set:
+      config.annotations: "invalid-annotation"
+    template: hivemq-configuration.yml
+    asserts:
+      - failedTemplate: {}
 
   - it: with lower case secret for createAs value, schema validation fails
     set:
@@ -45,7 +107,7 @@ tests:
     asserts:
       - failedTemplate: {}
 
-  - it: with default values, default labels created
+  - it: with default values, only default labels created
     asserts:
       - isSubset:
           path: metadata.labels
@@ -56,6 +118,8 @@ tests:
             app.kubernetes.io/version: 1.0.0
             app.kubernetes.io/managed-by: Helm
         template: hivemq-configuration.yml
+      - notExists:
+          path: metadata.annotations
 
   - it: with default platform values
     template: hivemq-configuration.yml

--- a/charts/hivemq-platform/tests/hivemq_platform_test.yaml
+++ b/charts/hivemq-platform/tests/hivemq_platform_test.yaml
@@ -15,7 +15,7 @@ tests:
           kind: HiveMQPlatform
           name: test-hivemq-platform
 
-  - it: with default values, default labels created
+  - it: with default values, only default labels created
     asserts:
       - isSubset:
           path: metadata.labels
@@ -25,6 +25,8 @@ tests:
             app.kubernetes.io/instance: test-hivemq-platform
             app.kubernetes.io/version: 1.0.0
             app.kubernetes.io/managed-by: Helm
+      - notExists:
+          path: metadata.annotations
 
   - it: with a custom operator selector
     set:
@@ -59,6 +61,34 @@ tests:
           content:
             group: alpha
             tier: one
+      - notExists:
+          path: metadata.annotations
+
+  - it: with invalid custom invalid labels, schema validation fails
+    set:
+      operator.labels: "invalid-label"
+    asserts:
+      - failedTemplate: {}
+
+  - it: with custom annotations, custom annotations set
+    set:
+      operator.annotations:
+        annotation-1: annotation-1
+        annotation-2: annotation-2
+    asserts:
+      - exists:
+          path: metadata.annotations
+      - isSubset:
+          path: metadata.annotations
+          content:
+            annotation-1: annotation-1
+            annotation-2: annotation-2
+
+  - it: with invalid custom annotations, schema validation fails
+    set:
+      operator.annotations: "invalid-annotation"
+    asserts:
+      - failedTemplate: {}
 
   - it: with image definition
     set:

--- a/charts/hivemq-platform/tests/licenses/hivemq_additional_broker_license_test.yaml
+++ b/charts/hivemq-platform/tests/licenses/hivemq_additional_broker_license_test.yaml
@@ -8,8 +8,11 @@ tests:
 
   - it: with additional broker license, Secret metadata is correct
     set:
-      license.create: true
-      license.additionalLicenses.broker1.data: broker1-license-content
+      license:
+        create: true
+        additionalLicenses:
+          broker1:
+            data: YnJva2VyMS1saWNlbnNlLWNvbnRlbnQ= # broker1-license-content
     asserts:
       - containsDocument:
           kind: Secret
@@ -19,22 +22,31 @@ tests:
 
   - it: with additional broker license only, no additional license added
     set:
-      license.create: true
-      license.additionalLicenses.broker1.data: broker1-license-content
+      license:
+        create: true
+        additionalLicenses:
+          broker1:
+            data: YnJva2VyMS1saWNlbnNlLWNvbnRlbnQ= # broker1-license-content
     asserts:
+      - notExists:
+          path: data["license.lic"]
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
-          path: data
-          value:
-            broker1.lic: broker1-license-content
+          path: data["broker1.lic"]
+          decodeBase64: true
+          value: broker1-license-content
         template: hivemq-license.yml
 
   - it: with additional broker license data empty, then validation fails
     set:
-      license.create: true
-      license.additionalLicenses.broker1.data: ""
+      license:
+        create: true
+        additionalLicenses:
+          broker1:
+            data: ""
     asserts:
       - failedTemplate:
           errorPattern: Additional HiveMQ Broker 'broker1' license content cannot be empty. Please, use either `data` or `overrideLicense` values
@@ -42,8 +54,11 @@ tests:
 
   - it: with additional broker license overrideLicense empty, then validation fails
     set:
-      license.create: true
-      license.additionalLicenses.broker1.overrideLicense: ""
+      license:
+        create: true
+        additionalLicenses:
+          broker1:
+            overrideLicense: ""
     asserts:
       - failedTemplate:
           errorPattern: Additional HiveMQ Broker 'broker1' license content cannot be empty. Please, use either `data` or `overrideLicense` values
@@ -51,9 +66,12 @@ tests:
 
   - it: with additional broker license overrideLicense and data empty, then validation fails
     set:
-      license.create: true
-      license.additionalLicenses.broker1.data: ""
-      license.additionalLicenses.broker1.overrideLicense: ""
+      license:
+        create: true
+        additionalLicenses:
+          broker1:
+            data: ""
+            overrideLicense: ""
     asserts:
       - failedTemplate:
           errorPattern: Additional HiveMQ Broker 'broker1' license content cannot be empty. Please, use either `data` or `overrideLicense` values
@@ -61,9 +79,12 @@ tests:
 
   - it: with additional broker license overrideLicense and data set, then validation fails
     set:
-      license.create: true
-      license.additionalLicenses.broker1.data: broker1-license-content1
-      license.additionalLicenses.broker1.overrideLicense: broker1-license-content2
+      license:
+        create: true
+        additionalLicenses:
+          broker1:
+            data: broker1-license-content1
+            overrideLicense: broker1-license-content2
     asserts:
       - failedTemplate:
           errorPattern: Both `data` and `overrideLicense` values are set for the Additional HiveMQ Broker 'broker1' license content. Please, use only one of them
@@ -71,9 +92,12 @@ tests:
 
   - it: with invalid additional broker license values, then validation fails
     set:
-      license.create: true
-      license.additionalLicenses.broker1.foo: broker1-license-content1
-      license.additionalLicenses.broker1.bar: broker1-license-content2
+      license:
+        create: true
+        additionalLicenses:
+          broker1:
+            foo: broker1-license-content1
+            bar: broker1-license-content2
     asserts:
       - failedTemplate:
           errorPattern: Invalid values for setting the Additional HiveMQ Broker 'broker1' license content. Only `data` or `overrideLicense` values are allowed
@@ -81,9 +105,12 @@ tests:
 
   - it: with broker license and duplicated "license.lic" for additional broker license data, then validation fails
     set:
-      license.create: true
-      license.data: broker-license-content
-      license.additionalLicenses.license.data: broker1-license-content
+      license:
+        create: true
+        data: broker-license-content
+        additionalLicenses:
+          license:
+            data: YnJva2VyMS1saWNlbnNlLWNvbnRlbnQ= # broker1-license-content
     asserts:
       - failedTemplate:
           errorPattern: Additional HiveMQ Broker license 'license' is already defined for the default broker license. Please, use a different license name
@@ -91,8 +118,11 @@ tests:
 
   - it: with no broker license and duplicated "license.lic" for additional broker license data, then validation succeeds
     set:
-      license.create: true
-      license.additionalLicenses.license.data: broker1-license-content
+      license:
+        create: true
+        additionalLicenses:
+          license:
+            data: YnJva2VyMS1saWNlbnNlLWNvbnRlbnQ= # broker1-license-content
     asserts:
       - notFailedTemplate: {}
         template: hivemq-license.yml
@@ -102,9 +132,12 @@ tests:
 
   - it: with broker license and duplicated "license.lic" for additional broker license overrideLicense, then validation fails
     set:
-      license.create: true
-      license.overrideLicense: broker-license-content
-      license.additionalLicenses.license.overrideLicense: broker1-license-content
+      license:
+        create: true
+        overrideLicense: broker-license-content
+        additionalLicenses:
+          license:
+            overrideLicense: broker1-license-content
     asserts:
       - failedTemplate:
           errorPattern: Additional HiveMQ Broker license 'license' is already defined for the default broker license. Please, use a different license name
@@ -112,8 +145,13 @@ tests:
 
   - it: with no broker license and duplicated "license.lic" for additional broker license overrideLicense, then validation succeeds
     set:
-      license.create: true
-      license.additionalLicenses.license.overrideLicense: broker1-license-content
+      license:
+        create: true
+        additionalLicenses:
+          license:
+            overrideLicense: |-
+              broker1-license-content1
+              broker1-license-content2
     asserts:
       - notFailedTemplate: {}
         template: hivemq-license.yml
@@ -121,10 +159,79 @@ tests:
           count: 1
         template: hivemq-license.yml
 
+  - it: with invalid Base64 encoded additional broker license data, then validation fails
+    set:
+      license:
+        create: true
+        additionalLicenses:
+          broker1:
+            data: invalid-base64-encoded-data
+    asserts:
+      - failedTemplate:
+          errorPattern: Additional HiveMQ Broker 'broker1' license data content is not a Base64 encoded string
+        template: hivemq-license.yml
+
+  - it: with invalid Base64 encoded additional broker license data but Base64 encoded disabled, then validation succeeds
+    set:
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        additionalLicenses:
+          broker1:
+            data: invalid-base64-encoded-data
+    asserts:
+      - notFailedTemplate: { hivemq-license.yml }
+      - hasDocuments:
+          count: 1
+        template: hivemq-license.yml
+
+  - it: with valid and invalid Base64 encoded additional broker licenses data, then validation fails
+    set:
+      license:
+        create: true
+        additionalLicenses:
+          broker1:
+            data: YnJva2VyMS1saWNlbnNlLWNvbnRlbnQ= # broker1-license-content
+          broker2:
+            data: invalid-base64-encoded-data
+    asserts:
+      - failedTemplate:
+          errorPattern: Additional HiveMQ Broker 'broker2' license data content is not a Base64 encoded string
+        template: hivemq-license.yml
+
+  - it: with valid Base64 encoded broker license data and invalid Base64 encoded additional broker license data, then validation fails
+    set:
+      license:
+        create: true
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
+        additionalLicenses:
+          broker1:
+            data: invalid-base64-encoded-data
+    asserts:
+      - failedTemplate:
+          errorPattern: Additional HiveMQ Broker 'broker1' license data content is not a Base64 encoded string
+        template: hivemq-license.yml
+
+  - it: with invalid Base64 encoded broker license data and valid Base64 encoded additional broker license data, then validation fails
+    set:
+      license:
+        create: true
+        data: invalid-base64-encoded-data
+        additionalLicenses:
+          broker1:
+            data: YnJva2VyMS1saWNlbnNlLWNvbnRlbnQ= # broker1-license-content
+    asserts:
+      - failedTemplate:
+          errorPattern: HiveMQ Broker 'license.lic' license data content is not a Base64 encoded string
+        template: hivemq-license.yml
+
   - it: with additional brokers license data, additional broker license created
     set:
-      license.create: true
-      license.additionalLicenses.broker1.data: broker1-license-content
+      license:
+        create: true
+        additionalLicenses:
+          broker1:
+            data: YnJva2VyMS1saWNlbnNlLWNvbnRlbnQ= # broker1-license-content
     asserts:
       - isKind:
           of: Secret
@@ -132,6 +239,9 @@ tests:
       - equal:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
         template: hivemq-license.yml
       - exists:
           path: data
@@ -141,6 +251,7 @@ tests:
         template: hivemq-license.yml
       - equal:
           path: data["broker1.lic"]
+          decodeBase64: true
           value: broker1-license-content
         template: hivemq-license.yml
       - exists:
@@ -165,11 +276,14 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with multiple license additional brokers data, multiple additional broker licenses created
+  - it: with clear additional brokers license data, additional broker license created without Base64 encoded
     set:
-      license.create: true
-      license.additionalLicenses.broker1.data: broker1-license-content
-      license.additionalLicenses.broker2.data: broker2-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        additionalLicenses:
+          broker1:
+            data: broker1-license-content
     asserts:
       - isKind:
           of: Secret
@@ -177,6 +291,61 @@ tests:
       - equal:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData["license.lic"]
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["broker1.lic"]
+          value: broker1-license-content
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with multiple additional broker licenses data, multiple additional broker licenses created
+    set:
+      license:
+        create: true
+        additionalLicenses:
+          broker1:
+            data: YnJva2VyMS1saWNlbnNlLWNvbnRlbnQ= # broker1-license-content
+          broker2:
+            data: YnJva2VyMi1saWNlbnNlLWNvbnRlbnQ= # broker2-license-content
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
         template: hivemq-license.yml
       - exists:
           path: data
@@ -186,10 +355,12 @@ tests:
         template: hivemq-license.yml
       - equal:
           path: data["broker1.lic"]
+          decodeBase64: true
           value: broker1-license-content
         template: hivemq-license.yml
       - equal:
           path: data["broker2.lic"]
+          decodeBase64: true
           value: broker2-license-content
         template: hivemq-license.yml
       - exists:
@@ -214,12 +385,16 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with broker license data and multiple license additional brokers data, broker and multiple additional broker licenses created
+  - it: with multiple clear additional broker licenses data, multiple additional broker licenses created without Base64 encoded
     set:
-      license.create: true
-      license.data: broker-license-content
-      license.additionalLicenses.broker1.data: broker1-license-content
-      license.additionalLicenses.broker2.data: broker2-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        additionalLicenses:
+          broker1:
+            data: broker1-license-content
+          broker2:
+            data: broker2-license-content
     asserts:
       - isKind:
           of: Secret
@@ -228,19 +403,141 @@ tests:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
         template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData["license.lic"]
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["broker1.lic"]
+          value: broker1-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["broker2.lic"]
+          value: broker2-license-content
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with broker license data and multiple additional broker licenses data, broker and multiple additional broker licenses created
+    set:
+      license:
+        create: true
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
+        additionalLicenses:
+          broker1:
+            data: YnJva2VyMS1saWNlbnNlLWNvbnRlbnQ= # broker1-license-content
+          broker2:
+            data: YnJva2VyMi1saWNlbnNlLWNvbnRlbnQ= # broker2-license-content
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
           path: data["license.lic"]
+          decodeBase64: true
           value: broker-license-content
         template: hivemq-license.yml
       - equal:
           path: data["broker1.lic"]
+          decodeBase64: true
           value: broker1-license-content
         template: hivemq-license.yml
       - equal:
           path: data["broker2.lic"]
+          decodeBase64: true
+          value: broker2-license-content
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with clear broker license data and multiple clear additional broker licenses data, broker and multiple additional broker licenses created without Base64 encoded
+    set:
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        data: broker-license-content
+        additionalLicenses:
+          broker1:
+            data: broker1-license-content
+          broker2:
+            data: broker2-license-content
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["license.lic"]
+          value: broker-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["broker1.lic"]
+          value: broker1-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["broker2.lic"]
           value: broker2-license-content
         template: hivemq-license.yml
       - exists:
@@ -267,8 +564,13 @@ tests:
 
   - it: with additional brokers overrideLicense, additional broker license created
     set:
-      license.create: true
-      license.additionalLicenses.broker1.overrideLicense: broker1-license-content
+      license:
+        create: true
+        additionalLicenses:
+          broker1:
+            overrideLicense: |-
+              broker1-license-content1
+              broker1-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -276,6 +578,9 @@ tests:
       - equal:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
         template: hivemq-license.yml
       - exists:
           path: data
@@ -286,7 +591,9 @@ tests:
       - equal:
           path: data["broker1.lic"]
           decodeBase64: true
-          value: broker1-license-content
+          value: |-
+            broker1-license-content1
+            broker1-license-content2
         template: hivemq-license.yml
       - exists:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
@@ -308,11 +615,16 @@ tests:
               secretName: hivemq-license-test-hivemq-platform
         template: hivemq-custom-resource.yml
 
-  - it: with multiple license additional brokers overrideLicenses, multiple additional broker licenses created
+  - it: with clear additional brokers overrideLicense, additional broker license created without Base64 encoded
     set:
-      license.create: true
-      license.additionalLicenses.broker1.overrideLicense: broker1-license-content
-      license.additionalLicenses.broker2.overrideLicense: broker2-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        additionalLicenses:
+          broker1:
+            overrideLicense: |-
+              broker1-license-content1
+              broker1-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -320,6 +632,65 @@ tests:
       - equal:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData["license.lic"]
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["broker1.lic"]
+          value: |-
+            broker1-license-content1
+            broker1-license-content2
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+        template: hivemq-custom-resource.yml
+
+  - it: with multiple additional broker licenses overrideLicenses, multiple additional broker licenses created
+    set:
+      license:
+        create: true
+        additionalLicenses:
+          broker1:
+            overrideLicense: |-
+              broker1-license-content1
+              broker1-license-content2
+          broker2:
+            overrideLicense: |-
+              broker2-license-content1
+              broker2-license-content2
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
         template: hivemq-license.yml
       - exists:
           path: data
@@ -330,12 +701,16 @@ tests:
       - equal:
           path: data["broker1.lic"]
           decodeBase64: true
-          value: broker1-license-content
+          value: |-
+            broker1-license-content1
+            broker1-license-content2
         template: hivemq-license.yml
       - equal:
           path: data["broker2.lic"]
           decodeBase64: true
-          value: broker2-license-content
+          value: |-
+            broker2-license-content1
+            broker2-license-content2
         template: hivemq-license.yml
       - exists:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
@@ -359,12 +734,20 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with with broker license overrideLicense and multiple license additional brokers overrideLicenses, broker and additional broker licenses created
+  - it: with multiple clear additional broker licenses overrideLicenses, multiple additional broker licenses created without Base64 encoded
     set:
-      license.create: true
-      license.overrideLicense: broker-license-content
-      license.additionalLicenses.broker1.overrideLicense: broker1-license-content
-      license.additionalLicenses.broker2.overrideLicense: broker2-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        additionalLicenses:
+          broker1:
+            overrideLicense: |-
+              broker1-license-content1
+              broker1-license-content2
+          broker2:
+            overrideLicense: |-
+              broker2-license-content1
+              broker2-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -373,23 +756,99 @@ tests:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
         template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData["license.lic"]
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["broker1.lic"]
+          value: |-
+            broker1-license-content1
+            broker1-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["broker2.lic"]
+          value: |-
+            broker2-license-content1
+            broker2-license-content2
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with with broker license overrideLicense and multiple additional broker licenses overrideLicenses, broker and additional broker licenses created
+    set:
+      license:
+        create: true
+        overrideLicense: |-
+          broker-license-content1
+          broker-license-content2
+        additionalLicenses:
+          broker1:
+            overrideLicense: |-
+              broker1-license-content1
+              broker1-license-content2
+          broker2:
+            overrideLicense: |-
+              broker2-license-content1
+              broker2-license-content2
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
           path: data["license.lic"]
           decodeBase64: true
-          value: broker-license-content
+          value: |-
+            broker-license-content1
+            broker-license-content2
         template: hivemq-license.yml
       - equal:
           path: data["broker1.lic"]
           decodeBase64: true
-          value: broker1-license-content
+          value: |-
+            broker1-license-content1
+            broker1-license-content2
         template: hivemq-license.yml
       - equal:
           path: data["broker2.lic"]
           decodeBase64: true
-          value: broker2-license-content
+          value: |-
+            broker2-license-content1
+            broker2-license-content2
         template: hivemq-license.yml
       - exists:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
@@ -413,11 +872,23 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with broker license data and license additional brokers overrideLicenses, broker and additional broker license created
+  - it: with with clear broker license overrideLicense and multiple clear additional broker license overrideLicenses, broker and additional broker licenses created without Base64 encoded
     set:
-      license.create: true
-      license.data: broker-license-content
-      license.additionalLicenses.broker1.overrideLicense: broker1-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        overrideLicense: |-
+          broker-license-content1
+          broker-license-content2
+        additionalLicenses:
+          broker1:
+            overrideLicense: |-
+              broker1-license-content1
+              broker1-license-content2
+          broker2:
+            overrideLicense: |-
+              broker2-license-content1
+              broker2-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -426,17 +897,29 @@ tests:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
         template: hivemq-license.yml
-      - exists:
+      - notExists:
           path: data
         template: hivemq-license.yml
-      - equal:
-          path: data["license.lic"]
-          value: broker-license-content
+      - exists:
+          path: stringData
         template: hivemq-license.yml
       - equal:
-          path: data["broker1.lic"]
-          decodeBase64: true
-          value: broker1-license-content
+          path: stringData["license.lic"]
+          value: |-
+            broker-license-content1
+            broker-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["broker1.lic"]
+          value: |-
+            broker1-license-content1
+            broker1-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["broker2.lic"]
+          value: |-
+            broker2-license-content1
+            broker2-license-content2
         template: hivemq-license.yml
       - exists:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
@@ -460,12 +943,16 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with broker license data and multiple license additional brokers overrideLicenses, broker and additional broker licenses created
+  - it: with broker license data and additional broker licenses overrideLicenses, broker and additional broker license created
     set:
-      license.create: true
-      license.data: broker-license-content
-      license.additionalLicenses.broker1.overrideLicense: broker1-license-content
-      license.additionalLicenses.broker2.overrideLicense: broker2-license-content
+      license:
+        create: true
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
+        additionalLicenses:
+          broker1:
+            overrideLicense: |-
+              broker1-license-content1
+              broker1-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -474,22 +961,149 @@ tests:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
         template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
           path: data["license.lic"]
+          decodeBase64: true
           value: broker-license-content
         template: hivemq-license.yml
       - equal:
           path: data["broker1.lic"]
           decodeBase64: true
-          value: broker1-license-content
+          value: |-
+            broker1-license-content1
+            broker1-license-content2
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with clear broker license data and clear additional broker license overrideLicenses, broker and additional broker license created without Base64 encoded
+    set:
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        data: broker-license-content
+        additionalLicenses:
+          broker1:
+            overrideLicense: |-
+              broker1-license-content1
+              broker1-license-content2
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["license.lic"]
+          value: broker-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["broker1.lic"]
+          value: |-
+            broker1-license-content1
+            broker1-license-content2
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with broker license data and multiple additional broker licenses overrideLicenses, broker and additional broker licenses created
+    set:
+      license:
+        create: true
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
+        additionalLicenses:
+          broker1:
+            overrideLicense: |-
+              broker1-license-content1
+              broker1-license-content2
+          broker2:
+            overrideLicense: |-
+              broker2-license-content1
+              broker2-license-content2
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
+      - exists:
+          path: data
+        template: hivemq-license.yml
+      - equal:
+          path: data["license.lic"]
+          decodeBase64: true
+          value: broker-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: data["broker1.lic"]
+          decodeBase64: true
+          value: |-
+            broker1-license-content1
+            broker1-license-content2
         template: hivemq-license.yml
       - equal:
           path: data["broker2.lic"]
           decodeBase64: true
-          value: broker2-license-content
+          value: |-
+            broker2-license-content1
+            broker2-license-content2
         template: hivemq-license.yml
       - exists:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
@@ -513,11 +1127,21 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with broker license overrideLicense and license additional brokers data, broker and additional broker license created
+  - it: with clear broker license data and multiple clear additional broker licenses overrideLicenses, broker and additional broker licenses created without Base64 encoded
     set:
-      license.create: true
-      license.overrideLicense: broker-license-content
-      license.additionalLicenses.broker1.data: broker1-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        data: broker-license-content
+        additionalLicenses:
+          broker1:
+            overrideLicense: |-
+              broker1-license-content1
+              broker1-license-content2
+          broker2:
+            overrideLicense: |-
+              broker2-license-content1
+              broker2-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -526,16 +1150,141 @@ tests:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
         template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["license.lic"]
+          value: broker-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["broker1.lic"]
+          value: |-
+            broker1-license-content1
+            broker1-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["broker2.lic"]
+          value: |-
+            broker2-license-content1
+            broker2-license-content2
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with broker license overrideLicense and additional broker licenses data, broker and additional broker license created
+    set:
+      license:
+        create: true
+        overrideLicense: |-
+          broker-license-content1
+          broker-license-content2
+        additionalLicenses:
+          broker1:
+            data: YnJva2VyMS1saWNlbnNlLWNvbnRlbnQ= # broker1-license-content
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
           path: data["license.lic"]
           decodeBase64: true
-          value: broker-license-content
+          value: |-
+            broker-license-content1
+            broker-license-content2
         template: hivemq-license.yml
       - equal:
           path: data["broker1.lic"]
+          decodeBase64: true
+          value: broker1-license-content
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with clear broker license overrideLicense and clear additional broker licenses data, broker and additional broker license created without Base64 encoded
+    set:
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        overrideLicense: |-
+          broker-license-content1
+          broker-license-content2
+        additionalLicenses:
+          broker1:
+            data: broker1-license-content
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["license.lic"]
+          value: |-
+            broker-license-content1
+            broker-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["broker1.lic"]
           value: broker1-license-content
         template: hivemq-license.yml
       - exists:

--- a/charts/hivemq-platform/tests/licenses/hivemq_datahub_license_test.yaml
+++ b/charts/hivemq-platform/tests/licenses/hivemq_datahub_license_test.yaml
@@ -8,8 +8,11 @@ tests:
 
   - it: with data hub license, Secret metadata is correct
     set:
-      license.create: true
-      license.dataHub.datahub1.data: datahub1-license-content
+      license:
+        create: true
+        dataHub:
+          datahub1:
+            data: ZGF0YWh1YjEtbGljZW5zZS1jb250ZW50 # datahub1-license-content
     asserts:
       - containsDocument:
           kind: Secret
@@ -19,22 +22,31 @@ tests:
 
   - it: with data hub license only, no additional license added
     set:
-      license.create: true
-      license.dataHub.datahub1.data: datahub1-license-content
+      license:
+        create: true
+        dataHub:
+          datahub1:
+            data: ZGF0YWh1YjEtbGljZW5zZS1jb250ZW50 # datahub1-license-content
     asserts:
+      - notExists:
+          path: data["license.lic"]
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
-          path: data
-          value:
-            datahub1.plic: datahub1-license-content
+          path: data["datahub1.plic"]
+          decodeBase64: true
+          value: datahub1-license-content
         template: hivemq-license.yml
 
   - it: with data hub license data empty, then validation fails
     set:
-      license.create: true
-      license.dataHub.datahub1.data: ""
+      license:
+        create: true
+        dataHub:
+          datahub1:
+            data: ""
     asserts:
       - failedTemplate:
           errorPattern: HiveMQ Data Hub 'datahub1' license content cannot be empty. Please, use either `data` or `overrideLicense` values
@@ -42,8 +54,11 @@ tests:
 
   - it: with data hub license overrideLicense empty, then validation fails
     set:
-      license.create: true
-      license.dataHub.datahub1.overrideLicense: ""
+      license:
+        create: true
+        dataHub:
+          datahub1:
+            overrideLicense: ""
     asserts:
       - failedTemplate:
           errorPattern: HiveMQ Data Hub 'datahub1' license content cannot be empty. Please, use either `data` or `overrideLicense` values
@@ -51,9 +66,12 @@ tests:
 
   - it: with data hub license overrideLicense and data empty, then validation fails
     set:
-      license.create: true
-      license.dataHub.datahub1.data: ""
-      license.dataHub.datahub1.overrideLicense: ""
+      license:
+        create: true
+        dataHub:
+          datahub1:
+            data: ""
+            overrideLicense: ""
     asserts:
       - failedTemplate:
           errorPattern: HiveMQ Data Hub 'datahub1' license content cannot be empty. Please, use either `data` or `overrideLicense` values
@@ -61,9 +79,12 @@ tests:
 
   - it: with data hub license overrideLicense and data set, then validation fails
     set:
-      license.create: true
-      license.dataHub.datahub1.data: datahub1-license-content1
-      license.dataHub.datahub1.overrideLicense: datahub1-license-content2
+      license:
+        create: true
+        dataHub:
+          datahub1:
+            data: ZGF0YWh1YjEtbGljZW5zZS1jb250ZW50 # datahub1-license-content1
+            overrideLicense: datahub1-license-content2
     asserts:
       - failedTemplate:
           errorPattern: Both `data` and `overrideLicense` values are set for the HiveMQ Data Hub 'datahub1' license content. Please, use only one of them
@@ -71,18 +92,90 @@ tests:
 
   - it: with invalid data hub license values, then validation fails
     set:
-      license.create: true
-      license.dataHub.datahub1.foo: datahub1-license-content1
-      license.dataHub.datahub1.bar: datahub1-license-content2
+      license:
+        create: true
+        dataHub:
+          datahub1:
+            foo: datahub1-license-content1
+            bar: datahub1-license-content2
     asserts:
       - failedTemplate:
           errorPattern: Invalid values for setting the HiveMQ Data Hub 'datahub1' license content. Only `data` or `overrideLicense` values are allowed
         template: hivemq-license.yml
 
+  - it: with invalid Base64 encoded data hub license data, then validation fails
+    set:
+      license:
+        create: true
+        dataHub:
+          datahub1:
+            data: invalid-base64-encoded-data
+    asserts:
+      - failedTemplate:
+          errorPattern: HiveMQ Data Hub 'datahub1' license data content is not a Base64 encoded string
+        template: hivemq-license.yml
+
+  - it: with invalid Base64 encoded data hub license data but Base64 encoded disabled, then validation succeeds
+    set:
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        dataHub:
+          datahub1:
+            data: invalid-base64-encoded-data
+    asserts:
+      - notFailedTemplate: { hivemq-license.yml }
+      - hasDocuments:
+          count: 1
+        template: hivemq-license.yml
+
+  - it: with valid and invalid Base64 encoded data hub licenses data, then validation fails
+    set:
+      license:
+        create: true
+        dataHub:
+          datahub1:
+            data: ZGF0YWh1YjEtbGljZW5zZS1jb250ZW50 # datahub1-license-content
+          datahub2:
+            data: invalid-base64-encoded-data
+    asserts:
+      - failedTemplate:
+          errorPattern: HiveMQ Data Hub 'datahub2' license data content is not a Base64 encoded string
+        template: hivemq-license.yml
+
+  - it: with valid Base64 encoded broker license data and invalid Base64 encoded data hub license data, then validation fails
+    set:
+      license:
+        create: true
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
+        dataHub:
+          datahub1:
+            data: invalid-base64-encoded-data
+    asserts:
+      - failedTemplate:
+          errorPattern: HiveMQ Data Hub 'datahub1' license data content is not a Base64 encoded string
+        template: hivemq-license.yml
+
+  - it: with invalid Base64 encoded broker license data and valid Base64 encoded data hub license data, then validation fails
+    set:
+      license:
+        create: true
+        data: invalid-base64-encoded-data
+        dataHub:
+          dataHub1:
+            data: ZGF0YWh1YjEtbGljZW5zZS1jb250ZW50 # datahub1-license-content
+    asserts:
+      - failedTemplate:
+          errorPattern: HiveMQ Broker 'license.lic' license data content is not a Base64 encoded string
+        template: hivemq-license.yml
+
   - it: with data hub license data, data hub license created
     set:
-      license.create: true
-      license.dataHub.datahub1.data: datahub1-license-content
+      license:
+        create: true
+        dataHub:
+          datahub1:
+            data: ZGF0YWh1YjEtbGljZW5zZS1jb250ZW50 # datahub1-license-content
     asserts:
       - isKind:
           of: Secret
@@ -90,6 +183,9 @@ tests:
       - equal:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
         template: hivemq-license.yml
       - exists:
           path: data
@@ -99,6 +195,7 @@ tests:
         template: hivemq-license.yml
       - equal:
           path: data["datahub1.plic"]
+          decodeBase64: true
           value: datahub1-license-content
         template: hivemq-license.yml
       - exists:
@@ -123,11 +220,14 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with multiple license data hub data, multiple data hub licenses created
+  - it: with clear data hub license data, data hub license created without Base64 encoded
     set:
-      license.create: true
-      license.dataHub.datahub1.data: datahub1-license-content
-      license.dataHub.datahub2.data: datahub2-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        dataHub:
+          datahub1:
+            data: datahub1-license-content
     asserts:
       - isKind:
           of: Secret
@@ -135,6 +235,61 @@ tests:
       - equal:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData["license.lic"]
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["datahub1.plic"]
+          value: datahub1-license-content
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with multiple data hub license data, multiple data hub licenses created
+    set:
+      license:
+        create: true
+        dataHub:
+          datahub1:
+            data: ZGF0YWh1YjEtbGljZW5zZS1jb250ZW50 # datahub1-license-content
+          datahub2:
+            data: ZGF0YWh1YjItbGljZW5zZS1jb250ZW50 # datahub2-license-content
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
         template: hivemq-license.yml
       - exists:
           path: data
@@ -144,10 +299,12 @@ tests:
         template: hivemq-license.yml
       - equal:
           path: data["datahub1.plic"]
+          decodeBase64: true
           value: datahub1-license-content
         template: hivemq-license.yml
       - equal:
           path: data["datahub2.plic"]
+          decodeBase64: true
           value: datahub2-license-content
         template: hivemq-license.yml
       - exists:
@@ -172,12 +329,16 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with broker license data and multiple license data hub data, broker and multiple data hub licenses created
+  - it: with multiple clear data hub license data, multiple data hub licenses created without Base64 encoded
     set:
-      license.create: true
-      license.data: broker-license-content
-      license.dataHub.datahub1.data: datahub1-license-content
-      license.dataHub.datahub2.data: datahub2-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        dataHub:
+          datahub1:
+            data: datahub1-license-content
+          datahub2:
+            data: datahub2-license-content
     asserts:
       - isKind:
           of: Secret
@@ -186,19 +347,141 @@ tests:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
         template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData["license.lic"]
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["datahub1.plic"]
+          value: datahub1-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["datahub2.plic"]
+          value: datahub2-license-content
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with broker license data and multiple data hub license data, broker and multiple data hub licenses created
+    set:
+      license:
+        create: true
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
+        dataHub:
+          datahub1:
+            data: ZGF0YWh1YjEtbGljZW5zZS1jb250ZW50 # datahub1-license-content
+          datahub2:
+            data: ZGF0YWh1YjItbGljZW5zZS1jb250ZW50 # datahub2-license-content
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
           path: data["license.lic"]
+          decodeBase64: true
           value: broker-license-content
         template: hivemq-license.yml
       - equal:
           path: data["datahub1.plic"]
+          decodeBase64: true
           value: datahub1-license-content
         template: hivemq-license.yml
       - equal:
           path: data["datahub2.plic"]
+          decodeBase64: true
+          value: datahub2-license-content
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with clear broker license data and multiple clear data hub license data, broker and multiple data hub licenses created without Base64 encoded
+    set:
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        data: broker-license-content
+        dataHub:
+          datahub1:
+            data: datahub1-license-content
+          datahub2:
+            data: datahub2-license-content
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["license.lic"]
+          value: broker-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["datahub1.plic"]
+          value: datahub1-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["datahub2.plic"]
           value: datahub2-license-content
         template: hivemq-license.yml
       - exists:
@@ -225,8 +508,13 @@ tests:
 
   - it: with data hub overrideLicense, data hub license created
     set:
-      license.create: true
-      license.dataHub.datahub1.overrideLicense: datahub1-license-content
+      license:
+        create: true
+        dataHub:
+          datahub1:
+            overrideLicense: |-
+              datahub1-license-content1
+              datahub1-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -234,6 +522,9 @@ tests:
       - equal:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
         template: hivemq-license.yml
       - exists:
           path: data
@@ -244,7 +535,9 @@ tests:
       - equal:
           path: data["datahub1.plic"]
           decodeBase64: true
-          value: datahub1-license-content
+          value: |-
+            datahub1-license-content1
+            datahub1-license-content2
         template: hivemq-license.yml
       - exists:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
@@ -266,11 +559,16 @@ tests:
               secretName: hivemq-license-test-hivemq-platform
         template: hivemq-custom-resource.yml
 
-  - it: with multiple license data hub overrideLicenses, multiple data hub licenses created
+  - it: with clear data hub overrideLicense, data hub license created without Base64 encoded
     set:
-      license.create: true
-      license.dataHub.datahub1.overrideLicense: datahub1-license-content
-      license.dataHub.datahub2.overrideLicense: datahub2-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        dataHub:
+          datahub1:
+            overrideLicense: |-
+              datahub1-license-content1
+              datahub1-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -278,6 +576,65 @@ tests:
       - equal:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData["license.lic"]
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["datahub1.plic"]
+          value: |-
+            datahub1-license-content1
+            datahub1-license-content2
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+        template: hivemq-custom-resource.yml
+
+  - it: with multiple data hub license overrideLicenses, multiple data hub licenses created
+    set:
+      license:
+        create: true
+        dataHub:
+          datahub1:
+            overrideLicense: |-
+              datahub1-license-content1
+              datahub1-license-content2
+          datahub2:
+            overrideLicense: |-
+              datahub2-license-content1
+              datahub2-license-content2
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
         template: hivemq-license.yml
       - exists:
           path: data
@@ -288,12 +645,16 @@ tests:
       - equal:
           path: data["datahub1.plic"]
           decodeBase64: true
-          value: datahub1-license-content
+          value: |-
+            datahub1-license-content1
+            datahub1-license-content2
         template: hivemq-license.yml
       - equal:
           path: data["datahub2.plic"]
           decodeBase64: true
-          value: datahub2-license-content
+          value: |-
+            datahub2-license-content1
+            datahub2-license-content2
         template: hivemq-license.yml
       - exists:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
@@ -317,12 +678,20 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with with broker license overrideLicense and multiple license data hub overrideLicenses, broker and data hub licenses created
+  - it: with multiple clear data hub license overrideLicenses, multiple data hub licenses created without Base64 encoded
     set:
-      license.create: true
-      license.overrideLicense: broker-license-content
-      license.dataHub.datahub1.overrideLicense: datahub1-license-content
-      license.dataHub.datahub2.overrideLicense: datahub2-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        dataHub:
+          datahub1:
+            overrideLicense: |-
+              datahub1-license-content1
+              datahub1-license-content2
+          datahub2:
+            overrideLicense: |-
+              datahub2-license-content1
+              datahub2-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -331,23 +700,99 @@ tests:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
         template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData["license.lic"]
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["datahub1.plic"]
+          value: |-
+            datahub1-license-content1
+            datahub1-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["datahub2.plic"]
+          value: |-
+            datahub2-license-content1
+            datahub2-license-content2
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with broker license overrideLicense and multiple data hub license overrideLicenses, broker and data hub licenses created
+    set:
+      license:
+        create: true
+        overrideLicense: |-
+          broker-license-content1
+          broker-license-content2
+        dataHub:
+          datahub1:
+            overrideLicense: |-
+              datahub1-license-content1
+              datahub1-license-content2
+          datahub2:
+            overrideLicense: |-
+              datahub2-license-content1
+              datahub2-license-content2
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
           path: data["license.lic"]
           decodeBase64: true
-          value: broker-license-content
+          value: |-
+            broker-license-content1
+            broker-license-content2
         template: hivemq-license.yml
       - equal:
           path: data["datahub1.plic"]
           decodeBase64: true
-          value: datahub1-license-content
+          value: |-
+            datahub1-license-content1
+            datahub1-license-content2
         template: hivemq-license.yml
       - equal:
           path: data["datahub2.plic"]
           decodeBase64: true
-          value: datahub2-license-content
+          value: |-
+            datahub2-license-content1
+            datahub2-license-content2
         template: hivemq-license.yml
       - exists:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
@@ -371,11 +816,23 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with broker license data and license data hub overrideLicenses, broker and data hub license created
+  - it: with clear broker license overrideLicense and multiple clear data hub license overrideLicenses, broker and data hub licenses created without Base64 encoded
     set:
-      license.create: true
-      license.data: broker-license-content
-      license.dataHub.datahub1.overrideLicense: datahub1-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        overrideLicense: |-
+          broker-license-content1
+          broker-license-content2
+        dataHub:
+          datahub1:
+            overrideLicense: |-
+              datahub1-license-content1
+              datahub1-license-content2
+          datahub2:
+            overrideLicense: |-
+              datahub2-license-content1
+              datahub2-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -384,17 +841,29 @@ tests:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
         template: hivemq-license.yml
-      - exists:
+      - notExists:
           path: data
         template: hivemq-license.yml
-      - equal:
-          path: data["license.lic"]
-          value: broker-license-content
+      - exists:
+          path: stringData
         template: hivemq-license.yml
       - equal:
-          path: data["datahub1.plic"]
-          decodeBase64: true
-          value: datahub1-license-content
+          path: stringData["license.lic"]
+          value: |-
+            broker-license-content1
+            broker-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["datahub1.plic"]
+          value: |-
+            datahub1-license-content1
+            datahub1-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["datahub2.plic"]
+          value: |-
+            datahub2-license-content1
+            datahub2-license-content2
         template: hivemq-license.yml
       - exists:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
@@ -418,12 +887,16 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with broker license data and multiple license data hub overrideLicenses, broker and data hub licenses created
+  - it: with broker license data and data hub license overrideLicenses, broker and data hub license created
     set:
-      license.create: true
-      license.data: broker-license-content
-      license.dataHub.datahub1.overrideLicense: datahub1-license-content
-      license.dataHub.datahub2.overrideLicense: datahub2-license-content
+      license:
+        create: true
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
+        dataHub:
+          datahub1:
+            overrideLicense: |-
+              datahub1-license-content1
+              datahub1-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -432,22 +905,149 @@ tests:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
         template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
           path: data["license.lic"]
+          decodeBase64: true
           value: broker-license-content
         template: hivemq-license.yml
       - equal:
           path: data["datahub1.plic"]
           decodeBase64: true
-          value: datahub1-license-content
+          value: |-
+            datahub1-license-content1
+            datahub1-license-content2
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with clear broker license data and clear data hub license overrideLicenses, broker and data hub license created without Base64 encoded
+    set:
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        data: broker-license-content
+        dataHub:
+          datahub1:
+            overrideLicense: |-
+              datahub1-license-content1
+              datahub1-license-content2
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["license.lic"]
+          value: broker-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["datahub1.plic"]
+          value: |-
+            datahub1-license-content1
+            datahub1-license-content2
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with broker license data and multiple data hub license overrideLicenses, broker and data hub licenses created
+    set:
+      license:
+        create: true
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
+        dataHub:
+          datahub1:
+            overrideLicense: |-
+              datahub1-license-content1
+              datahub1-license-content2
+          datahub2:
+            overrideLicense: |-
+              datahub2-license-content1
+              datahub2-license-content2
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
+      - exists:
+          path: data
+        template: hivemq-license.yml
+      - equal:
+          path: data["license.lic"]
+          decodeBase64: true
+          value: broker-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: data["datahub1.plic"]
+          decodeBase64: true
+          value: |-
+            datahub1-license-content1
+            datahub1-license-content2
         template: hivemq-license.yml
       - equal:
           path: data["datahub2.plic"]
           decodeBase64: true
-          value: datahub2-license-content
+          value: |-
+            datahub2-license-content1
+            datahub2-license-content2
         template: hivemq-license.yml
       - exists:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
@@ -471,11 +1071,21 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with broker license overrideLicense and license data hub data, broker and data hub license created
+  - it: with clear broker license data and multiple clear data hub license overrideLicenses, broker and data hub licenses created without Base64 encoded
     set:
-      license.create: true
-      license.overrideLicense: broker-license-content
-      license.dataHub.datahub1.data: datahub1-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        data: broker-license-content
+        dataHub:
+          datahub1:
+            overrideLicense: |-
+              datahub1-license-content1
+              datahub1-license-content2
+          datahub2:
+            overrideLicense: |-
+              datahub2-license-content1
+              datahub2-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -484,16 +1094,84 @@ tests:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
         template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["license.lic"]
+          value: broker-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["datahub1.plic"]
+          value: |-
+            datahub1-license-content1
+            datahub1-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["datahub2.plic"]
+          value: |-
+            datahub2-license-content1
+            datahub2-license-content2
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with broker license overrideLicense and data hub license data, broker and data hub license created
+    set:
+      license:
+        create: true
+        overrideLicense: |-
+          broker-license-content1
+          broker-license-content2
+        dataHub:
+          datahub1:
+            data: ZGF0YWh1YjEtbGljZW5zZS1jb250ZW50 # datahub1-license-content
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
           path: data["license.lic"]
           decodeBase64: true
-          value: broker-license-content
+          value: |-
+            broker-license-content1
+            broker-license-content2
         template: hivemq-license.yml
       - equal:
           path: data["datahub1.plic"]
+          decodeBase64: true
           value: datahub1-license-content
         template: hivemq-license.yml
       - exists:
@@ -518,13 +1196,17 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with all licenses set with data value, all licenses created
+  - it: with clear broker license overrideLicense and clear data hub license data, broker and data hub license created without Base64 encoded
     set:
-      license.create: true
-      license.data: broker-license-content
-      license.additionalLicenses.broker1.data: broker1-license-content
-      license.extensions.kafka.data: kafka-extension-license-content
-      license.dataHub.datahub1.data: datahub1-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        overrideLicense: |-
+          broker-license-content1
+          broker-license-content2
+        dataHub:
+          datahub1:
+            data: datahub1-license-content
     asserts:
       - isKind:
           of: Secret
@@ -533,23 +1215,20 @@ tests:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
         template: hivemq-license.yml
-      - exists:
+      - notExists:
           path: data
         template: hivemq-license.yml
-      - equal:
-          path: data["license.lic"]
-          value: broker-license-content
+      - exists:
+          path: stringData
         template: hivemq-license.yml
       - equal:
-          path: data["broker1.lic"]
-          value: broker1-license-content
+          path: stringData["license.lic"]
+          value: |-
+            broker-license-content1
+            broker-license-content2
         template: hivemq-license.yml
       - equal:
-          path: data["kafka.elic"]
-          value: kafka-extension-license-content
-        template: hivemq-license.yml
-      - equal:
-          path: data["datahub1.plic"]
+          path: stringData["datahub1.plic"]
           value: datahub1-license-content
         template: hivemq-license.yml
       - exists:

--- a/charts/hivemq-platform/tests/licenses/hivemq_extensions_license_test.yaml
+++ b/charts/hivemq-platform/tests/licenses/hivemq_extensions_license_test.yaml
@@ -9,7 +9,7 @@ tests:
   - it: with extension license, Secret metadata is correct
     set:
       license.create: true
-      license.extensions.kafka.data: kafka-extension-license-content
+      license.extensions.kafka.data: a2Fma2EtZXh0ZW5zaW9uLWxpY2Vuc2UtY29udGVudA== # kafka-extension-license-content
     asserts:
       - containsDocument:
           kind: Secret
@@ -19,22 +19,31 @@ tests:
 
   - it: with extension license only, no additional license added
     set:
-      license.create: true
-      license.extensions.kafka.data: kafka-extension-license-content
+      license:
+        create: true
+        extensions:
+          kafka:
+            data: a2Fma2EtZXh0ZW5zaW9uLWxpY2Vuc2UtY29udGVudA== # kafka-extension-license-content
     asserts:
+      - notExists:
+          path: data["license.lic"]
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
-          path: data
-          value:
-            kafka.elic: kafka-extension-license-content
+          path: data["kafka.elic"]
+          decodeBase64: true
+          value: kafka-extension-license-content
         template: hivemq-license.yml
 
   - it: with extension license data empty, then validation fails
     set:
-      license.create: true
-      license.extensions.kafka.data: ""
+      license:
+        create: true
+        extensions:
+          kafka:
+            data: ""
     asserts:
       - failedTemplate:
           errorPattern: HiveMQ Enterprise Extension 'kafka' license content cannot be empty. Please, use either `data` or `overrideLicense` values
@@ -42,8 +51,11 @@ tests:
 
   - it: with extension license overrideLicense empty, then validation fails
     set:
-      license.create: true
-      license.extensions.kafka.overrideLicense: ""
+      license:
+        create: true
+        extensions:
+          kafka:
+            overrideLicense: ""
     asserts:
       - failedTemplate:
           errorPattern: HiveMQ Enterprise Extension 'kafka' license content cannot be empty. Please, use either `data` or `overrideLicense` values
@@ -51,9 +63,12 @@ tests:
 
   - it: with extension license overrideLicense and data empty, then validation fails
     set:
-      license.create: true
-      license.extensions.kafka.data: ""
-      license.extensions.kafka.overrideLicense: ""
+      license:
+        create: true
+        extensions:
+          kafka:
+            data: ""
+            overrideLicense: ""
     asserts:
       - failedTemplate:
           errorPattern: HiveMQ Enterprise Extension 'kafka' license content cannot be empty. Please, use either `data` or `overrideLicense` values
@@ -61,9 +76,12 @@ tests:
 
   - it: with extension license overrideLicense and data set, then validation fails
     set:
-      license.create: true
-      license.extensions.kafka.data: kafka-extension-license-content1
-      license.extensions.kafka.overrideLicense: kafka-extension-license-content2
+      license:
+        create: true
+        extensions:
+          kafka:
+            data: a2Fma2EtZXh0ZW5zaW9uLWxpY2Vuc2UtY29udGVudA== # kafka-extension-license-content1
+            overrideLicense: kafka-extension-license-content2
     asserts:
       - failedTemplate:
           errorPattern: Both `data` and `overrideLicense` values are set for the HiveMQ Enterprise Extension 'kafka' license content. Please, use only one of them
@@ -71,18 +89,90 @@ tests:
 
   - it: with invalid extension license values, then validation fails
     set:
-      license.create: true
-      license.extensions.kafka.foo: kafka-extension-license-content1
-      license.extensions.kafka.bar: kafka-extension-license-content2
+      license:
+        create: true
+        extensions:
+          kafka:
+            foo: kafka-extension-license-content1
+            bar: kafka-extension-license-content2
     asserts:
       - failedTemplate:
           errorPattern: Invalid values for setting the HiveMQ Enterprise Extension 'kafka' license content. Only `data` or `overrideLicense` values are allowed
         template: hivemq-license.yml
 
-  - it: with license extensions data, extension license created
+  - it: with invalid Base64 encoded extension license data, then validation fails
     set:
-      license.create: true
-      license.extensions.kafka.data: kafka-extension-license-content
+      license:
+        create: true
+        extensions:
+          kafka:
+            data: invalid-base64-encoded-data
+    asserts:
+      - failedTemplate:
+          errorPattern: HiveMQ Enterprise Extension 'kafka' license data content is not a Base64 encoded string
+        template: hivemq-license.yml
+
+  - it: with invalid Base64 encoded extension license data but Base64 encoded disabled, then validation succeeds
+    set:
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        extensions:
+          kafka:
+            data: invalid-base64-encoded-data
+    asserts:
+      - notFailedTemplate: { hivemq-license.yml }
+      - hasDocuments:
+          count: 1
+        template: hivemq-license.yml
+
+  - it: with valid and invalid Base64 encoded extension licenses data, then validation fails
+    set:
+      license:
+        create: true
+        extensions:
+          kafka:
+            data: a2Fma2EtZXh0ZW5zaW9uLWxpY2Vuc2UtY29udGVudA== # kafka-extension-license-content
+          pubsub:
+            data: invalid-base64-encoded-data
+    asserts:
+      - failedTemplate:
+          errorPattern: HiveMQ Enterprise Extension 'pubsub' license data content is not a Base64 encoded string
+        template: hivemq-license.yml
+
+  - it: with valid Base64 encoded broker license data and invalid Base64 encoded extension license data, then validation fails
+    set:
+      license:
+        create: true
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
+        extensions:
+          kafka:
+            data: invalid-base64-encoded-data
+    asserts:
+      - failedTemplate:
+          errorPattern: HiveMQ Enterprise Extension 'kafka' license data content is not a Base64 encoded string
+        template: hivemq-license.yml
+
+  - it: with invalid Base64 encoded broker license data and valid Base64 encoded extension license data, then validation fails
+    set:
+      license:
+        create: true
+        data: invalid-base64-encoded-data
+        extensions:
+          kafka:
+            data: a2Fma2EtZXh0ZW5zaW9uLWxpY2Vuc2UtY29udGVudA== # kafka-extension-license-content
+    asserts:
+      - failedTemplate:
+          errorPattern: HiveMQ Broker 'license.lic' license data content is not a Base64 encoded string
+        template: hivemq-license.yml
+
+  - it: with extension license data, extension license created
+    set:
+      license:
+        create: true
+        extensions:
+          kafka:
+            data: a2Fma2EtZXh0ZW5zaW9uLWxpY2Vuc2UtY29udGVudA== # kafka-extension-license-content
     asserts:
       - isKind:
           of: Secret
@@ -90,6 +180,9 @@ tests:
       - equal:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
         template: hivemq-license.yml
       - exists:
           path: data
@@ -99,6 +192,7 @@ tests:
         template: hivemq-license.yml
       - equal:
           path: data["kafka.elic"]
+          decodeBase64: true
           value: kafka-extension-license-content
         template: hivemq-license.yml
       - exists:
@@ -123,11 +217,14 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with multiple license extensions data, multiple extension licenses created
+  - it: with clear extension license data, extension license created without Base64 encoded
     set:
-      license.create: true
-      license.extensions.kafka.data: kafka-extension-license-content
-      license.extensions.pubsub.data: pubsub-extension-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        extensions:
+          kafka:
+            data: kafka-extension-license-content
     asserts:
       - isKind:
           of: Secret
@@ -135,6 +232,61 @@ tests:
       - equal:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData["license.lic"]
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["kafka.elic"]
+          value: kafka-extension-license-content
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with multiple extension licenses data, multiple extension licenses created
+    set:
+      license:
+        create: true
+        extensions:
+          kafka:
+            data: a2Fma2EtZXh0ZW5zaW9uLWxpY2Vuc2UtY29udGVudA== # kafka-extension-license-content
+          pubsub:
+            data: cHVic3ViLWV4dGVuc2lvbi1saWNlbnNlLWNvbnRlbnQ= # pubsub-extension-license-content
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
         template: hivemq-license.yml
       - exists:
           path: data
@@ -144,10 +296,69 @@ tests:
         template: hivemq-license.yml
       - equal:
           path: data["kafka.elic"]
+          decodeBase64: true
           value: kafka-extension-license-content
         template: hivemq-license.yml
       - equal:
           path: data["pubsub.elic"]
+          decodeBase64: true
+          value: pubsub-extension-license-content
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with clear multiple extension licenses data, multiple extension licenses created without Base64 encoded
+    set:
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        extensions:
+          kafka:
+            data: kafka-extension-license-content
+          pubsub:
+            data: pubsub-extension-license-content
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData["license.lic"]
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["kafka.elic"]
+          value: kafka-extension-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["pubsub.elic"]
           value: pubsub-extension-license-content
         template: hivemq-license.yml
       - exists:
@@ -174,10 +385,14 @@ tests:
 
   - it: with broker license data and multiple extension license data, broker and multiple extension licenses created
     set:
-      license.create: true
-      license.data: broker-license-content
-      license.extensions.kafka.data: kafka-extension-license-content
-      license.extensions.pubsub.data: pubsub-extension-license-content
+      license:
+        create: true
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
+        extensions:
+          kafka:
+            data: a2Fma2EtZXh0ZW5zaW9uLWxpY2Vuc2UtY29udGVudA== # kafka-extension-license-content
+          pubsub:
+            data: cHVic3ViLWV4dGVuc2lvbi1saWNlbnNlLWNvbnRlbnQ= # pubsub-extension-license-content
     asserts:
       - isKind:
           of: Secret
@@ -186,19 +401,25 @@ tests:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
         template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
           path: data["license.lic"]
+          decodeBase64: true
           value: broker-license-content
         template: hivemq-license.yml
       - equal:
           path: data["kafka.elic"]
+          decodeBase64: true
           value: kafka-extension-license-content
         template: hivemq-license.yml
       - equal:
           path: data["pubsub.elic"]
+          decodeBase64: true
           value: pubsub-extension-license-content
         template: hivemq-license.yml
       - exists:
@@ -223,10 +444,17 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with license extensions overrideLicense, extension license created
+  - it: with clear broker license data and multiple clear extension license data, broker and multiple extension licenses created without Base64 encoded
     set:
-      license.create: true
-      license.extensions.kafka.overrideLicense: kafka-extension-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        data: broker-license-content
+        extensions:
+          kafka:
+            data: kafka-extension-license-content
+          pubsub:
+            data: pubsub-extension-license-content
     asserts:
       - isKind:
           of: Secret
@@ -234,6 +462,66 @@ tests:
       - equal:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["license.lic"]
+          value: broker-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["kafka.elic"]
+          value: kafka-extension-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["pubsub.elic"]
+          value: pubsub-extension-license-content
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with extension license overrideLicense, extension license created
+    set:
+      license:
+        create: true
+        extensions:
+          kafka:
+            overrideLicense: |-
+              kafka-extension-license-content1
+              kafka-extension-license-content2
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
         template: hivemq-license.yml
       - exists:
           path: data
@@ -244,7 +532,9 @@ tests:
       - equal:
           path: data["kafka.elic"]
           decodeBase64: true
-          value: kafka-extension-license-content
+          value: |-
+            kafka-extension-license-content1
+            kafka-extension-license-content2
         template: hivemq-license.yml
       - exists:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
@@ -266,11 +556,16 @@ tests:
               secretName: hivemq-license-test-hivemq-platform
         template: hivemq-custom-resource.yml
 
-  - it: with multiple license extensions overrideLicense, multiple extension licenses created
+  - it: with clear extension license overrideLicense, extension license created without Base64 encoded
     set:
-      license.create: true
-      license.extensions.kafka.overrideLicense: kafka-extension-license-content
-      license.extensions.pubsub.overrideLicense: pubsub-extension-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        extensions:
+          kafka:
+            overrideLicense: |-
+              kafka-extension-license-content1
+              kafka-extension-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -278,6 +573,65 @@ tests:
       - equal:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData["license.lic"]
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["kafka.elic"]
+          value: |-
+            kafka-extension-license-content1
+            kafka-extension-license-content2
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+        template: hivemq-custom-resource.yml
+
+  - it: with multiple extension licenses overrideLicense, multiple extension licenses created
+    set:
+      license:
+        create: true
+        extensions:
+          kafka:
+            overrideLicense: |-
+              kafka-extension-license-content1
+              kafka-extension-license-content2
+          pubsub:
+            overrideLicense: |-
+              pubsub-extension-license-content1
+              pubsub-extension-license-content2
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
         template: hivemq-license.yml
       - exists:
           path: data
@@ -288,12 +642,16 @@ tests:
       - equal:
           path: data["kafka.elic"]
           decodeBase64: true
-          value: kafka-extension-license-content
+          value: |-
+            kafka-extension-license-content1
+            kafka-extension-license-content2
         template: hivemq-license.yml
       - equal:
           path: data["pubsub.elic"]
           decodeBase64: true
-          value: pubsub-extension-license-content
+          value: |-
+            pubsub-extension-license-content1
+            pubsub-extension-license-content2
         template: hivemq-license.yml
       - exists:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
@@ -317,12 +675,20 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with with broker license overrideLicense and multiple extension license overrideLicense, broker and extension licenses created
+  - it: with multiple clear extension licenses overrideLicense, multiple extension licenses created without Base64 encoded
     set:
-      license.create: true
-      license.overrideLicense: broker-license-content
-      license.extensions.kafka.overrideLicense: kafka-extension-license-content
-      license.extensions.pubsub.overrideLicense: pubsub-extension-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        extensions:
+          kafka:
+            overrideLicense: |-
+              kafka-extension-license-content1
+              kafka-extension-license-content2
+          pubsub:
+            overrideLicense: |-
+              pubsub-extension-license-content1
+              pubsub-extension-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -331,23 +697,99 @@ tests:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
         template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData["license.lic"]
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["kafka.elic"]
+          value: |-
+            kafka-extension-license-content1
+            kafka-extension-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["pubsub.elic"]
+          value: |-
+            pubsub-extension-license-content1
+            pubsub-extension-license-content2
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with broker license overrideLicense and multiple extension license overrideLicense, broker and extension licenses created
+    set:
+      license:
+        create: true
+        overrideLicense: |-
+          broker-license-content1
+          broker-license-content2
+        extensions:
+          kafka:
+            overrideLicense: |-
+              kafka-extension-license-content1
+              kafka-extension-license-content2
+          pubsub:
+            overrideLicense: |-
+              pubsub-extension-license-content1
+              pubsub-extension-license-content2
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
           path: data["license.lic"]
           decodeBase64: true
-          value: broker-license-content
+          value: |-
+            broker-license-content1
+            broker-license-content2
         template: hivemq-license.yml
       - equal:
           path: data["kafka.elic"]
           decodeBase64: true
-          value: kafka-extension-license-content
+          value: |-
+            kafka-extension-license-content1
+            kafka-extension-license-content2
         template: hivemq-license.yml
       - equal:
           path: data["pubsub.elic"]
           decodeBase64: true
-          value: pubsub-extension-license-content
+          value: |-
+            pubsub-extension-license-content1
+            pubsub-extension-license-content2
         template: hivemq-license.yml
       - exists:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
@@ -371,11 +813,23 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with broker license data and license extensions overrideLicense, broker and extension license created
+  - it: with clear broker license overrideLicense and multiple clear extension license overrideLicense, broker and extension licenses created without Base64 encoded
     set:
-      license.create: true
-      license.data: broker-license-content
-      license.extensions.kafka.overrideLicense: kafka-extension-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        overrideLicense: |-
+          broker-license-content1
+          broker-license-content2
+        extensions:
+          kafka:
+            overrideLicense: |-
+              kafka-extension-license-content1
+              kafka-extension-license-content2
+          pubsub:
+            overrideLicense: |-
+              pubsub-extension-license-content1
+              pubsub-extension-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -384,17 +838,29 @@ tests:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
         template: hivemq-license.yml
-      - exists:
+      - notExists:
           path: data
         template: hivemq-license.yml
-      - equal:
-          path: data["license.lic"]
-          value: broker-license-content
+      - exists:
+          path: stringData
         template: hivemq-license.yml
       - equal:
-          path: data["kafka.elic"]
-          decodeBase64: true
-          value: kafka-extension-license-content
+          path: stringData["license.lic"]
+          value: |-
+            broker-license-content1
+            broker-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["kafka.elic"]
+          value: |-
+            kafka-extension-license-content1
+            kafka-extension-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["pubsub.elic"]
+          value: |-
+            pubsub-extension-license-content1
+            pubsub-extension-license-content2
         template: hivemq-license.yml
       - exists:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
@@ -418,12 +884,16 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with broker license data and multiple license extensions overrideLicense, broker and extension licenses created
+  - it: with broker license data and extension license overrideLicense, broker and extension license created
     set:
-      license.create: true
-      license.data: broker-license-content
-      license.extensions.kafka.overrideLicense: kafka-extension-license-content
-      license.extensions.pubsub.overrideLicense: pubsub-extension-license-content
+      license:
+        create: true
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
+        extensions:
+          kafka:
+            overrideLicense: |-
+              kafka-extension-license-content1
+              kafka-extension-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -432,22 +902,149 @@ tests:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
         template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
           path: data["license.lic"]
+          decodeBase64: true
           value: broker-license-content
         template: hivemq-license.yml
       - equal:
           path: data["kafka.elic"]
           decodeBase64: true
-          value: kafka-extension-license-content
+          value: |-
+            kafka-extension-license-content1
+            kafka-extension-license-content2
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with clear broker license data and clear extension license overrideLicense, broker and extension license created without Base64 encoded
+    set:
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        data: broker-license-content
+        extensions:
+          kafka:
+            overrideLicense: |-
+              kafka-extension-license-content1
+              kafka-extension-license-content2
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["license.lic"]
+          value: broker-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["kafka.elic"]
+          value: |-
+            kafka-extension-license-content1
+            kafka-extension-license-content2
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with broker license data and multiple extension licenses overrideLicense, broker and extension licenses created
+    set:
+      license:
+        create: true
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
+        extensions:
+          kafka:
+            overrideLicense: |-
+              kafka-extension-license-content1
+              kafka-extension-license-content2
+          pubsub:
+            overrideLicense: |-
+              pubsub-extension-license-content1
+              pubsub-extension-license-content2
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
+      - exists:
+          path: data
+        template: hivemq-license.yml
+      - equal:
+          path: data["license.lic"]
+          decodeBase64: true
+          value: broker-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: data["kafka.elic"]
+          decodeBase64: true
+          value: |-
+            kafka-extension-license-content1
+            kafka-extension-license-content2
         template: hivemq-license.yml
       - equal:
           path: data["pubsub.elic"]
           decodeBase64: true
-          value: pubsub-extension-license-content
+          value: |-
+            pubsub-extension-license-content1
+            pubsub-extension-license-content2
         template: hivemq-license.yml
       - exists:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
@@ -471,11 +1068,21 @@ tests:
           count: 1
         template: hivemq-custom-resource.yml
 
-  - it: with broker license overrideLicense and license extensions data, broker and extension license created
+  - it: with clear broker license data and multiple clear extension licenses overrideLicense, broker and extension licenses created without Base64 encoded
     set:
-      license.create: true
-      license.overrideLicense: broker-license-content
-      license.extensions.kafka.data: kafka-extension-license-content
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        data: broker-license-content
+        extensions:
+          kafka:
+            overrideLicense: |-
+              kafka-extension-license-content1
+              kafka-extension-license-content2
+          pubsub:
+            overrideLicense: |-
+              pubsub-extension-license-content1
+              pubsub-extension-license-content2
     asserts:
       - isKind:
           of: Secret
@@ -484,16 +1091,141 @@ tests:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
         template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["license.lic"]
+          value: broker-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["kafka.elic"]
+          value: |-
+            kafka-extension-license-content1
+            kafka-extension-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["pubsub.elic"]
+          value: |-
+            pubsub-extension-license-content1
+            pubsub-extension-license-content2
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with broker license overrideLicense and extension license data, broker and extension license created
+    set:
+      license:
+        create: true
+        overrideLicense: |-
+          broker-license-content1
+          broker-license-content2
+        extensions:
+          kafka:
+            data: a2Fma2EtZXh0ZW5zaW9uLWxpY2Vuc2UtY29udGVudA== # kafka-extension-license-content
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
           path: data["license.lic"]
           decodeBase64: true
-          value: broker-license-content
+          value: |-
+            broker-license-content1
+            broker-license-content2
         template: hivemq-license.yml
       - equal:
           path: data["kafka.elic"]
+          decodeBase64: true
+          value: kafka-extension-license-content
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with clear broker license overrideLicense and clear extension license data, broker and extension license created without Base64 encoded
+    set:
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        overrideLicense: |-
+          broker-license-content1
+          broker-license-content2
+        extensions:
+          kafka:
+            data: kafka-extension-license-content
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["license.lic"]
+          value: |-
+            broker-license-content1
+            broker-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["kafka.elic"]
           value: kafka-extension-license-content
         template: hivemq-license.yml
       - exists:

--- a/charts/hivemq-platform/tests/licenses/hivemq_license_test.yaml
+++ b/charts/hivemq-platform/tests/licenses/hivemq_license_test.yaml
@@ -20,8 +20,9 @@ tests:
 
   - it: with broker license data, then broker license created
     set:
-      license.create: true
-      license.data: broker-license-content
+      license:
+        create: true
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
     asserts:
       - isKind:
           of: Secret
@@ -32,11 +33,15 @@ tests:
       - notExists:
           path: metadata.labels
         template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
           path: data["license.lic"]
+          decodeBase64: true
           value: broker-license-content
         template: hivemq-license.yml
       - equal:
@@ -63,13 +68,64 @@ tests:
                 secretName: hivemq-license-test-hivemq-platform
         template: hivemq-custom-resource.yml
 
+  - it: with clear broker license data, then broker license created without Base64 encoded
+    set:
+      license:
+        create: true
+        data: broker-license-content
+        isLicenseBase64Encoded: false
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - notExists:
+          path: metadata.annotations
+        template: hivemq-license.yml
+      - notExists:
+          path: metadata.labels
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["license.lic"]
+          value: broker-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+        template: hivemq-custom-resource.yml
+
   - it: with broker license data and custom annotations, then broker license created with custom annotations
     set:
-      license.create: true
-      license.annotations:
-        annotation-1: annotation-1
-        annotation-2: annotation-2
-      license.data: broker-license-content
+      license:
+        create: true
+        annotations:
+          annotation-1: annotation-1
+          annotation-2: annotation-2
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
     template: hivemq-license.yml
     asserts:
       - exists:
@@ -84,20 +140,22 @@ tests:
 
   - it: with broker license data and invalid custom annotations, schema validation fails
     set:
-      license.create: true
-      license.annotations: "invalid-annotation"
-      license.data: broker-license-content
+      license:
+        create: true
+        annotations: "invalid-annotation"
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
     template: hivemq-license.yml
     asserts:
       - failedTemplate: {}
 
   - it: with broker license data and custom labels, then broker license created with custom labels
     set:
-      license.create: true
-      license.labels:
-        label-1: label-1
-        label-2: label-2
-      license.data: broker-license-content
+      license:
+        create: true
+        labels:
+          label-1: label-1
+          label-2: label-2
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
     template: hivemq-license.yml
     asserts:
       - exists:
@@ -112,20 +170,27 @@ tests:
 
   - it: with broker license data and invalid custom labels, schema validation fails
     set:
-      license.create: true
-      license.labels: "invalid-label"
-      license.data: broker-license-content
+      license:
+        create: true
+        labels: "invalid-label"
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
     template: hivemq-license.yml
     asserts:
       - failedTemplate: {}
 
   - it: with broker license overrideLicense, then broker license created
     set:
-      license.create: true
-      license.overrideLicense: license-content-override
+      license:
+        create: true
+        overrideLicense: |-
+          broker-license-content1
+          broker-license-content2
     asserts:
       - isKind:
           of: Secret
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
         template: hivemq-license.yml
       - exists:
           path: data
@@ -133,7 +198,57 @@ tests:
       - equal:
           path: data["license.lic"]
           decodeBase64: true
-          value: license-content-override
+          value: |-
+            broker-license-content1
+            broker-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+        template: hivemq-custom-resource.yml
+
+  - it: with clear broker license overrideLicense, then broker license created without Base64 encoded
+    set:
+      license:
+        create: true
+        overrideLicense: |-
+          broker-license-content1
+          broker-license-content2
+        isLicenseBase64Encoded: false
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["license.lic"]
+          value: |-
+            broker-license-content1
+            broker-license-content2
         template: hivemq-license.yml
       - equal:
           path: metadata.name
@@ -198,22 +313,24 @@ tests:
 
   - it: with broker license only, no additional license added
     set:
-      license.create: true
-      license.data: broker-license-content
+      license:
+        create: true
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
     asserts:
       - exists:
           path: data
         template: hivemq-license.yml
       - equal:
-          path: data
-          value:
-            license.lic: broker-license-content
+          path: data["license.lic"]
+          decodeBase64: true
+          value: broker-license-content
         template: hivemq-license.yml
 
   - it: with broker license data empty, then validation fails
     set:
-      license.create: true
-      license.data: ""
+      license:
+        create: true
+        data: ""
     asserts:
       - failedTemplate:
           errorPattern: HiveMQ Platform license content cannot be empty
@@ -221,8 +338,9 @@ tests:
 
   - it: with broker license overrideLicense empty, then validation fails
     set:
-      license.create: true
-      license.overrideLicense: ""
+      license:
+        create: true
+        overrideLicense: ""
     asserts:
       - failedTemplate:
           errorPattern: HiveMQ Platform license content cannot be empty
@@ -230,9 +348,10 @@ tests:
 
   - it: with broker license overrideLicense and data empty, then validation fails
     set:
-      license.create: true
-      license.data: ""
-      license.overrideLicense: ""
+      license:
+        create: true
+        data: ""
+        overrideLicense: ""
     asserts:
       - failedTemplate:
           errorPattern: HiveMQ Platform license content cannot be empty
@@ -240,9 +359,12 @@ tests:
 
   - it: with broker license overrideLicense and data set, then validation fails
     set:
-      license.create: true
-      license.data: broker-license-content1
-      license.overrideLicense: broker-license-content2
+      license:
+        create: true
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudDE= # broker-license-content1
+        overrideLicense:
+          broker-license-content1
+          broker-license-content2
     asserts:
       - failedTemplate:
           errorPattern: Both `data` and `overrideLicense` values are set for the HiveMQ Broker license content. Please, use only one of them
@@ -250,21 +372,51 @@ tests:
 
   - it: with invalid broker license values, then validation fails
     set:
-      license.create: true
-      license.foo: kafka-extension-license-content1
-      license.bar: kafka-extension-license-content2
+      license:
+        create: true
+        foo: kafka-extension-license-content1
+        bar: kafka-extension-license-content2
     asserts:
       - failedTemplate:
           errorPattern: HiveMQ Platform license content cannot be empty
         template: hivemq-license.yml
 
-  - it: with all licenses set with overrideLicense value, all licenses created
+  - it: with invalid Base64 encoded broker license data, then validation fails
     set:
-      license.create: true
-      license.overrideLicense: broker-license-content
-      license.additionalLicenses.broker1.overrideLicense: broker1-license-content
-      license.extensions.kafka.overrideLicense: kafka-extension-license-content
-      license.dataHub.datahub1.overrideLicense: datahub1-license-content
+      license:
+        create: true
+        data: invalid-base64-encoded-data
+    asserts:
+      - failedTemplate:
+          errorPattern: HiveMQ Broker 'license.lic' license data content is not a Base64 encoded string
+        template: hivemq-license.yml
+
+  - it: with invalid Base64 encoded broker license data but Base64 encoded disabled, then validation succeeds
+    set:
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        data: invalid-base64-encoded-data
+    asserts:
+      - notFailedTemplate: { hivemq-license.yml }
+      - hasDocuments:
+          count: 1
+        template: hivemq-license.yml
+
+  - it: with all licenses set with data value, all licenses created
+    set:
+      license:
+        create: true
+        data: YnJva2VyLWxpY2Vuc2UtY29udGVudA== # broker-license-content
+        additionalLicenses:
+          broker1:
+            data: YnJva2VyMS1saWNlbnNlLWNvbnRlbnQ= # broker1-license-content
+        extensions:
+          kafka:
+            data: a2Fma2EtZXh0ZW5zaW9uLWxpY2Vuc2UtY29udGVudA== # kafka-extension-license-content
+        dataHub:
+          datahub1:
+            data: ZGF0YWh1YjEtbGljZW5zZS1jb250ZW50 # datahub1-license-content
     asserts:
       - isKind:
           of: Secret
@@ -272,6 +424,9 @@ tests:
       - equal:
           path: metadata.name
           value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
         template: hivemq-license.yml
       - exists:
           path: data
@@ -295,6 +450,242 @@ tests:
           path: data["datahub1.plic"]
           value: datahub1-license-content
           decodeBase64: true
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with all clear licenses set with data value, all licenses created without Base64 encoded
+    set:
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        data: broker-license-content
+        additionalLicenses:
+          broker1:
+            data: broker1-license-content
+        extensions:
+          kafka:
+            data: kafka-extension-license-content
+        dataHub:
+          datahub1:
+            data: datahub1-license-content
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["license.lic"]
+          value: broker-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["broker1.lic"]
+          value: broker1-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["kafka.elic"]
+          value: kafka-extension-license-content
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["datahub1.plic"]
+          value: datahub1-license-content
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with all licenses set with overrideLicense value, all licenses created
+    set:
+      license:
+        create: true
+        overrideLicense: |-
+          broker-license-content1
+          broker-license-content2
+        additionalLicenses:
+          broker1:
+            overrideLicense: |-
+              broker1-license-content1
+              broker1-license-content2
+        extensions:
+          kafka:
+            overrideLicense: |- 
+              kafka-extension-license-content1
+              kafka-extension-license-content2
+        dataHub:
+          datahub1:
+            overrideLicense: |-
+              datahub1-license-content1
+              datahub1-license-content2
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: stringData
+        template: hivemq-license.yml
+      - exists:
+          path: data
+        template: hivemq-license.yml
+      - equal:
+          path: data["license.lic"]
+          value: |-
+            broker-license-content1
+            broker-license-content2
+          decodeBase64: true
+        template: hivemq-license.yml
+      - equal:
+          path: data["broker1.lic"]
+          value: |-
+            broker1-license-content1
+            broker1-license-content2
+          decodeBase64: true
+        template: hivemq-license.yml
+      - equal:
+          path: data["kafka.elic"]
+          value: |-
+            kafka-extension-license-content1
+            kafka-extension-license-content2
+          decodeBase64: true
+        template: hivemq-license.yml
+      - equal:
+          path: data["datahub1.plic"]
+          value: |-
+            datahub1-license-content1
+            datahub1-license-content2
+          decodeBase64: true
+        template: hivemq-license.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: licenses
+            mountPath: /opt/hivemq/license
+          count: 1
+        template: hivemq-custom-resource.yml
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+        template: hivemq-custom-resource.yml
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: licenses
+            secret:
+              secretName: hivemq-license-test-hivemq-platform
+          count: 1
+        template: hivemq-custom-resource.yml
+
+  - it: with all clear licenses set with overrideLicense value, all licenses created without Base64 encoded
+    set:
+      license:
+        create: true
+        isLicenseBase64Encoded: false
+        overrideLicense: |-
+          broker-license-content1
+          broker-license-content2
+        additionalLicenses:
+          broker1:
+            overrideLicense: |-
+              broker1-license-content1
+              broker1-license-content2
+        extensions:
+          kafka:
+            overrideLicense: |-
+              kafka-extension-license-content1
+              kafka-extension-license-content2
+        dataHub:
+          datahub1:
+            overrideLicense: |-
+              datahub1-license-content1
+              datahub1-license-content2
+    asserts:
+      - isKind:
+          of: Secret
+        template: hivemq-license.yml
+      - equal:
+          path: metadata.name
+          value: hivemq-license-test-hivemq-platform
+        template: hivemq-license.yml
+      - notExists:
+          path: data
+        template: hivemq-license.yml
+      - exists:
+          path: stringData
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["license.lic"]
+          value: |-
+            broker-license-content1
+            broker-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["broker1.lic"]
+          value: |-
+            broker1-license-content1
+            broker1-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["kafka.elic"]
+          value: |-
+            kafka-extension-license-content1
+            kafka-extension-license-content2
+        template: hivemq-license.yml
+      - equal:
+          path: stringData["datahub1.plic"]
+          value: |-
+            datahub1-license-content1
+            datahub1-license-content2
         template: hivemq-license.yml
       - exists:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts

--- a/charts/hivemq-platform/tests/licenses/hivemq_license_test.yaml
+++ b/charts/hivemq-platform/tests/licenses/hivemq_license_test.yaml
@@ -26,6 +26,12 @@ tests:
       - isKind:
           of: Secret
         template: hivemq-license.yml
+      - notExists:
+          path: metadata.annotations
+        template: hivemq-license.yml
+      - notExists:
+          path: metadata.labels
+        template: hivemq-license.yml
       - exists:
           path: data
         template: hivemq-license.yml
@@ -56,6 +62,62 @@ tests:
             secret:
                 secretName: hivemq-license-test-hivemq-platform
         template: hivemq-custom-resource.yml
+
+  - it: with broker license data and custom annotations, then broker license created with custom annotations
+    set:
+      license.create: true
+      license.annotations:
+        annotation-1: annotation-1
+        annotation-2: annotation-2
+      license.data: broker-license-content
+    template: hivemq-license.yml
+    asserts:
+      - exists:
+          path: metadata.annotations
+      - isSubset:
+          path: metadata.annotations
+          content:
+            annotation-1: annotation-1
+            annotation-2: annotation-2
+      - notExists:
+          path: metadata.labels
+
+  - it: with broker license data and invalid custom annotations, schema validation fails
+    set:
+      license.create: true
+      license.annotations: "invalid-annotation"
+      license.data: broker-license-content
+    template: hivemq-license.yml
+    asserts:
+      - failedTemplate: {}
+
+  - it: with broker license data and custom labels, then broker license created with custom labels
+    set:
+      license.create: true
+      license.labels:
+        label-1: label-1
+        label-2: label-2
+      license.data: broker-license-content
+    template: hivemq-license.yml
+    asserts:
+      - exists:
+          path: metadata.labels
+      - isSubset:
+          path: metadata.labels
+          content:
+            label-1: label-1
+            label-2: label-2
+      - notExists:
+          path: metadata.annotations
+
+  - it: with broker license data and invalid custom labels, schema validation fails
+    set:
+      license.create: true
+      license.labels: "invalid-label"
+      license.data: broker-license-content
+    template: hivemq-license.yml
+    asserts:
+      - failedTemplate: {}
 
   - it: with broker license overrideLicense, then broker license created
     set:

--- a/charts/hivemq-platform/values.schema.json
+++ b/charts/hivemq-platform/values.schema.json
@@ -95,8 +95,14 @@
       "type" : "array"
     },
     "config" : {
+      "description" : "Defines how the HiveMQ Platform configuration is deployed as a Kubernetes object.",
       "properties" : {
+        "annotations" : {
+          "description" : "Defines specific annotations to be applied to the Kubernetes ConfigMap or Kubernetes Secret that contains the HiveMQ Platform configuration.",
+          "type" : "object"
+        },
         "create" : {
+          "description" : "Boolean value, that configures whether to use a default HiveMQ configuration.",
           "type" : "boolean"
         },
         "createAs" : {
@@ -108,29 +114,41 @@
           "type" : "string"
         },
         "customLogbackConfig" : {
+          "description" : "Optional setting to provide a custom HiveMQ Platform logging configuration (logback.xml) from a file using --set-file config.customLogbackConfig=your-logback-config.xml.",
           "type" : "string"
         },
         "customTracingConfig" : {
+          "description" : "Optional setting to provide a custom HiveMQ Platform tracing configuration (tracing.xml) from a file using --set-file config.customTracingConfig=your-tracing-config.xml.",
           "type" : "string"
         },
         "dataHub" : {
+          "description" : "Optional setting to enable HiveMQ Data Hub functionality.",
           "properties" : {
             "behaviorValidationEnabled" : {
+              "description" : "Optional setting to enable data validation.",
               "type" : "boolean"
             },
             "dataValidationEnabled" : {
+              "description" : "Optional setting to enable behavior validation.",
               "type" : "boolean"
             }
           },
           "type" : "object"
         },
+        "labels" : {
+          "description" : "Defines specific labels to be applied to the Kubernetes ConfigMap or Kubernetes Secret that contains the HiveMQ Platform configuration.",
+          "type" : "object"
+        },
         "name" : {
+          "description" : "The name of an existing Kubernetes ConfigMap or Secret with a valid HiveMQ configuration.",
           "type" : "string"
         },
         "overrideHiveMQConfig" : {
+          "description" : "Optional setting to provide the HiveMQ configuration from a file using --set-file config.overrideHiveMQConfig=your-hivemq-config.xml.",
           "type" : "string"
         },
         "overrideStatefulSet" : {
+          "description" : "Optional setting to provide the StatefulSetSpec configuration from a file using --set-file config.overrideStateFulSet=your-statefulsetspec.yml.",
           "type" : "string"
         }
       },
@@ -447,26 +465,42 @@
       "type" : "object"
     },
     "license" : {
+      "description" : "Defines all HiveMQ licenses to be used for the HiveMQ Platform.",
       "properties" : {
         "additionalLicenses" : {
+          "description" : "Adds additional main HiveMQ licenses to the Kubernetes Secret as .lic files, if needed.",
+          "type" : "object"
+        },
+        "annotations" : {
+          "description" : "Defines specific annotations to be applied to the Kubernetes Secret that contains the HiveMQ licenses.",
           "type" : "object"
         },
         "create" : {
+          "description" : "Creates a Kubernetes Secret for all configured HiveMQ licenses.",
           "type" : "boolean"
         },
         "data" : {
+          "description" : "The main HiveMQ license in an encoded 64-byte string.",
           "type" : "string"
         },
         "dataHub" : {
+          "description" : "Configures a list of HiveMQ Data Hub licenses to include as part of the Kubernetes Secret.",
           "type" : "object"
         },
         "extensions" : {
+          "description" : "Defines a list of HiveMQ Enterprise Extension licenses to include as part of the Kubernetes Secret.",
+          "type" : "object"
+        },
+        "labels" : {
+          "description" : "Defines specific labels to be applied to the Kubernetes Secret that contains the HiveMQ licenses.",
           "type" : "object"
         },
         "name" : {
+          "description" : "Defines the name of the Kubernetes Secret that contains the HiveMQ licenses.",
           "type" : "string"
         },
         "overrideLicense" : {
+          "description" : "Sets the main HiveMQ license with your own file from a specified license path.",
           "type" : "string"
         }
       },
@@ -647,7 +681,12 @@
       "type" : "object"
     },
     "operator" : {
+      "description" : "Provides the selection criteria to identify which operator manages the selected HiveMQ Platform custom resource.",
       "properties" : {
+        "annotations" : {
+          "description" : "Annotations to add to the HiveMQ Platform custom resource.",
+          "type" : "object"
+        },
         "labels" : {
           "description" : "Labels to add to the HiveMQ Platform custom resource.",
           "type" : "object"

--- a/charts/hivemq-platform/values.schema.json
+++ b/charts/hivemq-platform/values.schema.json
@@ -480,7 +480,7 @@
           "type" : "boolean"
         },
         "data" : {
-          "description" : "The main HiveMQ license in an encoded 64-byte string.",
+          "description" : "The main HiveMQ license as a string. By default, this data must be a Base64 encoded string. Otherwise, set isLicenseBase64Encoded=false to use a clear string.",
           "type" : "string"
         },
         "dataHub" : {
@@ -502,6 +502,10 @@
         "overrideLicense" : {
           "description" : "Sets the main HiveMQ license with your own file from a specified license path.",
           "type" : "string"
+        },
+        "isLicenseBase64Encoded" : {
+          "description" : "Configures whether to use a Base64 encoded string (data) or clear string (stringData) for the Kubernetes Secret. The default setting is `true`.",
+          "type": "boolean"
         }
       },
       "type" : "object"

--- a/charts/hivemq-platform/values.yaml
+++ b/charts/hivemq-platform/values.yaml
@@ -101,6 +101,10 @@ license:
   # The name of the Kubernetes Secret with all HiveMQ licenses.
   # To create a new Kubernetes Secret with licenses, set create=true. Otherwise, false to reuse an existing Secret.
   name: ""
+  # Defines specific annotations to be applied to the Kubernetes Secret that contains the HiveMQ licenses.
+  annotations: {}
+  # Defines specific labels to be applied to the Kubernetes Secret that contains the HiveMQ licenses.
+  labels: {}
   # Inlines the main HiveMQ license as an encoded 64-bytes string.
   data: ""
   # Overrides the main HiveMQ license via file using --set-file license.lic.
@@ -209,6 +213,8 @@ operator:
   # Labels can be used to configure which HiveMQ Platform Operator manages this platform.
   # Use the "selectors" value in the HiveMQ Platform Operator Helm chart to configure matching label selectors.
   labels: {}
+  # Annotations to add to the HiveMQ Platform custom resource.
+  annotations: {}
 
 # Configures how the HiveMQ platform pods should be scheduled on the Kubernetes worker nodes.
 podScheduling:
@@ -403,6 +409,10 @@ config:
   # Overrides the default HiveMQ Platform configuration (config.xml) by providing
   # the name of a Kubernetes ConfigMap or Kubernetes Secret that contains the config.xml file (also set create=false).
   name: ""
+  # Defines specific annotations to be applied to the Kubernetes ConfigMap or Kubernetes Secret that contains the HiveMQ Platform configuration.
+  annotations: {}
+  # Defines specific labels to be applied to the Kubernetes ConfigMap or Kubernetes Secret that contains the HiveMQ Platform configuration.
+  labels: {}
   # Inlines the HiveMQ Platform configuration (config.xml) from a file:
   # --set-file config.overrideHiveMQConfig=your-config.xml
   # WARNING: When this configuration option is used, all other configuration options for the HiveMQ Platform configuration are ignored.

--- a/charts/hivemq-platform/values.yaml
+++ b/charts/hivemq-platform/values.yaml
@@ -105,7 +105,20 @@ license:
   annotations: {}
   # Defines specific labels to be applied to the Kubernetes Secret that contains the HiveMQ licenses.
   labels: {}
-  # Inlines the main HiveMQ license as an encoded 64-bytes string.
+  # Configures whether to use a Base64 encoded string (data) or clear content (stringData) for the rendered Kubernetes Secret.
+  # This is useful when using some third party tools to handle the license content through placeholders, such as the ArgoCD Vault plugin.
+  # For example, the following Helm command:
+  #   `helm template platform hivemq/hivemq-platform --set license.create=true --set license.isLicenseBase64Encoded=false --set license.data=<hivemq-license-placeholder>`
+  # will render the following Kubernetes Secret:
+  #   apiVersion: v1
+  #   kind: Secret
+  #   metadata:
+  #     name: hivemq-license-platform
+  #   stringData:
+  #     license.lic: <hivemq-license-placeholder>
+  isLicenseBase64Encoded: true
+  # Inlines the main HiveMQ license as a string.
+  # By default, this data must be a Base64 encoded string. Otherwise, set isLicenseBase64Encoded=false to use a clear string.
   data: ""
   # Overrides the main HiveMQ license via file using --set-file license.lic.
   overrideLicense: ""
@@ -114,7 +127,8 @@ license:
   additionalLicenses: {}
     ## Defines the name of the additional main HiveMQ license (the .lic suffix will be added automatically).
     #license-name:
-    #  # Inlines the additional main HiveMQ license as an encoded 64-bytes string.
+    #  # Inlines the additional main HiveMQ license as a string.
+    #  # By default, this data must be a Base64 encoded string. Otherwise, set isLicenseBase64Encoded=false to use a clear string.
     #  data: ""
     #  # Overrides the additional main HiveMQ license via file using --set-file additional-license.lic.
     #  overrideLicense: ""
@@ -123,7 +137,8 @@ license:
   extensions: {}
     ## Defines the name of the HiveMQ Enterprise Extension license in the Kubernetes Secret (the .elic suffix will be added automatically).
     #extension-license-name:
-    #  # Inlines the HiveMQ Enterprise Extension license as an encoded 64-bytes string.
+    #  # Inlines the HiveMQ Enterprise Extension license as a string.
+    #  # By default, this data must be a Base64 encoded string. Otherwise, set isLicenseBase64Encoded=false to use a clear string.
     #  data: ""
     #  # Overrides the HiveMQ Enterprise Extension license via file using --set-file license.elic.
     #  overrideLicense: ""
@@ -138,7 +153,8 @@ license:
   dataHub: {}
     ## Defines the name of the HiveMQ Data Hub license in the Kubernetes Secret (the .plic suffix will be added automatically).
     #data-hub-license-name:
-    #  # Inlines the HiveMQ Data Hub license as an encoded 64-bytes string.
+    #  # Inlines the HiveMQ Data Hub license as a string.
+    #  # By default, this data must be a Base64 encoded string. Otherwise, set isLicenseBase64Encoded=false to use a clear string.
     #  data: ""
     #  # Overrides the HiveMQ Data Hub license via file using --set-file license.plic.
     #  overrideLicense: ""


### PR DESCRIPTION
https://hivemq.kanbanize.com/ctrl_board/22/cards/28888/details/

_Implementation notes_: We cannot use an auto detect mechanism here to check whether the data passed in the value is actually Base64 encoded or not, due to the use of `overrideLicense` which is always in cleared text. Right now, if customer provides the `data` that one has to be Base64 encoded, but when using the `overrideLicense` that has to be in cleared text as per the license file itself.
So in an auto discovery mechanism, when using the `overrideLicense` value it will always be using the `data` field in the Secret no matter what, instead of the `stringData`