### PR TITLE
INT-210 Migrate to OCI version catalog plugin

### DIFF
--- a/.github/workflows/platform-integration-tests.yml
+++ b/.github/workflows/platform-integration-tests.yml
@@ -112,6 +112,7 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_dockerHubUsername: ${{ secrets.DOCKER_USERNAME }}
           ORG_GRADLE_PROJECT_dockerHubPassword: ${{ secrets.DOCKER_TOKEN }}
+          K8S_VERSION_TYPE: ${{ matrix.k8s-version-type }}
         run: ./gradlew :tests-hivemq-platform-operator:integrationTestPrepare
 
       - name: Split tests

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,18 +11,16 @@
     addLabels: [
         'integrations-team-coordination',
     ],
-    customManagers: [
+    packageRules: [
         {
-            customType: 'regex',
-            datasourceTemplate: 'docker',
-            description: 'Custom Manager for Docker images',
-            managerFilePatterns: [
-                '(^|/)docker.versions.toml$',
+            description: 'OCI image dependency is not a real Maven package (gradle-oci plugin)',
+            matchManagers: [
+                'gradle',
             ],
-            matchStrings: [
-                '.* = \\{ image = "(?<packageName>.+)", tag = "(?<currentValue>.+)" \\}',
+            matchPackageNames: [
+                'com.hivemq:hivemq-enterprise-k8s',
             ],
-            versioningTemplate: 'docker',
+            enabled: false,
         },
     ],
 }

--- a/tests-hivemq-platform-operator/build.gradle.kts
+++ b/tests-hivemq-platform-operator/build.gradle.kts
@@ -1,15 +1,5 @@
-import com.fasterxml.jackson.dataformat.toml.TomlMapper
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath(libs.jackson.dataformat.toml)
-    }
-}
 
 plugins {
     java
@@ -106,11 +96,11 @@ testing {
                     runtime("com.hivemq:hivemq-platform-operator-init").tag("snapshot")
                     runtime("com.hivemq:hivemq-enterprise:$hivemqVersion").tag("latest")
                     runtime("com.hivemq:hivemq-enterprise-k8s:4.47.1").tag("k8s-latest")
-                    runtime("hivemq:hivemq-operator:4.7.10").tag("latest")
-                    runtime("hivemq:init-dns-wait:1.0.1").tag("latest")
-                    runtime("library:busybox:1.37.0").name("busybox").tag("latest")
-                    runtime("library:nginx:1.29.7").name("nginx").tag("latest")
-                    runtime("selenium:standalone-firefox:148.0-20260222").tag("latest")
+                    runtime(ociImages.hivemq.operator.oci).tag("latest")
+                    runtime(ociImages.init.dns.wait.oci).tag("latest")
+                    runtime(ociImages.busybox.oci).name("busybox").tag("latest")
+                    runtime(ociImages.nginx.oci).name("nginx").tag("latest")
+                    runtime(ociImages.selenium.standalone.firefox.oci).tag("latest")
                 }
                 val linuxAmd64 = platformSelector(platform("linux", "amd64"))
                 val linuxArm64v8 = platformSelector(platform("linux", "arm64", "v8"))
@@ -168,8 +158,7 @@ oci {
     }
     parentImageDependencies {
         create("noble") {
-            // https://hub.docker.com/layers/library/ubuntu/noble/
-            runtime("library:ubuntu:sha256!186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c") // noble
+            runtime(ociImages.ubuntu.noble.oci)
         }
     }
     imageDefinitions {
@@ -239,12 +228,8 @@ val updatePlatformVersion by tasks.registering {
 }
 
 fun resolveK3sTag(): String {
-    val tomlFile = projectDir.resolve("gradle").resolve("docker.versions.toml")
-    val tomlDocker = TomlMapper().readTree(tomlFile).path("docker")
-
     val k8sVersionType = System.getenv("K8S_VERSION_TYPE") ?: "LATEST"
-    val key = if (k8sVersionType == "MINIMUM") "k3s-minimum" else "k3s-latest"
-    val tag = tomlDocker.path(key).path("tag").asText()
+    val tag = if (k8sVersionType == "MINIMUM") ociImages.k3s.minimum.tag else ociImages.k3s.latest.tag
     println("Resolving test OCI image k3s:$tag ($k8sVersionType)")
-    return tag
+    return tag!!
 }

--- a/tests-hivemq-platform-operator/gradle/docker.versions.toml
+++ b/tests-hivemq-platform-operator/gradle/docker.versions.toml
@@ -1,5 +1,0 @@
-[docker]
-# https://hub.docker.com/r/rancher/k3s/tags?page=1&name=v1.24
-k3s-minimum = { image = "rancher/k3s", tag = "v1.24.17-k3s1", update = false }
-# https://hub.docker.com/r/rancher/k3s/tags?page=1&name=v1.35
-k3s-latest = { image = "rancher/k3s", tag = "v1.35.3-k3s1" }

--- a/tests-hivemq-platform-operator/gradle/libs.versions.toml
+++ b/tests-hivemq-platform-operator/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ kubernetes = "7.6.1"
 gradleOci-junitJupiter = "0.8.0"
 hivemq-mqttClient = "1.3.13"
 hivemq-platform = "4.50.0"
-jackson = "2.21.2"
 javassist = "3.30.2-GA"
 junit-jupiter = "6.0.3"
 logback = "1.5.32"
@@ -26,7 +25,6 @@ kubernetes-client-jdk = { module = "io.fabric8:kubernetes-httpclient-jdk", versi
 gradleOci-junitJupiter = { module = "io.github.sgtsilvio:gradle-oci-junit-jupiter", version.ref = "gradleOci-junitJupiter" }
 hivemq-extensionSdk = { module = "com.hivemq:hivemq-extension-sdk", version.ref = "hivemq-platform" }
 hivemq-mqttClient = { module = "com.hivemq:hivemq-mqtt-client", version.ref = "hivemq-mqttClient" }
-jackson-dataformat-toml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-toml", version.ref = "jackson" }
 javassist = { module = "org.javassist:javassist", version.ref = "javassist" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-jupiter" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }

--- a/tests-hivemq-platform-operator/gradle/oci.versions.toml
+++ b/tests-hivemq-platform-operator/gradle/oci.versions.toml
@@ -1,0 +1,58 @@
+# https://hub.docker.com/_/ubuntu/tags?name=noble
+[[oci]]
+name = "ubuntu-noble"
+image = "library/ubuntu"
+digest = "sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c"
+tag = "noble"
+
+# https://hub.docker.com/r/rancher/k3s/tags?page=1&name=v1.24
+[[oci]]
+name = "k3s-minimum"
+image = "rancher/k3s"
+digest = "sha256:9e034931999854c6210b86a0708fde66b91370459fa077a4f9d008e7f51fc51d"
+tag = "v1.24.17-k3s1"
+update = false
+
+# https://hub.docker.com/r/rancher/k3s/tags?page=1&name=v1.35
+[[oci]]
+name = "k3s-latest"
+image = "rancher/k3s"
+digest = "sha256:4607083d3cac07e1ccde7317297271d13ed5f60f35a78f33fcef84858a9f1d69"
+tag = "v1.35.3-k3s1"
+
+# https://hub.docker.com/_/busybox/tags?name=latest
+[[oci]]
+name = "busybox"
+image = "library/busybox"
+digest = "sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e"
+tag = "latest"
+
+# https://hub.docker.com/_/nginx/tags?name=latest
+[[oci]]
+name = "nginx"
+image = "library/nginx"
+digest = "sha256:7150b3a39203cb5bee612ff4a9d18774f8c7caf6399d6e8985e97e28eb751c18"
+tag = "latest"
+
+# https://hub.docker.com/r/selenium/standalone-firefox/tags?name=148
+[[oci]]
+name = "selenium-standalone-firefox"
+image = "selenium/standalone-firefox"
+digest = "sha256:14fde146732a1bab99f1423ac171eb61a38706710ffe8b71c887a8ada6052631"
+tag = "148.0-20260222"
+
+# https://hub.docker.com/r/hivemq/hivemq-operator/tags
+[[oci]]
+name = "hivemq-operator"
+image = "hivemq/hivemq-operator"
+digest = "sha256:241d6a8e1963968ebafb7f63396c56e1d8e41fc4065ee6257679ba5e3cf127f0"
+tag = "4.7.10"
+update = false
+
+# https://hub.docker.com/r/hivemq/init-dns-wait/tags
+[[oci]]
+name = "init-dns-wait"
+image = "hivemq/init-dns-wait"
+digest = "sha256:96f972c3029a2bab716c43c5404280030ecd98d199bd9cbe5de0f495a8f06945"
+tag = "1.0.1"
+update = false

--- a/tests-hivemq-platform-operator/settings.gradle.kts
+++ b/tests-hivemq-platform-operator/settings.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("com.hivemq.tools.oci-version-catalog") version "0.1.0"
+}
+
 rootProject.name = "tests-hivemq-platform-operator"
 
 if (file("../../hivemq-platform-operator/hivemq-platform-operator-init").exists()) {


### PR DESCRIPTION
- Add `gradle/oci.versions.toml` with OCI image definitions
- Apply `com.hivemq.tools.oci-version-catalog` settings plugin
- Replace hardcoded `sha256!` digests and tag-based `runtime()` calls with `ociImages.*` accessors
- Replace Jackson TOML-based `resolveK3sTag()` with `ociImages.k3s.*.tag`
- Remove old `docker.versions.toml` and regex Renovate custom manager
- Remove `jackson-dataformat-toml` buildscript dependency