### PR TITLE
Set kube-prometheus-stack Chart version to last version supporting K8s 1.23

### DIFF
--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/monitoring/AbstractHelmMonitoringIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/monitoring/AbstractHelmMonitoringIT.java
@@ -32,6 +32,8 @@ abstract class AbstractHelmMonitoringIT extends AbstractHelmChartIT {
         helmChartContainer.addHelmRepo("prometheus-community", "https://prometheus-community.github.io/helm-charts");
         helmChartContainer.installChart(MONITORING_RELEASE,
                 "prometheus-community/kube-prometheus-stack",
+                "--version",
+                "72.9.1",
                 "--set",
                 "prometheus-node-exporter.hostRootFsMount.enabled=false",
                 "--set",


### PR DESCRIPTION
https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/UPGRADE.md#from-72x-to-73x