### PR TITLE
Add platform license configuration (license.xml)

### DIFF
--- a/charts/hivemq-platform/templates/_helpers.tpl
+++ b/charts/hivemq-platform/templates/_helpers.tpl
@@ -1570,6 +1570,45 @@ Usage: {{ include "hivemq-platform.generate-hivemq-logback-configuration" . }}
 {{- end -}}
 
 {{/*
+Checks whether a platform license configuration (license.xml) should be generated.
+Returns `true` if either `config.platformLicense.licenseKey` or `config.platformLicense.overrideLicenseConfig` is set. Empty string otherwise.
+Usage: {{ include "hivemq-platform.has-platform-license-config" . }}
+*/}}
+{{- define "hivemq-platform.has-platform-license-config" -}}
+{{- if or .Values.config.platformLicense.licenseKey .Values.config.platformLicense.overrideLicenseConfig -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generates the default HiveMQ Platform license configuration (license.xml) content.
+Usage: {{ include "hivemq-platform.default-platform-license-configuration" . }}
+*/}}
+{{- define "hivemq-platform.default-platform-license-configuration" -}}
+<?xml version="1.0" encoding="UTF-8" ?>
+<license xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="license.xsd">
+  <license-key>{{ .Values.config.platformLicense.licenseKey }}</license-key>
+</license>
+{{- end -}}
+
+{{/*
+Generates the HiveMQ Platform license configuration (license.xml) content based on whether a ConfigMap or a Secret is used.
+Usage: {{ include "hivemq-platform.generate-platform-license-configuration" . }}
+*/}}
+{{- define "hivemq-platform.generate-platform-license-configuration" -}}
+{{- $isSecret := (eq .Values.config.createAs "Secret") -}}
+{{- if and .Values.config.platformLicense.overrideLicenseConfig $isSecret -}}
+    {{- range (.Values.config.platformLicense.overrideLicenseConfig | b64enc) | toStrings }}
+        {{- . | nindent 4 }}
+    {{- end }}
+{{- else if .Values.config.platformLicense.overrideLicenseConfig }}
+    {{- .Values.config.platformLicense.overrideLicenseConfig | nindent 4 }}
+{{- else }}
+    {{- ternary (include "hivemq-platform.default-platform-license-configuration" . | b64enc | nindent 4) (include "hivemq-platform.default-platform-license-configuration" . | nindent 4) $isSecret }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Validates that Prometheus Operator CRDs (monitoring.coreos.com/v1) are installed in the cluster.
 
 Skips validation during 'helm template' by checking if 'hivemq.com/v1' API is available.

--- a/charts/hivemq-platform/templates/_helpers.tpl
+++ b/charts/hivemq-platform/templates/_helpers.tpl
@@ -1581,6 +1581,17 @@ Usage: {{ include "hivemq-platform.has-platform-license-config" . }}
 {{- end -}}
 
 {{/*
+Validates the platform license configuration values:
+ - Only one of `licenseKey` or `overrideLicenseConfig` are set, and not both.
+Usage: {{ include "hivemq-platform.validate-platform-license-config" . }}
+*/}}
+{{- define "hivemq-platform.validate-platform-license-config" -}}
+{{- if and .Values.config.platformLicense.licenseKey .Values.config.platformLicense.overrideLicenseConfig -}}
+    {{- fail (printf "\nBoth `licenseKey` and `overrideLicenseConfig` values are set for the HiveMQ Platform license configuration. Please, use only one of them") -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Generates the default HiveMQ Platform license configuration (license.xml) content.
 Usage: {{ include "hivemq-platform.default-platform-license-configuration" . }}
 */}}

--- a/charts/hivemq-platform/templates/hivemq-configuration.yml
+++ b/charts/hivemq-platform/templates/hivemq-configuration.yml
@@ -24,6 +24,7 @@ data:
     {{- include "hivemq-platform.generate-hivemq-logback-configuration" . }}
   {{- end }}
   {{- if (include "hivemq-platform.has-platform-license-config" .) }}
+  {{- include "hivemq-platform.validate-platform-license-config" . }}
   license.xml: |-
     {{- include "hivemq-platform.generate-platform-license-configuration" . }}
   {{- end }}

--- a/charts/hivemq-platform/templates/hivemq-configuration.yml
+++ b/charts/hivemq-platform/templates/hivemq-configuration.yml
@@ -23,4 +23,8 @@ data:
   logback.xml: |-
     {{- include "hivemq-platform.generate-hivemq-logback-configuration" . }}
   {{- end }}
+  {{- if (include "hivemq-platform.has-platform-license-config" .) }}
+  license.xml: |-
+    {{- include "hivemq-platform.generate-platform-license-configuration" . }}
+  {{- end }}
 {{- end }}

--- a/charts/hivemq-platform/tests/configuration/configmap/hivemq_platform_license_configuration_test.yaml
+++ b/charts/hivemq-platform/tests/configuration/configmap/hivemq_platform_license_configuration_test.yaml
@@ -17,6 +17,16 @@ tests:
       - notExists:
           path: data["license.xml"]
 
+  - it: with config.create disabled and licenseKey set, no ConfigMap is rendered
+    set:
+      config.create: false
+      config.name: my-external-config
+      config.platformLicense.licenseKey: my-license-key-123
+    template: hivemq-configuration.yml
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: with platformLicense.licenseKey set, license.xml is created with correct content
     set:
       config.platformLicense.licenseKey: my-license-key-123

--- a/charts/hivemq-platform/tests/configuration/configmap/hivemq_platform_license_configuration_test.yaml
+++ b/charts/hivemq-platform/tests/configuration/configmap/hivemq_platform_license_configuration_test.yaml
@@ -1,0 +1,68 @@
+suite: HiveMQ Platform Configuration as ConfigMap - Platform License Configuration tests
+templates:
+  - hivemq-configuration.yml
+release:
+  name: test-hivemq-platform
+  namespace: test-hivemq-platform-namespace
+chart:
+  version: 0.0.1
+  appVersion: 1.0.0
+set:
+  config.createAs: ConfigMap
+tests:
+
+  - it: with default values, no license.xml is created
+    template: hivemq-configuration.yml
+    asserts:
+      - notExists:
+          path: data["license.xml"]
+
+  - it: with platformLicense.licenseKey set, license.xml is created with correct content
+    set:
+      config.platformLicense.licenseKey: my-license-key-123
+    template: hivemq-configuration.yml
+    asserts:
+      - exists:
+          path: data["license.xml"]
+      - equal:
+          path: data["license.xml"]
+          value: |-
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <license xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="license.xsd">
+              <license-key>my-license-key-123</license-key>
+            </license>
+
+  - it: with platformLicense.overrideLicenseConfig set, custom license.xml is used
+    set:
+      config.platformLicense.overrideLicenseConfig: |-
+        <license>
+          <custom-config/>
+        </license>
+    template: hivemq-configuration.yml
+    asserts:
+      - exists:
+          path: data["license.xml"]
+      - equal:
+          path: data["license.xml"]
+          value: |-
+            <license>
+              <custom-config/>
+            </license>
+
+  - it: with both licenseKey and overrideLicenseConfig set, overrideLicenseConfig takes precedence
+    set:
+      config.platformLicense.licenseKey: my-license-key-123
+      config.platformLicense.overrideLicenseConfig: |-
+        <license>
+          <override/>
+        </license>
+    template: hivemq-configuration.yml
+    asserts:
+      - exists:
+          path: data["license.xml"]
+      - equal:
+          path: data["license.xml"]
+          value: |-
+            <license>
+              <override/>
+            </license>

--- a/charts/hivemq-platform/tests/configuration/configmap/hivemq_platform_license_configuration_test.yaml
+++ b/charts/hivemq-platform/tests/configuration/configmap/hivemq_platform_license_configuration_test.yaml
@@ -59,7 +59,7 @@ tests:
               <custom-config/>
             </license>
 
-  - it: with both licenseKey and overrideLicenseConfig set, overrideLicenseConfig takes precedence
+  - it: with both licenseKey and overrideLicenseConfig set, validation fails
     set:
       config.platformLicense.licenseKey: my-license-key-123
       config.platformLicense.overrideLicenseConfig: |-
@@ -68,11 +68,6 @@ tests:
         </license>
     template: hivemq-configuration.yml
     asserts:
-      - exists:
-          path: data["license.xml"]
-      - equal:
-          path: data["license.xml"]
-          value: |-
-            <license>
-              <override/>
-            </license>
+      - failedTemplate:
+          errorPattern: |-
+            Both `licenseKey` and `overrideLicenseConfig` values are set for the HiveMQ Platform license configuration. Please, use only one of them

--- a/charts/hivemq-platform/tests/configuration/secret/hivemq_platform_license_configuration_test.yaml
+++ b/charts/hivemq-platform/tests/configuration/secret/hivemq_platform_license_configuration_test.yaml
@@ -61,7 +61,7 @@ tests:
               <custom-config/>
             </license>
 
-  - it: with both licenseKey and overrideLicenseConfig set, overrideLicenseConfig takes precedence
+  - it: with both licenseKey and overrideLicenseConfig set, validation fails
     set:
       config.platformLicense.licenseKey: my-license-key-123
       config.platformLicense.overrideLicenseConfig: |-
@@ -70,12 +70,6 @@ tests:
         </license>
     template: hivemq-configuration.yml
     asserts:
-      - exists:
-          path: data["license.xml"]
-      - equal:
-          path: data["license.xml"]
-          decodeBase64: true
-          value: |-
-            <license>
-              <override/>
-            </license>
+      - failedTemplate:
+          errorPattern: |-
+            Both `licenseKey` and `overrideLicenseConfig` values are set for the HiveMQ Platform license configuration. Please, use only one of them

--- a/charts/hivemq-platform/tests/configuration/secret/hivemq_platform_license_configuration_test.yaml
+++ b/charts/hivemq-platform/tests/configuration/secret/hivemq_platform_license_configuration_test.yaml
@@ -1,0 +1,71 @@
+suite: HiveMQ Platform Configuration as Secret - Platform License Configuration tests
+templates:
+  - hivemq-configuration.yml
+release:
+  name: test-hivemq-platform
+  namespace: test-hivemq-platform-namespace
+chart:
+  version: 0.0.1
+  appVersion: 1.0.0
+set:
+  config.createAs: Secret
+tests:
+
+  - it: with default values, no license.xml is created
+    template: hivemq-configuration.yml
+    asserts:
+      - notExists:
+          path: data["license.xml"]
+
+  - it: with platformLicense.licenseKey set, license.xml is created with base64-encoded content
+    set:
+      config.platformLicense.licenseKey: my-license-key-123
+    template: hivemq-configuration.yml
+    asserts:
+      - exists:
+          path: data["license.xml"]
+      - equal:
+          path: data["license.xml"]
+          decodeBase64: true
+          value: |-
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <license xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="license.xsd">
+              <license-key>my-license-key-123</license-key>
+            </license>
+
+  - it: with platformLicense.overrideLicenseConfig set, custom license.xml is base64-encoded
+    set:
+      config.platformLicense.overrideLicenseConfig: |-
+        <license>
+          <custom-config/>
+        </license>
+    template: hivemq-configuration.yml
+    asserts:
+      - exists:
+          path: data["license.xml"]
+      - equal:
+          path: data["license.xml"]
+          decodeBase64: true
+          value: |-
+            <license>
+              <custom-config/>
+            </license>
+
+  - it: with both licenseKey and overrideLicenseConfig set, overrideLicenseConfig takes precedence
+    set:
+      config.platformLicense.licenseKey: my-license-key-123
+      config.platformLicense.overrideLicenseConfig: |-
+        <license>
+          <override/>
+        </license>
+    template: hivemq-configuration.yml
+    asserts:
+      - exists:
+          path: data["license.xml"]
+      - equal:
+          path: data["license.xml"]
+          decodeBase64: true
+          value: |-
+            <license>
+              <override/>
+            </license>

--- a/charts/hivemq-platform/tests/configuration/secret/hivemq_platform_license_configuration_test.yaml
+++ b/charts/hivemq-platform/tests/configuration/secret/hivemq_platform_license_configuration_test.yaml
@@ -17,6 +17,16 @@ tests:
       - notExists:
           path: data["license.xml"]
 
+  - it: with config.create disabled and licenseKey set, no Secret is rendered
+    set:
+      config.create: false
+      config.name: my-external-config
+      config.platformLicense.licenseKey: my-license-key-123
+    template: hivemq-configuration.yml
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: with platformLicense.licenseKey set, license.xml is created with base64-encoded content
     set:
       config.platformLicense.licenseKey: my-license-key-123

--- a/charts/hivemq-platform/values.schema.json
+++ b/charts/hivemq-platform/values.schema.json
@@ -215,6 +215,20 @@
         "overrideStatefulSet" : {
           "description" : "Optional setting to provide the StatefulSetSpec configuration from a file using --set-file config.overrideStateFulSet=your-statefulsetspec.yml.",
           "type" : "string"
+        },
+        "platformLicense" : {
+          "description" : "Configures the HiveMQ Platform license configuration (license.xml).",
+          "properties" : {
+            "licenseKey" : {
+              "description" : "The platform license key identifier. When non-empty, a license.xml is generated and included in the configuration.",
+              "type" : "string"
+            },
+            "overrideLicenseConfig" : {
+              "description" : "Optional setting to provide a custom license.xml from a file using --set-file config.platformLicense.overrideLicenseConfig=your-license.xml. When set, licenseKey is ignored.",
+              "type" : "string"
+            }
+          },
+          "type" : "object"
         }
       },
       "type" : "object"

--- a/charts/hivemq-platform/values.schema.json
+++ b/charts/hivemq-platform/values.schema.json
@@ -224,7 +224,7 @@
               "type" : "string"
             },
             "overrideLicenseConfig" : {
-              "description" : "Optional setting to provide a custom license.xml from a file using --set-file config.platformLicense.overrideLicenseConfig=your-license.xml. When set, licenseKey is ignored.",
+              "description" : "Optional setting to provide a custom license.xml from a file using --set-file config.platformLicense.overrideLicenseConfig=your-license.xml.",
               "type" : "string"
             }
           },
@@ -645,22 +645,22 @@
       "type" : "object"
     },
     "license" : {
-      "description" : "Defines all HiveMQ licenses to be used for the HiveMQ Platform.",
+      "description" : "Defines all HiveMQ file based licenses to be used for the HiveMQ Platform.",
       "properties" : {
         "additionalLicenses" : {
-          "description" : "Adds additional main HiveMQ licenses to the Kubernetes Secret as .lic files, if needed.",
+          "description" : "Adds additional main HiveMQ file based licenses to the Kubernetes Secret as .lic files, if needed.",
           "type" : "object"
         },
         "annotations" : {
-          "description" : "Defines specific annotations to be applied to the Kubernetes Secret that contains the HiveMQ licenses.",
+          "description" : "Defines specific annotations to be applied to the Kubernetes Secret that contains the HiveMQ file based licenses.",
           "type" : "object"
         },
         "create" : {
-          "description" : "Creates a Kubernetes Secret for all configured HiveMQ licenses.",
+          "description" : "Creates a Kubernetes Secret for all configured HiveMQ file based licenses.",
           "type" : "boolean"
         },
         "data" : {
-          "description" : "The main HiveMQ license as a string. By default, this data must be a Base64 encoded string. Otherwise, set isLicenseBase64Encoded=false to use a clear string.",
+          "description" : "The main HiveMQ file based license as a string. By default, this data must be a Base64 encoded string. Otherwise, set isLicenseBase64Encoded=false to use a clear string.",
           "type" : "string"
         },
         "dataHub" : {
@@ -672,15 +672,15 @@
           "type" : "object"
         },
         "labels" : {
-          "description" : "Defines specific labels to be applied to the Kubernetes Secret that contains the HiveMQ licenses.",
+          "description" : "Defines specific labels to be applied to the Kubernetes Secret that contains the HiveMQ file based licenses.",
           "type" : "object"
         },
         "name" : {
-          "description" : "Defines the name of the Kubernetes Secret that contains the HiveMQ licenses.",
+          "description" : "Defines the name of the Kubernetes Secret that contains the HiveMQ file based licenses.",
           "type" : "string"
         },
         "overrideLicense" : {
-          "description" : "Sets the main HiveMQ license with your own file from a specified license path.",
+          "description" : "Sets the main HiveMQ file based license with your own file from a specified license path.",
           "type" : "string"
         },
         "isLicenseBase64Encoded" : {

--- a/charts/hivemq-platform/values.yaml
+++ b/charts/hivemq-platform/values.yaml
@@ -102,71 +102,6 @@ restApi:
   # Enables or disables authentication and authorization.
   authEnabled: false
 
-# Configures all HiveMQ licenses.
-license:
-  # Creates a Kubernetes Secret for the configured HiveMQ licenses.
-  create: false
-  # The name of the Kubernetes Secret with all HiveMQ licenses.
-  # To create a new Kubernetes Secret with licenses, set create=true. Otherwise, false to reuse an existing Secret.
-  name: ""
-  # Defines custom annotations for the Kubernetes Secret that contains the HiveMQ licenses.
-  annotations: {}
-  # Defines custom labels for the Kubernetes Secret that contains the HiveMQ licenses.
-  labels: {}
-  # Indicates whether the license data is provided as Base64 encoded string (data) or plain content (stringData) for the rendered Kubernetes Secret.
-  # This is useful for third party tools that handle license content through placeholders, such as the ArgoCD Vault plugin.
-  # For example, the following Helm command:
-  #   `helm template platform hivemq/hivemq-platform --set license.create=true --set license.isLicenseBase64Encoded=false --set license.data=<hivemq-license-placeholder>`
-  # renders the following Kubernetes Secret:
-  #   apiVersion: v1
-  #   kind: Secret
-  #   metadata:
-  #     name: hivemq-license-platform
-  #   stringData:
-  #     license.lic: <hivemq-license-placeholder>
-  isLicenseBase64Encoded: true
-  # Inlines the main HiveMQ license as a string.
-  # By default, this data is expected as Base64 encoded string. Set "isLicenseBase64Encoded=false" to provide a plain string.
-  data: ""
-  # Overrides the main HiveMQ license via file using --set-file license.lic.
-  overrideLicense: ""
-
-  # Adds additional main HiveMQ licenses to the Kubernetes Secret as .lic files if needed.
-  additionalLicenses: {}
-    ## Defines the name of the additional main HiveMQ license (the .lic suffix will be added automatically).
-    #license-name:
-    #  # Inlines the additional main HiveMQ license as a string.
-    #  # By default, this data is expected as Base64 encoded string. Set "isLicenseBase64Encoded=false" to provide a plain string.
-    #  data: ""
-    #  # Overrides the additional main HiveMQ license via file using --set-file additional-license.lic.
-    #  overrideLicense: ""
-
-  # HiveMQ Enterprise Extension licenses to include as part of the Kubernetes Secret. Add your required licenses to the list.
-  extensions: {}
-    ## Defines the name of the HiveMQ Enterprise Extension license in the Kubernetes Secret (the .elic suffix will be added automatically).
-    #extension-license-name:
-    #  # Inlines the HiveMQ Enterprise Extension license as a string.
-    #  # By default, this data is expected as Base64 encoded string. Set "isLicenseBase64Encoded=false" to provide a plain string.
-    #  data: ""
-    #  # Overrides the HiveMQ Enterprise Extension license via file using --set-file license.elic.
-    #  overrideLicense: ""
-    ## Example of a HiveMQ Enterprise Extension for Kafka license configuration:
-    ## license:
-    ##   create: true
-    ##   extensions:
-    ##     hivemq-kafka-extension-license:
-    ##       data: kafka-license-content
-
-  # HiveMQ Data Hub licenses to include as part of the Kubernetes Secret.
-  dataHub: {}
-    ## Defines the name of the HiveMQ Data Hub license in the Kubernetes Secret (the .plic suffix will be added automatically).
-    #data-hub-license-name:
-    #  # Inlines the HiveMQ Data Hub license as a string.
-    #  # By default, this data is expected as Base64 encoded string. Set "isLicenseBase64Encoded=false" to provide a plain string.
-    #  data: ""
-    #  # Overrides the HiveMQ Data Hub license via file using --set-file license.plic.
-    #  overrideLicense: ""
-
 # Configures HiveMQ restriction options.
 # See https://docs.hivemq.com/hivemq/latest/user-guide/restrictions.html
 #hivemqRestrictions:
@@ -929,3 +864,68 @@ telemetry:
   # Configures the collection of anonymous usage statistics.
   anonymousUsageStatistics:
     enabled: true
+
+# Configures all HiveMQ file based licenses.
+license:
+  # Creates a Kubernetes Secret for the configured HiveMQ file based licenses.
+  create: false
+  # The name of the Kubernetes Secret with all HiveMQ file based licenses.
+  # To create a new Kubernetes Secret with licenses, set create=true. Otherwise, false to reuse an existing Secret.
+  name: ""
+  # Defines custom annotations for the Kubernetes Secret that contains the HiveMQ file based licenses.
+  annotations: {}
+  # Defines custom labels for the Kubernetes Secret that contains the HiveMQ file based licenses.
+  labels: {}
+  # Indicates whether the license data is provided as Base64 encoded string (data) or plain content (stringData) for the rendered Kubernetes Secret.
+  # This is useful for third party tools that handle license content through placeholders, such as the ArgoCD Vault plugin.
+  # For example, the following Helm command:
+  #   `helm template platform hivemq/hivemq-platform --set license.create=true --set license.isLicenseBase64Encoded=false --set license.data=<hivemq-license-placeholder>`
+  # renders the following Kubernetes Secret:
+  #   apiVersion: v1
+  #   kind: Secret
+  #   metadata:
+  #     name: hivemq-license-platform
+  #   stringData:
+  #     license.lic: <hivemq-license-placeholder>
+  isLicenseBase64Encoded: true
+  # Inlines the main HiveMQ file based license as a string.
+  # By default, this data is expected as Base64 encoded string. Set "isLicenseBase64Encoded=false" to provide a plain string.
+  data: ""
+  # Overrides the main HiveMQ file based license via file using --set-file license.lic.
+  overrideLicense: ""
+
+  # Adds additional main HiveMQ file based licenses to the Kubernetes Secret as .lic files if needed.
+  additionalLicenses: {}
+    ## Defines the name of the additional main HiveMQ file based license (the .lic suffix will be added automatically).
+    #license-name:
+    #  # Inlines the additional main HiveMQ file based license as a string.
+    #  # By default, this data is expected as Base64 encoded string. Set "isLicenseBase64Encoded=false" to provide a plain string.
+    #  data: ""
+  #  # Overrides the additional main HiveMQ file based license via file using --set-file additional-license.lic.
+  #  overrideLicense: ""
+
+  # HiveMQ Enterprise Extension licenses to include as part of the Kubernetes Secret. Add your required licenses to the list.
+  extensions: {}
+    ## Defines the name of the HiveMQ Enterprise Extension license in the Kubernetes Secret (the .elic suffix will be added automatically).
+    #extension-license-name:
+    #  # Inlines the HiveMQ Enterprise Extension license as a string.
+    #  # By default, this data is expected as Base64 encoded string. Set "isLicenseBase64Encoded=false" to provide a plain string.
+    #  data: ""
+    #  # Overrides the HiveMQ Enterprise Extension license via file using --set-file license.elic.
+    #  overrideLicense: ""
+    ## Example of a HiveMQ Enterprise Extension for Kafka license configuration:
+    ## license:
+    ##   create: true
+    ##   extensions:
+  ##     hivemq-kafka-extension-license:
+  ##       data: kafka-license-content
+
+  # HiveMQ Data Hub licenses to include as part of the Kubernetes Secret.
+  dataHub: {}
+    ## Defines the name of the HiveMQ Data Hub license in the Kubernetes Secret (the .plic suffix will be added automatically).
+    #data-hub-license-name:
+    #  # Inlines the HiveMQ Data Hub license as a string.
+    #  # By default, this data is expected as Base64 encoded string. Set "isLicenseBase64Encoded=false" to provide a plain string.
+    #  data: ""
+  #  # Overrides the HiveMQ Data Hub license via file using --set-file license.plic.
+  #  overrideLicense: ""

--- a/charts/hivemq-platform/values.yaml
+++ b/charts/hivemq-platform/values.yaml
@@ -572,6 +572,14 @@ config:
   # Inlines a custom HiveMQ Platform logging configuration (logback.xml) from a file:
   # --set-file config.customLogbackConfig=your-logback.xml
   customLogbackConfig: ""
+  # Configures the HiveMQ Platform license configuration (license.xml).
+  # When set, the license.xml file is included in the HiveMQ Platform configuration ConfigMap or Secret.
+  platformLicense:
+    # The platform license key identifier.
+    licenseKey: ""
+    # Inlines the HiveMQ Platform license configuration (license.xml) from a file:
+    # --set-file config.platformLicense.overrideLicenseConfig=your-license.xml
+    overrideLicenseConfig: ""
 
 # Custom init containers to be added to the HiveMQ platform StatefulSet
 additionalInitContainers: []


### PR DESCRIPTION
## Summary

- Adds `config.platformLicense.licenseKey` and `config.platformLicense.overrideLicenseConfig` values to configure the new HiveMQ Platform license configuration (`license.xml`)
- When set, `license.xml` is conditionally included in the existing HiveMQ configuration ConfigMap or Secret alongside `config.xml`, `tracing.xml`, and `logback.xml`
- Adds validation that `licenseKey` and `overrideLicenseConfig` cannot both be set simultaneously

Relates to [INT-201](https://linear.app/hivemq/issue/INT-201/helm-add-platform-license-configuration-licensexml-to-hivemq-platform)

## Changes

- **`values.yaml`**: New `config.platformLicense` section with `licenseKey` and `overrideLicenseConfig`
- **`values.schema.json`**: Schema entries for the new values
- **`_helpers.tpl`**: Three new helpers — `has-platform-license-config`, `default-platform-license-configuration`, `generate-platform-license-configuration`, and `validate-platform-license-config`
- **`hivemq-configuration.yml`**: Conditional `license.xml` entry with validation
- **Unit tests**: 10 new tests (5 ConfigMap + 5 Secret) covering default behavior, licenseKey, overrideLicenseConfig, mutual exclusion validation, and config.create=false edge case

## Test plan

- [x] `helm lint charts/hivemq-platform` passes
- [x] All 1468 unit tests pass (`helm unittest ./charts/hivemq-platform -f './tests/**/*_test.yaml'`)
- [x] Manifests unchanged after regeneration (`./gradlew updateAllManifestFiles`)
- [x] `license.xml` is generated only when `config.platformLicense.licenseKey` or `config.platformLicense.overrideLicenseConfig` is set
- [x] Setting both values fails with a clear error message
- [x] Works with both `config.createAs: ConfigMap` and `config.createAs: Secret`