### PR TITLE
Fix race condition in release notes updates and do not check previous appVersion for simple release note generation (used by hivemq-edge)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,4 +71,4 @@ jobs:
       - name: Update GitHub release notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bash ./release/update-github-release-notes.sh 20
+        run: bash ./release/update-github-release-notes.sh 10

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@ charts/**/charts/**.tgz
 .debug
 
 # temporary files for the github-release-note-updater
+charts.yaml
 releases.json
-charts.json

--- a/github-release-note-updater/build.gradle.kts
+++ b/github-release-note-updater/build.gradle.kts
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     compileOnly(libs.jetbrains.annotations)
     implementation(libs.jackson.databind)
+    implementation(libs.jackson.dataformat.yaml)
     implementation(libs.java.semver)
     implementation(libs.jcommander)
 }

--- a/github-release-note-updater/gradle/libs.versions.toml
+++ b/github-release-note-updater/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ jetbrains-annotations = "26.0.1"
 
 [libraries]
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
 java-semver = { module = "com.github.zafarkhaja:java-semver", version.ref = "java-semver" }
 jcommander = { module = "com.beust:jcommander", version.ref = "jcommander" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }

--- a/github-release-note-updater/src/main/java/com/hivemq/release/Chart.java
+++ b/github-release-note-updater/src/main/java/com/hivemq/release/Chart.java
@@ -1,19 +1,21 @@
 package com.hivemq.release;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.zafarkhaja.semver.Version;
 import org.jetbrains.annotations.NotNull;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 record Chart(String name, Version version, Version appVersion, String description) implements Comparable<Chart> {
 
     @JsonCreator
     Chart(
             @JsonProperty(value = "name") final @NotNull String name,
             @JsonProperty(value = "version") final @NotNull String version,
-            @JsonProperty(value = "app_version") final @NotNull String appVersion,
+            @JsonProperty(value = "appVersion") final @NotNull String appVersion,
             @JsonProperty(value = "description") final @NotNull String description) {
-        this(name.split("/")[1], Version.parse(version), Version.parse(appVersion, false), description);
+        this(name, Version.parse(version), Version.parse(appVersion, false), description);
     }
 
     @Override

--- a/github-release-note-updater/src/main/java/com/hivemq/release/GitHubReleaseNotesUpdater.java
+++ b/github-release-note-updater/src/main/java/com/hivemq/release/GitHubReleaseNotesUpdater.java
@@ -206,19 +206,13 @@ public class GitHubReleaseNotesUpdater {
             final @NotNull List<Chart> charts,
             final @NotNull String releaseNoteTemplate,
             final @NotNull Function<Version, String> releaseUrlFunction) {
-        for (int i = 0; i < charts.size(); i++) {
-            // we get the previous chart and check if the appVersion has changed in the current chart
-            final var chart = charts.get(i);
-            final var previousChart = i == 0 ? null : charts.get(i - 1);
-            final var wasChartUpdated = previousChart == null || !previousChart.appVersion().equals(chart.appVersion());
-            if (wasChartUpdated) {
-                final var releaseTag = String.format("%s-%s", chart.name(), chart.version());
-                final var releaseNote = String.format(releaseNoteTemplate,
-                        chart.description(),
-                        chart.appVersion(),
-                        releaseUrlFunction.apply(chart.appVersion()));
-                releaseNotes.put(releaseTag, releaseNote);
-            }
+        for (final var chart : charts) {
+            final var releaseTag = String.format("%s-%s", chart.name(), chart.version());
+            final var releaseNote = String.format(releaseNoteTemplate,
+                    chart.description(),
+                    chart.appVersion(),
+                    releaseUrlFunction.apply(chart.appVersion()));
+            releaseNotes.put(releaseTag, releaseNote);
         }
     }
 

--- a/github-release-note-updater/src/main/java/com/hivemq/release/IndexFile.java
+++ b/github-release-note-updater/src/main/java/com/hivemq/release/IndexFile.java
@@ -1,0 +1,23 @@
+package com.hivemq.release;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+record IndexFile(String apiVersion, Map<String, List<Chart>> entries, String generated) {
+
+    @JsonCreator
+    IndexFile(
+            @JsonProperty("apiVersion") final @NotNull String apiVersion,
+            @JsonProperty("entries") final @NotNull Map<String, List<Chart>> entries,
+            @JsonProperty("generated") final @NotNull String generated) {
+        this.apiVersion = apiVersion;
+        this.entries = entries;
+        this.generated = generated;
+    }
+}

--- a/release/update-github-release-notes.sh
+++ b/release/update-github-release-notes.sh
@@ -6,7 +6,7 @@ cd "${SCRIPT_DIR}" || exit 1
 
 # configuration
 REPO="hivemq/helm-charts"
-RELEASE_COUNT=${1:-200}
+RELEASE_COUNT=${1:-10}
 
 # check if binaries are installed
 IS_GH_INSTALLED=$(which gh >/dev/null 2>&1 || echo "GitHub CLI is not installed")

--- a/release/update-github-release-notes.sh
+++ b/release/update-github-release-notes.sh
@@ -9,11 +9,6 @@ REPO="hivemq/helm-charts"
 RELEASE_COUNT=${1:-200}
 
 # check if binaries are installed
-IS_HELM_INSTALLED=$(which helm >/dev/null 2>&1 || echo "Helm is not installed")
-if [ -n "$IS_HELM_INSTALLED" ]; then
-  echo "$IS_HELM_INSTALLED"
-  exit 1
-fi
 IS_GH_INSTALLED=$(which gh >/dev/null 2>&1 || echo "GitHub CLI is not installed")
 if [ -n "$IS_GH_INSTALLED" ]; then
   echo "$IS_GH_INSTALLED"
@@ -29,13 +24,11 @@ fi
 
 cd .. || exit 1
 
-helm repo add hivemq https://hivemq.github.io/helm-charts
-helm repo update
-helm search repo hivemq --versions -o json > charts.json
+curl -L -s -o charts.yaml https://raw.githubusercontent.com/hivemq/helm-charts/refs/heads/gh-pages/index.yaml
 gh release list --repo "$REPO" --limit "$RELEASE_COUNT" --json name,tagName,publishedAt > releases.json
 
 GH_PATH=$(which gh)
 PWD=$(pwd)
 ./gradlew :github-release-note-updater:run --args " -g $GH_PATH -p $PWD"
 
-rm releases.json charts.json
+rm charts.yaml releases.json


### PR DESCRIPTION
https://hivemq.kanbanize.com/ctrl_board/22/cards/29898/details/

We need to fix this, otherwise the release notes will not be updated if just the Chart is released for `hivemq-edge` without bumping the `appVersion` as well.

This also fixes the race condition between updating the `index.yaml` by the chart releaser, which triggers a deployment of the GitHub page that is used for our Helm repository, and using the Helm repository information to update the GitHub release notes. The solution is to download the updated `index.yaml` file instead of using the `helm repo update` (that needs the GitHub pages deployment to be done).