### PR TITLE
Use unique Helm release names per test class

### DIFF
--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/AbstractHelmChartIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/AbstractHelmChartIT.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import static com.hivemq.helmcharts.util.K8sUtil.MAX_RELEASE_NAME_LENGTH;
 import static com.hivemq.helmcharts.util.K8sUtil.getNamespaceName;
 import static com.hivemq.helmcharts.util.K8sUtil.getOperatorNamespaceName;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,17 +39,8 @@ public abstract class AbstractHelmChartIT {
     protected static final @NotNull String PLATFORM_CRD = "hivemq-platforms.hivemq.com";
 
     protected static final @NotNull String DEFAULT_OPERATOR_NAME_PREFIX = "hivemq";
-    protected static final @NotNull String PLATFORM_RELEASE_NAME = "test-hivemq-platform";
-    protected static final @NotNull String OPERATOR_RELEASE_NAME = "test-hivemq-platform-operator";
-    protected static final @NotNull String LEGACY_RELEASE_NAME = "test-hivemq-legacy-platform";
 
     protected static final int DEFAULT_MQTT_SERVICE_PORT = 1883;
-    protected static final @NotNull String DEFAULT_MQTT_SERVICE_NAME =
-            "hivemq-%s-mqtt-%s".formatted(PLATFORM_RELEASE_NAME, DEFAULT_MQTT_SERVICE_PORT);
-
-    protected static final @NotNull String PLATFORM_LOG_WAITER_PREFIX = PLATFORM_RELEASE_NAME + "-0";
-    protected static final @NotNull String OPERATOR_LOG_WAITER_PREFIX =
-            "%s-%s-.*".formatted(DEFAULT_OPERATOR_NAME_PREFIX, OPERATOR_RELEASE_NAME);
 
     protected static @NotNull HelmChartContainer helmChartContainer;
     protected static @NotNull Network network;
@@ -57,6 +49,18 @@ public abstract class AbstractHelmChartIT {
 
     protected final @NotNull String platformNamespace = getNamespaceName(getClass());
     protected final @NotNull String operatorNamespace = getOperatorNamespaceName(getClass());
+
+    protected final @NotNull String releaseBaseName = getReleaseBaseName();
+    protected final @NotNull String platformReleaseName = releaseBaseName + "-pf";
+    protected final @NotNull String operatorReleaseName = releaseBaseName + "-op";
+    protected final @NotNull String legacyReleaseName = releaseBaseName + "-lg";
+
+    protected final @NotNull String defaultMqttServiceName =
+            "hivemq-%s-mqtt-%s".formatted(platformReleaseName, DEFAULT_MQTT_SERVICE_PORT);
+
+    protected final @NotNull String platformLogWaiterPrefix = platformReleaseName + "-0";
+    protected final @NotNull String operatorLogWaiterPrefix =
+            "%s-%s-.*".formatted(DEFAULT_OPERATOR_NAME_PREFIX, operatorReleaseName);
 
     @BeforeAll
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
@@ -78,6 +82,9 @@ public abstract class AbstractHelmChartIT {
     @BeforeEach
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     final void baseSetUp() throws Exception {
+        assertThat(platformReleaseName).as("platformReleaseName").hasSizeLessThanOrEqualTo(MAX_RELEASE_NAME_LENGTH);
+        assertThat(operatorReleaseName).as("operatorReleaseName").hasSizeLessThanOrEqualTo(MAX_RELEASE_NAME_LENGTH);
+        assertThat(legacyReleaseName).as("legacyReleaseName").hasSizeLessThanOrEqualTo(MAX_RELEASE_NAME_LENGTH);
         if (createOperatorNamespace()) {
             helmChartContainer.createNamespace(operatorNamespace);
         }
@@ -85,7 +92,7 @@ public abstract class AbstractHelmChartIT {
             helmChartContainer.createNamespace(platformNamespace);
         }
         if (installPlatformOperatorChart()) {
-            helmChartContainer.installPlatformOperatorChart(OPERATOR_RELEASE_NAME, "--namespace", operatorNamespace);
+            helmChartContainer.installPlatformOperatorChart(operatorReleaseName, "--namespace", operatorNamespace);
         }
     }
 
@@ -94,11 +101,11 @@ public abstract class AbstractHelmChartIT {
     final void baseTearDown() throws Exception {
         try {
             if (uninstallPlatformChart()) {
-                helmChartContainer.uninstallRelease(PLATFORM_RELEASE_NAME, platformNamespace, true);
+                helmChartContainer.uninstallRelease(platformReleaseName, platformNamespace, true);
             }
         } finally {
             if (uninstallPlatformOperatorChart()) {
-                helmChartContainer.uninstallRelease(OPERATOR_RELEASE_NAME, operatorNamespace, true);
+                helmChartContainer.uninstallRelease(operatorReleaseName, operatorNamespace, true);
             }
             K8sUtil.deleteCrd(client, PLATFORM_CRD);
         }
@@ -110,10 +117,11 @@ public abstract class AbstractHelmChartIT {
         installLegacyOperatorChartAndWaitToBeRunning("-f", valuesResourceFile);
     }
 
-    protected void installLegacyOperatorChartAndWaitToBeRunning(final @NotNull String... commands) throws Exception {
-        helmChartContainer.installLegacyOperatorChart(LEGACY_RELEASE_NAME, addDefaultOperatorCommands(commands));
-        K8sUtil.waitForLegacyOperatorPodStateRunning(client, operatorNamespace, LEGACY_RELEASE_NAME);
-        K8sUtil.waitForLegacyHiveMQPlatformStateRunning(client, operatorNamespace, LEGACY_RELEASE_NAME);
+    protected void installLegacyOperatorChartAndWaitToBeRunning(final @NotNull String... commands)
+            throws Exception {
+        helmChartContainer.installLegacyOperatorChart(legacyReleaseName, addDefaultOperatorCommands(commands));
+        K8sUtil.waitForLegacyOperatorPodStateRunning(client, operatorNamespace, legacyReleaseName);
+        K8sUtil.waitForLegacyHiveMQPlatformStateRunning(client, operatorNamespace, legacyReleaseName);
     }
 
     protected void installPlatformOperatorChartAndWaitToBeRunning(final @NotNull String valuesResourceFile)
@@ -121,18 +129,20 @@ public abstract class AbstractHelmChartIT {
         installPlatformOperatorChartAndWaitToBeRunning("-f", valuesResourceFile);
     }
 
-    protected void installPlatformOperatorChartAndWaitToBeRunning(final @NotNull String... commands) throws Exception {
-        helmChartContainer.installPlatformOperatorChart(OPERATOR_RELEASE_NAME, addDefaultOperatorCommands(commands));
-        K8sUtil.waitForPlatformOperatorPodStateRunning(client, operatorNamespace, OPERATOR_RELEASE_NAME);
+    protected void installPlatformOperatorChartAndWaitToBeRunning(final @NotNull String... commands)
+            throws Exception {
+        helmChartContainer.installPlatformOperatorChart(operatorReleaseName, addDefaultOperatorCommands(commands));
+        K8sUtil.waitForPlatformOperatorPodStateRunning(client, operatorNamespace, operatorReleaseName);
     }
 
-    protected void installPlatformChartAndWaitToBeRunning(final @NotNull String valuesResourceFile) throws Exception {
+    protected void installPlatformChartAndWaitToBeRunning(final @NotNull String valuesResourceFile)
+            throws Exception {
         installPlatformChartAndWaitToBeRunning("-f", valuesResourceFile);
     }
 
     protected void installPlatformChartAndWaitToBeRunning(final @NotNull String... commands) throws Exception {
-        installPlatformChart(PLATFORM_RELEASE_NAME, commands);
-        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        installPlatformChart(platformReleaseName, commands);
+        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, platformReleaseName);
     }
 
     protected void installPlatformChart(final @NotNull String releaseName, final @NotNull String... commands)
@@ -144,6 +154,15 @@ public abstract class AbstractHelmChartIT {
     protected void upgradePlatformChart(final @NotNull String releaseName, final @NotNull String... commands)
             throws Exception {
         helmChartContainer.upgradePlatformChart(releaseName, addDefaultPlatformCommands(commands));
+    }
+
+    /**
+     * Override to provide a custom release base name, e.g. when the default truncated name would collide with
+     * another test class. The suffixes {@code -pf}, {@code -op}, and {@code -lg} are appended automatically.
+     * The returned base name must not exceed {@value K8sUtil#MAX_RELEASE_BASE_NAME_LENGTH} characters.
+     */
+    protected @NotNull String getReleaseBaseName() {
+        return K8sUtil.getReleaseBaseName(getClass());
     }
 
     /**
@@ -187,15 +206,15 @@ public abstract class AbstractHelmChartIT {
     }
 
     protected final @NotNull CompletableFuture<String> waitForOperatorLog(final @NotNull String log) {
-        return logWaiter.waitFor(OPERATOR_LOG_WAITER_PREFIX, log);
+        return logWaiter.waitFor(operatorLogWaiterPrefix, log);
     }
 
     protected final @NotNull CompletableFuture<String> waitForPlatformLog(final @NotNull String log) {
-        return logWaiter.waitFor(PLATFORM_LOG_WAITER_PREFIX, log);
+        return logWaiter.waitFor(platformLogWaiterPrefix, log);
     }
 
     protected final @NotNull CompletableFuture<String> waitForInitAppLog(final @NotNull String log) {
-        return logWaiter.waitFor(PLATFORM_LOG_WAITER_PREFIX,
+        return logWaiter.waitFor(platformLogWaiterPrefix,
                 ".*\\[HiveMQ Platform Operator Init App [A-Z0-9.-]+\\] " + log);
     }
 
@@ -210,8 +229,8 @@ public abstract class AbstractHelmChartIT {
         }
     }
 
-    protected static @NotNull String getOperatorName() {
-        return "%s-%s".formatted(DEFAULT_OPERATOR_NAME_PREFIX, OPERATOR_RELEASE_NAME);
+    protected @NotNull String getOperatorName() {
+        return "%s-%s".formatted(DEFAULT_OPERATOR_NAME_PREFIX, operatorReleaseName);
     }
 
     private @NotNull String @NotNull [] addDefaultOperatorCommands(final @NotNull String... commands) {

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/AbstractHelmChartIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/AbstractHelmChartIT.java
@@ -112,46 +112,46 @@ public abstract class AbstractHelmChartIT {
     }
 
     @SuppressWarnings("SameParameterValue")
-    protected void installLegacyOperatorChartAndWaitToBeRunning(final @NotNull String valuesResourceFile)
+    protected final void installLegacyOperatorChartAndWaitToBeRunning(final @NotNull String valuesResourceFile)
             throws Exception {
         installLegacyOperatorChartAndWaitToBeRunning("-f", valuesResourceFile);
     }
 
-    protected void installLegacyOperatorChartAndWaitToBeRunning(final @NotNull String... commands)
+    protected final void installLegacyOperatorChartAndWaitToBeRunning(final @NotNull String... commands)
             throws Exception {
         helmChartContainer.installLegacyOperatorChart(legacyReleaseName, addDefaultOperatorCommands(commands));
         K8sUtil.waitForLegacyOperatorPodStateRunning(client, operatorNamespace, legacyReleaseName);
         K8sUtil.waitForLegacyHiveMQPlatformStateRunning(client, operatorNamespace, legacyReleaseName);
     }
 
-    protected void installPlatformOperatorChartAndWaitToBeRunning(final @NotNull String valuesResourceFile)
+    protected final void installPlatformOperatorChartAndWaitToBeRunning(final @NotNull String valuesResourceFile)
             throws Exception {
         installPlatformOperatorChartAndWaitToBeRunning("-f", valuesResourceFile);
     }
 
-    protected void installPlatformOperatorChartAndWaitToBeRunning(final @NotNull String... commands)
+    protected final void installPlatformOperatorChartAndWaitToBeRunning(final @NotNull String... commands)
             throws Exception {
         helmChartContainer.installPlatformOperatorChart(operatorReleaseName, addDefaultOperatorCommands(commands));
         K8sUtil.waitForPlatformOperatorPodStateRunning(client, operatorNamespace, operatorReleaseName);
     }
 
-    protected void installPlatformChartAndWaitToBeRunning(final @NotNull String valuesResourceFile)
+    protected final void installPlatformChartAndWaitToBeRunning(final @NotNull String valuesResourceFile)
             throws Exception {
         installPlatformChartAndWaitToBeRunning("-f", valuesResourceFile);
     }
 
-    protected void installPlatformChartAndWaitToBeRunning(final @NotNull String... commands) throws Exception {
+    protected final void installPlatformChartAndWaitToBeRunning(final @NotNull String... commands) throws Exception {
         installPlatformChart(platformReleaseName, commands);
         K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, platformReleaseName);
     }
 
-    protected void installPlatformChart(final @NotNull String releaseName, final @NotNull String... commands)
+    protected final void installPlatformChart(final @NotNull String releaseName, final @NotNull String... commands)
             throws Exception {
         helmChartContainer.installPlatformChart(releaseName, addDefaultPlatformCommands(commands));
     }
 
     @SuppressWarnings("SameParameterValue")
-    protected void upgradePlatformChart(final @NotNull String releaseName, final @NotNull String... commands)
+    protected final void upgradePlatformChart(final @NotNull String releaseName, final @NotNull String... commands)
             throws Exception {
         helmChartContainer.upgradePlatformChart(releaseName, addDefaultPlatformCommands(commands));
     }
@@ -229,7 +229,7 @@ public abstract class AbstractHelmChartIT {
         }
     }
 
-    protected @NotNull String getOperatorName() {
+    protected final @NotNull String getOperatorName() {
         return "%s-%s".formatted(DEFAULT_OPERATOR_NAME_PREFIX, operatorReleaseName);
     }
 

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/containers/HelmAdditionalContainersIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/containers/HelmAdditionalContainersIT.java
@@ -20,7 +20,7 @@ class HelmAdditionalContainersIT extends AbstractHelmChartIT {
 
         await().untilAsserted(() -> {
             final var statefulSet =
-                    client.apps().statefulSets().inNamespace(platformNamespace).withName(PLATFORM_RELEASE_NAME).get();
+                    client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
             assertThat(statefulSet).isNotNull();
             final var hivemqContainer = K8sUtil.getHiveMQContainer(statefulSet.getSpec());
             assertThat(hivemqContainer.getVolumeMounts().stream()) //

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/containers/HelmInitContainerConsulTemplateIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/containers/HelmInitContainerConsulTemplateIT.java
@@ -25,7 +25,7 @@ class HelmInitContainerConsulTemplateIT extends AbstractHelmChartIT {
 
         await().atMost(TWO_MINUTES).untilAsserted(() -> {
             final var statefulSet =
-                    client.apps().statefulSets().inNamespace(platformNamespace).withName(PLATFORM_RELEASE_NAME).get();
+                    client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
             assertThat(statefulSet).isNotNull();
             final var hivemqContainer = K8sUtil.getHiveMQContainer(statefulSet.getSpec());
             assertThat(hivemqContainer.getVolumeMounts().stream()) //

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/containers/HelmInitContainerIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/containers/HelmInitContainerIT.java
@@ -32,7 +32,7 @@ class HelmInitContainerIT extends AbstractHelmChartIT {
 
         await().untilAsserted(() -> {
             final var statefulSet =
-                    client.apps().statefulSets().inNamespace(platformNamespace).withName(PLATFORM_RELEASE_NAME).get();
+                    client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
             assertThat(statefulSet).isNotNull();
             final var template = statefulSet.getSpec().getTemplate();
             assertThat(template.getSpec().getVolumes()).isNotEmpty().map(Volume::getName).contains(mountName);
@@ -41,7 +41,7 @@ class HelmInitContainerIT extends AbstractHelmChartIT {
 
             await().untilAsserted(() -> assertThat(client.pods()
                     .inNamespace(platformNamespace)
-                    .withName(PLATFORM_RELEASE_NAME + "-0")
+                    .withName(platformReleaseName + "-0")
                     .get()) //
                     .isNotNull() //
                     .satisfies(this::assertThatFileContains));

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/extensions/AbstractHelmBridgeExtensionIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/extensions/AbstractHelmBridgeExtensionIT.java
@@ -49,7 +49,7 @@ abstract class AbstractHelmBridgeExtensionIT extends AbstractHelmChartIT {
         // assert MQTT messages are bridged
         MqttUtil.execute(client,
                 platformNamespace,
-                DEFAULT_MQTT_SERVICE_NAME,
+                defaultMqttServiceName,
                 DEFAULT_MQTT_SERVICE_PORT,
                 portForward -> getBlockingClient(portForward, "PublishClient"),
                 portForward -> getBlockingClient(hivemqContainer.getHost(),
@@ -70,12 +70,12 @@ abstract class AbstractHelmBridgeExtensionIT extends AbstractHelmChartIT {
     }
 
     protected @NotNull CompletableFuture<String> brokerExtensionStartedFuture() {
-        return logWaiter.waitFor(PLATFORM_LOG_WAITER_PREFIX,
+        return logWaiter.waitFor(platformLogWaiterPrefix,
                 ".*Extension \"HiveMQ Enterprise Bridge Extension\" version .* started successfully.");
     }
 
     protected @NotNull CompletableFuture<String> brokerExtensionStoppedFuture() {
-        return logWaiter.waitFor(PLATFORM_LOG_WAITER_PREFIX,
+        return logWaiter.waitFor(platformLogWaiterPrefix,
                 ".*Extension \"HiveMQ Enterprise Bridge Extension\" version .* stopped successfully.");
     }
 

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/extensions/HelmDataHubIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/extensions/HelmDataHubIT.java
@@ -15,8 +15,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class HelmDataHubIT extends AbstractHelmChartIT {
 
-    private static final @NotNull String REST_API_SERVICE_NAME = "hivemq-test-hivemq-platform-rest-8890";
     private static final int REST_API_SERVICE_PORT = 8890;
+
+    private final @NotNull String restApiServiceName =
+            "hivemq-%s-rest-%s".formatted(platformReleaseName, REST_API_SERVICE_PORT);
 
     @Test
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
@@ -26,7 +28,7 @@ class HelmDataHubIT extends AbstractHelmChartIT {
         // forward the port from the service
         try (final var forwarded = K8sUtil.getPortForward(client,
                 platformNamespace,
-                REST_API_SERVICE_NAME,
+                restApiServiceName,
                 REST_API_SERVICE_PORT)) {
             final var baseRestApiEndpoint = "http://localhost:" + forwarded.getLocalPort();
 

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/extensions/HelmExtensionPriorityIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/extensions/HelmExtensionPriorityIT.java
@@ -28,10 +28,12 @@ import static org.awaitility.Durations.ONE_MINUTE;
 
 class HelmExtensionPriorityIT extends AbstractHelmChartIT {
 
-    private static final @NotNull String MQTT_SERVICE_NAME = "hivemq-test-hivemq-platform-mqtt-1884";
     private static final int MQTT_SERVICE_PORT = 1884;
 
     private static final @NotNull Logger LOG = LoggerFactory.getLogger(HelmExtensionPriorityIT.class);
+
+    private final @NotNull String mqttServiceName =
+            "hivemq-%s-mqtt-%s".formatted(platformReleaseName, MQTT_SERVICE_PORT);
 
     @TempDir
     private @NotNull Path tmp;
@@ -75,7 +77,7 @@ class HelmExtensionPriorityIT extends AbstractHelmChartIT {
         await().atMost(ONE_MINUTE).until(bazExtensionStartedFuture::isDone);
         await().untilAsserted(() -> assertThat(client.pods()
                 .inNamespace(platformNamespace)
-                .withName(PLATFORM_RELEASE_NAME + "-0")
+                .withName(platformReleaseName + "-0")
                 .get()) //
                 .isNotNull() //
                 .satisfies(pod -> {
@@ -93,11 +95,11 @@ class HelmExtensionPriorityIT extends AbstractHelmChartIT {
                             "<start-priority>3000</start-priority>");
                 }));
 
-        K8sUtil.assertMqttService(client, platformNamespace, MQTT_SERVICE_NAME);
+        K8sUtil.assertMqttService(client, platformNamespace, mqttServiceName);
 
         MqttUtil.execute(client,
                 platformNamespace,
-                MQTT_SERVICE_NAME,
+                mqttServiceName,
                 MQTT_SERVICE_PORT,
                 (publishClient, subscribeClient, publishes) -> {
                     subscribeClient.subscribeWith().topicFilter("topic").send();

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/extensions/HelmUpgradeExtensionIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/extensions/HelmUpgradeExtensionIT.java
@@ -26,7 +26,7 @@ class HelmUpgradeExtensionIT extends AbstractHelmBridgeExtensionIT {
         await().until(extensionEnabledInitAppFuture::isDone);
         await().until(extensionStartedBrokerFuture::isDone);
 
-        final var hivemqCustomResource = K8sUtil.getHiveMQPlatform(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        final var hivemqCustomResource = K8sUtil.getHiveMQPlatform(client, platformNamespace, platformReleaseName);
         // check that extensions are enabled
         assertThat(hivemqCustomResource.get().getAdditionalProperties().get("spec").toString()).matches(
                 ".*extensions=\\[.*?enabled=true,.*?id=hivemq-bridge-extension,.*?].*");
@@ -35,7 +35,7 @@ class HelmUpgradeExtensionIT extends AbstractHelmBridgeExtensionIT {
         final var extensionStoppedBrokerFuture = brokerExtensionStoppedFuture();
         final var extensionStoppedInitAppFuture = initAppExtensionStoppedFuture();
         final var extensionUpdateDoneInitAppFuture = initAppExtensionUpdateDoneFuture();
-        upgradePlatformChart(PLATFORM_RELEASE_NAME, "-f", "/files/disable-bridge-values.yaml");
+        upgradePlatformChart(platformReleaseName, "-f", "/files/disable-bridge-values.yaml");
 
         hivemqCustomResource.waitUntilCondition(K8sUtil.getCustomResourceStateCondition("RESTART_EXTENSIONS"),
                 1,

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/extensions/HelmUpgradeExtensionWithNewConfigIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/extensions/HelmUpgradeExtensionWithNewConfigIT.java
@@ -31,7 +31,7 @@ class HelmUpgradeExtensionWithNewConfigIT extends AbstractHelmBridgeExtensionIT 
         await().until(extensionStartedBrokerFuture1::isDone);
 
         // check that extensions are enabled
-        final var hivemqCustomResource = K8sUtil.getHiveMQPlatform(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        final var hivemqCustomResource = K8sUtil.getHiveMQPlatform(client, platformNamespace, platformReleaseName);
         assertThat(hivemqCustomResource.get().getAdditionalProperties().get("spec").toString()).matches(
                 ".*extensions=\\[.*?enabled=true,.*?id=hivemq-bridge-extension,.*?].*");
 
@@ -41,13 +41,13 @@ class HelmUpgradeExtensionWithNewConfigIT extends AbstractHelmBridgeExtensionIT 
         K8sUtil.createConfigMap(client, platformNamespace, "updated-test-bridge-configuration", bridgeConfiguration);
 
         // upgrade chart and wait to be ready
-        upgradePlatformChart(PLATFORM_RELEASE_NAME, "-f", "/files/bridge-updated-values.yaml");
-        K8sUtil.waitForHiveMQPlatformStateRunningAfterRollingRestart(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        upgradePlatformChart(platformReleaseName, "-f", "/files/bridge-updated-values.yaml");
+        K8sUtil.waitForHiveMQPlatformStateRunningAfterRollingRestart(client, platformNamespace, platformReleaseName);
         await().until(extensionEnabledInitAppFuture2::isDone);
         await().until(extensionStartedBrokerFuture2::isDone);
 
         final var upgradedStatefulSet =
-                client.apps().statefulSets().inNamespace(platformNamespace).withName(PLATFORM_RELEASE_NAME).get();
+                client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
         assertThat(upgradedStatefulSet.getStatus().getAvailableReplicas()).isEqualTo(1);
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/AbstractHelmLicensesIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/AbstractHelmLicensesIT.java
@@ -13,7 +13,7 @@ abstract class AbstractHelmLicensesIT extends AbstractHelmChartIT {
     protected void assertLicense(final @NotNull String licenseSecretName) {
         await().atMost(TWO_MINUTES).untilAsserted(() -> {
             final var statefulSet =
-                    client.apps().statefulSets().inNamespace(platformNamespace).withName(PLATFORM_RELEASE_NAME).get();
+                    client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
             assertThat(statefulSet).isNotNull();
             assertThat(K8sUtil.getHiveMQContainer(statefulSet.getSpec()).getVolumeMounts().stream()) //
                     .anyMatch(volumeMount -> volumeMount.getName().equals("licenses") &&

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/HelmAdditionalBrokerExistingSecretLicensesIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/HelmAdditionalBrokerExistingSecretLicensesIT.java
@@ -17,7 +17,7 @@ class HelmAdditionalBrokerExistingSecretLicensesIT extends AbstractHelmLicensesI
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void withExistingAdditionalBrokerLicenseFileContent_statefulSetWithLicenseSecretMounted() throws Exception {
         final var brokerLicenseFuture =
-                logWaiter.waitFor(PLATFORM_LOG_WAITER_PREFIX, ".*License file license.lic is corrupt.");
+                logWaiter.waitFor(platformLogWaiterPrefix, ".*License file license.lic is corrupt.");
         K8sUtil.createSecret(client,
                 platformNamespace,
                 "test-additional-broker-license",

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/HelmAdditionalBrokerLicensesIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/HelmAdditionalBrokerLicensesIT.java
@@ -13,14 +13,14 @@ class HelmAdditionalBrokerLicensesIT extends AbstractHelmLicensesIT {
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void withAdditionalBrokerLicenseFileContent_statefulSetWithLicenseSecretMounted() throws Exception {
         final var brokerLicenseFuture =
-                logWaiter.waitFor(PLATFORM_LOG_WAITER_PREFIX, ".*License file broker.lic is corrupt.");
+                logWaiter.waitFor(platformLogWaiterPrefix, ".*License file broker.lic is corrupt.");
         installPlatformChartAndWaitToBeRunning("--set",
                 "nodes.replicaCount=1",
                 "--set",
                 "license.create=true",
                 "--set-file",
                 "license.additionalLicenses.broker.overrideLicense=/files/mock-additional-license.lic");
-        assertLicense("hivemq-license-test-hivemq-platform");
+        assertLicense("hivemq-license-" + platformReleaseName);
         await().until(brokerLicenseFuture::isDone);
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/HelmBrokerExistingSecretLicensesIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/HelmBrokerExistingSecretLicensesIT.java
@@ -17,7 +17,7 @@ class HelmBrokerExistingSecretLicensesIT extends AbstractHelmLicensesIT {
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void withExistingBrokerLicenseSecret_statefulSetWithLicenseSecretMounted() throws Exception {
         final var brokerLicenseFuture =
-                logWaiter.waitFor(PLATFORM_LOG_WAITER_PREFIX, ".*License file license.lic is corrupt.");
+                logWaiter.waitFor(platformLogWaiterPrefix, ".*License file license.lic is corrupt.");
         K8sUtil.createSecret(client,
                 platformNamespace,
                 "test-license",

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/HelmBrokerLicensesIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/HelmBrokerLicensesIT.java
@@ -13,14 +13,14 @@ class HelmBrokerLicensesIT extends AbstractHelmLicensesIT {
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void withBrokerLicenseFileContent_statefulSetWithLicenseSecretMounted() throws Exception {
         final var brokerLicenseFuture =
-                logWaiter.waitFor(PLATFORM_LOG_WAITER_PREFIX, ".*License file license.lic is corrupt.");
+                logWaiter.waitFor(platformLogWaiterPrefix, ".*License file license.lic is corrupt.");
         installPlatformChartAndWaitToBeRunning("--set",
                 "nodes.replicaCount=1",
                 "--set",
                 "license.create=true",
                 "--set-file",
                 "license.overrideLicense=/files/mock-license.lic");
-        assertLicense("hivemq-license-test-hivemq-platform");
+        assertLicense("hivemq-license-" + platformReleaseName);
         await().until(brokerLicenseFuture::isDone);
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/HelmDataHubExistingSecretLicensesIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/HelmDataHubExistingSecretLicensesIT.java
@@ -17,7 +17,7 @@ class HelmDataHubExistingSecretLicensesIT extends AbstractHelmLicensesIT {
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void withExistingDataHubLicenseFileContent_statefulSetWithLicenseSecretMounted() throws Exception {
         final var dataHubLicenseFuture =
-                logWaiter.waitFor(PLATFORM_LOG_WAITER_PREFIX, ".*License file dataHub.plic is corrupt.");
+                logWaiter.waitFor(platformLogWaiterPrefix, ".*License file dataHub.plic is corrupt.");
         K8sUtil.createSecret(client,
                 platformNamespace,
                 "test-data-hub-license",

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/HelmDataHubLicensesIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/HelmDataHubLicensesIT.java
@@ -13,14 +13,14 @@ class HelmDataHubLicensesIT extends AbstractHelmLicensesIT {
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void withDataHubLicenseFileContent_statefulSetWithLicenseSecretMounted() throws Exception {
         final var dataHubLicenseFuture =
-                logWaiter.waitFor(PLATFORM_LOG_WAITER_PREFIX, ".*License file dataHub1.plic is corrupt.");
+                logWaiter.waitFor(platformLogWaiterPrefix, ".*License file dataHub1.plic is corrupt.");
         installPlatformChartAndWaitToBeRunning("--set",
                 "nodes.replicaCount=1",
                 "--set",
                 "license.create=true",
                 "--set-file",
                 "license.dataHub.dataHub1.overrideLicense=/files/mock-data-hub-license.plic");
-        assertLicense("hivemq-license-test-hivemq-platform");
+        assertLicense("hivemq-license-" + platformReleaseName);
         await().until(dataHubLicenseFuture::isDone);
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/HelmExtensionExistingSecretLicensesIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/HelmExtensionExistingSecretLicensesIT.java
@@ -21,7 +21,7 @@ class HelmExtensionExistingSecretLicensesIT extends AbstractHelmLicensesIT {
         final var extensionStartedFuture = waitForPlatformLog(
                 ".*Extension \"HiveMQ Enterprise Distributed Tracing Extension\" version .* started successfully.");
         final var extensionLicenseFuture =
-                logWaiter.waitFor(PLATFORM_LOG_WAITER_PREFIX, ".*License file tracing.elic is corrupt.");
+                logWaiter.waitFor(platformLogWaiterPrefix, ".*License file tracing.elic is corrupt.");
 
         K8sUtil.createSecret(client,
                 platformNamespace,

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/HelmExtensionLicensesIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/license/HelmExtensionLicensesIT.java
@@ -18,7 +18,7 @@ class HelmExtensionLicensesIT extends AbstractHelmLicensesIT {
         final var extensionStartedFuture = waitForPlatformLog(
                 ".*Extension \"HiveMQ Enterprise Distributed Tracing Extension\" version .* started successfully.");
         final var extensionLicenseFuture =
-                logWaiter.waitFor(PLATFORM_LOG_WAITER_PREFIX, ".*License file tracing.elic is corrupt.");
+                logWaiter.waitFor(platformLogWaiterPrefix, ".*License file tracing.elic is corrupt.");
 
         installPlatformChartAndWaitToBeRunning("-f",
                 "/files/distributed-tracing-extension-values.yaml",
@@ -26,7 +26,7 @@ class HelmExtensionLicensesIT extends AbstractHelmLicensesIT {
                 "license.create=true",
                 "--set-file",
                 "license.extensions.tracing.overrideLicense=/files/mock-extension-license.elic");
-        assertLicense("hivemq-license-test-hivemq-platform");
+        assertLicense("hivemq-license-" + platformReleaseName);
         await().until(extensionStartedFuture::isDone);
         await().until(extensionLicenseFuture::isDone);
     }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/migration/HelmLegacyStatefulSetMigrationIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/migration/HelmLegacyStatefulSetMigrationIT.java
@@ -45,14 +45,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 class HelmLegacyStatefulSetMigrationIT extends AbstractHelmChartIT {
 
     private static final int MQTT_SERVICE_PORT = 1883;
-    private static final @NotNull String MQTT_SERVICE_NAME = "hivemq-%s-mqtt".formatted(LEGACY_RELEASE_NAME);
     private static final int CC_SERVICE_PORT = 8080;
-    private static final @NotNull String CC_SERVICE_NAME = "hivemq-%s-cc".formatted(LEGACY_RELEASE_NAME);
     private static final int METRICS_SERVICE_PORT = 9399;
-    private static final @NotNull String METRICS_SERVICE_NAME = "hivemq-%s-metrics".formatted(LEGACY_RELEASE_NAME);
     private static final int REST_API_SERVICE_PORT = 8888;
-    private static final @NotNull String REST_API_SERVICE_NAME = "hivemq-%s-api".formatted(LEGACY_RELEASE_NAME);
-    private static final @NotNull String CLUSTER_SERVICE_NAME = "hivemq-%s-cluster".formatted(LEGACY_RELEASE_NAME);
+
+    private final @NotNull String mqttServiceName = "hivemq-%s-mqtt".formatted(legacyReleaseName);
+    private final @NotNull String ccServiceName = "hivemq-%s-cc".formatted(legacyReleaseName);
+    private final @NotNull String metricsServiceName = "hivemq-%s-metrics".formatted(legacyReleaseName);
+    private final @NotNull String restApiServiceName = "hivemq-%s-api".formatted(legacyReleaseName);
+    private final @NotNull String clusterServiceName = "hivemq-%s-cluster".formatted(legacyReleaseName);
 
     @RegisterExtension
     private static final @NotNull WebDriverContainerExtension WEB_DRIVER_CONTAINER_EXTENSION =
@@ -74,7 +75,7 @@ class HelmLegacyStatefulSetMigrationIT extends AbstractHelmChartIT {
     @AfterEach
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void tearDown() throws Exception {
-        helmChartContainer.uninstallRelease(LEGACY_RELEASE_NAME, operatorNamespace);
+        helmChartContainer.uninstallRelease(legacyReleaseName, operatorNamespace);
     }
 
     @Test
@@ -90,31 +91,31 @@ class HelmLegacyStatefulSetMigrationIT extends AbstractHelmChartIT {
         // assert service annotations and labels
         final var mqttAnnotations = Map.of("service.spec.externalTrafficPolicy", "Local");
         final var metricsAnnotations = Map.of("prometheus.io/scrape", "true");
-        final var legacyLabels = Map.of("app", "hivemq", "hivemq-cluster", LEGACY_RELEASE_NAME);
+        final var legacyLabels = Map.of("app", "hivemq", "hivemq-cluster", legacyReleaseName);
         assertAnnotationsAndLabels("Legacy MQTT Service",
-                client.services().inNamespace(operatorNamespace).withName(MQTT_SERVICE_NAME).get().getMetadata(),
+                client.services().inNamespace(operatorNamespace).withName(mqttServiceName).get().getMetadata(),
                 mqttAnnotations,
                 legacyLabels);
         assertAnnotationsAndLabels("Legacy Control Center Service",
-                client.services().inNamespace(operatorNamespace).withName(CC_SERVICE_NAME).get().getMetadata(),
+                client.services().inNamespace(operatorNamespace).withName(ccServiceName).get().getMetadata(),
                 Map.of(),
                 legacyLabels);
         assertAnnotationsAndLabels("Legacy Metrics Service",
-                client.services().inNamespace(operatorNamespace).withName(METRICS_SERVICE_NAME).get().getMetadata(),
+                client.services().inNamespace(operatorNamespace).withName(metricsServiceName).get().getMetadata(),
                 metricsAnnotations,
                 legacyLabels);
         assertAnnotationsAndLabels("Legacy REST API Service",
-                client.services().inNamespace(operatorNamespace).withName(REST_API_SERVICE_NAME).get().getMetadata(),
+                client.services().inNamespace(operatorNamespace).withName(restApiServiceName).get().getMetadata(),
                 Map.of(),
                 legacyLabels);
         assertAnnotationsAndLabels("Legacy Cluster Service",
-                client.services().inNamespace(operatorNamespace).withName(CLUSTER_SERVICE_NAME).get().getMetadata(),
+                client.services().inNamespace(operatorNamespace).withName(clusterServiceName).get().getMetadata(),
                 Map.of(),
                 legacyLabels);
         final var legacyStatefulSetMetadata = client.apps()
                 .statefulSets()
                 .inNamespace(operatorNamespace)
-                .withName(LEGACY_RELEASE_NAME)
+                .withName(legacyReleaseName)
                 .get()
                 .getMetadata();
         assertThat(legacyStatefulSetMetadata.getAnnotations()).containsOnlyKeys("hivemq.com/resource-spec",
@@ -125,7 +126,7 @@ class HelmLegacyStatefulSetMigrationIT extends AbstractHelmChartIT {
                 legacyStatefulSetMetadata.getAnnotations(),
                 mergeMaps(legacyLabels,
                         Map.of("app.kubernetes.io/instance",
-                                LEGACY_RELEASE_NAME,
+                                legacyReleaseName,
                                 "app.kubernetes.io/managed-by",
                                 "Helm",
                                 "app.kubernetes.io/name",
@@ -135,12 +136,12 @@ class HelmLegacyStatefulSetMigrationIT extends AbstractHelmChartIT {
                                 "helm.sh/chart",
                                 "hivemq-operator-%s".formatted(legacyChartVersion),
                                 "hivemq-cluster",
-                                LEGACY_RELEASE_NAME)));
+                                legacyReleaseName)));
         assertAnnotationsAndLabels("Legacy StatefulSet Template",
                 client.apps()
                         .statefulSets()
                         .inNamespace(operatorNamespace)
-                        .withName(LEGACY_RELEASE_NAME)
+                        .withName(legacyReleaseName)
                         .get()
                         .getSpec()
                         .getTemplate()
@@ -148,20 +149,20 @@ class HelmLegacyStatefulSetMigrationIT extends AbstractHelmChartIT {
                 Map.of(),
                 mergeMaps(legacyLabels, Map.of("hivemq.com/node-offline", "false")));
         // assert Control Center login
-        ControlCenterUtil.assertLogin(client, operatorNamespace, webDriverContainer, CC_SERVICE_NAME, CC_SERVICE_PORT);
+        ControlCenterUtil.assertLogin(client, operatorNamespace, webDriverContainer, ccServiceName, CC_SERVICE_PORT);
         // publish retained messages
         final var topicList =
-                MqttUtil.publishRetainedMessages(client, operatorNamespace, MQTT_SERVICE_NAME, MQTT_SERVICE_PORT);
+                MqttUtil.publishRetainedMessages(client, operatorNamespace, mqttServiceName, MQTT_SERVICE_PORT);
         // assert RestAPI service and authorization with ESE extension
-        RestAPIUtil.assertAuth(client, operatorNamespace, REST_API_SERVICE_NAME, REST_API_SERVICE_PORT, false);
+        RestAPIUtil.assertAuth(client, operatorNamespace, restApiServiceName, REST_API_SERVICE_PORT, false);
         // assert publishes metrics
-        MonitoringUtil.assertPublishesMetrics(client, operatorNamespace, METRICS_SERVICE_NAME, METRICS_SERVICE_PORT);
+        MonitoringUtil.assertPublishesMetrics(client, operatorNamespace, metricsServiceName, METRICS_SERVICE_PORT);
 
         // scale down the legacy operator
         // kubectl scale deployment <release-name>-hivemq-operator-operator --replicas=0 -n <namespace>
-        final var legacyOperatorDeploymentName = "%s-hivemq-operator-operator".formatted(LEGACY_RELEASE_NAME);
+        final var legacyOperatorDeploymentName = "%s-hivemq-operator-operator".formatted(legacyReleaseName);
         K8sUtil.scaleDeployment(client, operatorNamespace, legacyOperatorDeploymentName, 0);
-        var legacyOperatorLabels = K8sUtil.getHiveMQLegacyOperatorLabels(LEGACY_RELEASE_NAME);
+        var legacyOperatorLabels = K8sUtil.getHiveMQLegacyOperatorLabels(legacyReleaseName);
         client.pods()
                 .inNamespace(operatorNamespace)
                 .withLabels(legacyOperatorLabels)
@@ -174,14 +175,14 @@ class HelmLegacyStatefulSetMigrationIT extends AbstractHelmChartIT {
 
         // delete custom resource with orphan
         // kubectl delete hivemq-clusters.hivemq.com <release-name> --cascade=orphan -n <namespace>
-        final var legacyPlatform = K8sUtil.getLegacyHiveMQPlatform(client, operatorNamespace, LEGACY_RELEASE_NAME);
+        final var legacyPlatform = K8sUtil.getLegacyHiveMQPlatform(client, operatorNamespace, legacyReleaseName);
         legacyPlatform.withPropagationPolicy(DeletionPropagation.ORPHAN).withTimeoutInMillis(5000).delete();
-        assertThat(K8sUtil.getLegacyHiveMQPlatform(client, operatorNamespace, LEGACY_RELEASE_NAME).get()).isNull();
+        assertThat(K8sUtil.getLegacyHiveMQPlatform(client, operatorNamespace, legacyReleaseName).get()).isNull();
 
         // scale up the legacy operator
         // kubectl scale deployment <release-name>-hivemq-operator-operator --replicas=1 -n <namespace>
         K8sUtil.scaleDeployment(client, operatorNamespace, legacyOperatorDeploymentName, 1);
-        K8sUtil.waitForLegacyOperatorPodStateRunning(client, operatorNamespace, LEGACY_RELEASE_NAME);
+        K8sUtil.waitForLegacyOperatorPodStateRunning(client, operatorNamespace, legacyReleaseName);
         assertThat(client.pods()
                 .inNamespace(operatorNamespace)
                 .withLabels(legacyOperatorLabels)
@@ -192,13 +193,13 @@ class HelmLegacyStatefulSetMigrationIT extends AbstractHelmChartIT {
         // we need to uninstall the legacy release with orphan option so existing resources can be taken over by the platform Helm install
         // TODO: We cannot execute `helm uninstall my-release --cascade orphan` because this will delete resources
         //  without an owner reference, that are still needed - See: https://github.com/helm/helm/issues/13279
-        //helmChartContainer.uninstallRelease(LEGACY_RELEASE_NAME, operatorNamespace, "--cascade", "orphan");
+        //helmChartContainer.uninstallRelease(legacyReleaseName, operatorNamespace, "--cascade", "orphan");
 
         // as a workaround we need to delete all the corresponding Helm versioned Secrets installed for each of the possible Helm releases
         // we may have. These will be named with a format like "sh.helm.release.v1.<release-name>.v<release-version>" and we will delete them
         // based on the labels instead as follows:
         // kubectl delete secret -l owner=helm,name=<release-name> -n <namespace>
-        final var helmSecretLabels = Map.of("owner", "helm", "name", LEGACY_RELEASE_NAME);
+        final var helmSecretLabels = Map.of("owner", "helm", "name", legacyReleaseName);
         client.secrets().inNamespace(operatorNamespace).withLabels(helmSecretLabels).withTimeoutInMillis(5000).delete();
         assertThat(client.secrets()
                 .inNamespace(operatorNamespace)
@@ -210,20 +211,22 @@ class HelmLegacyStatefulSetMigrationIT extends AbstractHelmChartIT {
         // ConfigMap by adding a new entry for `config.xml`.
         K8sUtil.updateConfigMap(client, operatorNamespace, "ese-legacy-config-map-update.yml");
 
-        helmChartContainer.installPlatformChart(LEGACY_RELEASE_NAME,
+        helmChartContainer.installPlatformChart(legacyReleaseName,
                 "-f",
                 "/files/migration-platform-stateful-set-values.yaml",
+                "--set",
+                "services[0].name=" + mqttServiceName,
                 "--namespace",
                 operatorNamespace);
 
-        K8sUtil.waitForHiveMQPlatformState(client, operatorNamespace, LEGACY_RELEASE_NAME, "STATEFULSET_MIGRATION");
-        K8sUtil.waitForHiveMQPlatformState(client, operatorNamespace, LEGACY_RELEASE_NAME, "ROLLING_RESTART");
-        K8sUtil.waitForHiveMQPlatformStateRunning(client, operatorNamespace, LEGACY_RELEASE_NAME);
+        K8sUtil.waitForHiveMQPlatformState(client, operatorNamespace, legacyReleaseName, "STATEFULSET_MIGRATION");
+        K8sUtil.waitForHiveMQPlatformState(client, operatorNamespace, legacyReleaseName, "ROLLING_RESTART");
+        K8sUtil.waitForHiveMQPlatformStateRunning(client, operatorNamespace, legacyReleaseName);
 
         // assert service annotations and labels
         final var hiveMQVersion = System.getProperty("hivemq.tag", "latest");
         final var platformLabels = Map.of("app.kubernetes.io/instance",
-                LEGACY_RELEASE_NAME,
+                legacyReleaseName,
                 "app.kubernetes.io/managed-by",
                 "Helm",
                 "app.kubernetes.io/name",
@@ -231,34 +234,34 @@ class HelmLegacyStatefulSetMigrationIT extends AbstractHelmChartIT {
                 "app.kubernetes.io/version",
                 hiveMQVersion,
                 "hivemq-platform",
-                LEGACY_RELEASE_NAME);
+                legacyReleaseName);
         final var platformServiceLabels = mergeMaps(platformLabels, Map.of("hivemq/platform-service", "true"));
         final var clusterServiceLabels = mergeMaps(platformLabels, Map.of("hivemq/cluster-service", "true"));
         assertAnnotationsAndLabels("Migrated MQTT Service",
-                client.services().inNamespace(operatorNamespace).withName(MQTT_SERVICE_NAME).get().getMetadata(),
+                client.services().inNamespace(operatorNamespace).withName(mqttServiceName).get().getMetadata(),
                 mqttAnnotations,
                 platformServiceLabels);
         assertAnnotationsAndLabels("Migrated Control Center Service",
-                client.services().inNamespace(operatorNamespace).withName(CC_SERVICE_NAME).get().getMetadata(),
+                client.services().inNamespace(operatorNamespace).withName(ccServiceName).get().getMetadata(),
                 Map.of(),
                 platformServiceLabels);
         assertAnnotationsAndLabels("Migrated Metrics Service",
-                client.services().inNamespace(operatorNamespace).withName(METRICS_SERVICE_NAME).get().getMetadata(),
+                client.services().inNamespace(operatorNamespace).withName(metricsServiceName).get().getMetadata(),
                 metricsAnnotations,
                 platformServiceLabels);
         assertAnnotationsAndLabels("Migrated REST API Service",
-                client.services().inNamespace(operatorNamespace).withName(REST_API_SERVICE_NAME).get().getMetadata(),
+                client.services().inNamespace(operatorNamespace).withName(restApiServiceName).get().getMetadata(),
                 Map.of(),
                 platformServiceLabels);
         assertAnnotationsAndLabels("Migrated Cluster Service",
-                client.services().inNamespace(operatorNamespace).withName(CLUSTER_SERVICE_NAME).get().getMetadata(),
+                client.services().inNamespace(operatorNamespace).withName(clusterServiceName).get().getMetadata(),
                 Map.of(),
                 clusterServiceLabels);
         assertAnnotationsAndLabels("Migrated StatefulSet",
                 client.apps()
                         .statefulSets()
                         .inNamespace(operatorNamespace)
-                        .withName(LEGACY_RELEASE_NAME)
+                        .withName(legacyReleaseName)
                         .get()
                         .getMetadata(),
                 Map.of("operator.platform.hivemq.com/last-controller-revision-hash", ""),
@@ -266,7 +269,7 @@ class HelmLegacyStatefulSetMigrationIT extends AbstractHelmChartIT {
         final var statefulSetMetadata = client.apps()
                 .statefulSets()
                 .inNamespace(operatorNamespace)
-                .withName(LEGACY_RELEASE_NAME)
+                .withName(legacyReleaseName)
                 .get()
                 .getSpec()
                 .getTemplate()
@@ -277,13 +280,13 @@ class HelmLegacyStatefulSetMigrationIT extends AbstractHelmChartIT {
                 statefulSetMetadata.getAnnotations(),
                 platformLabels);
         // assert Control Center login
-        ControlCenterUtil.assertLogin(client, operatorNamespace, webDriverContainer, CC_SERVICE_NAME, CC_SERVICE_PORT);
+        ControlCenterUtil.assertLogin(client, operatorNamespace, webDriverContainer, ccServiceName, CC_SERVICE_PORT);
         // assert retained messages
-        MqttUtil.assertRetainedMessages(client, operatorNamespace, topicList, MQTT_SERVICE_NAME, MQTT_SERVICE_PORT);
+        MqttUtil.assertRetainedMessages(client, operatorNamespace, topicList, mqttServiceName, MQTT_SERVICE_PORT);
         // assert RestAPI service and authorization with ESE extension
-        RestAPIUtil.assertAuth(client, operatorNamespace, REST_API_SERVICE_NAME, REST_API_SERVICE_PORT, false);
+        RestAPIUtil.assertAuth(client, operatorNamespace, restApiServiceName, REST_API_SERVICE_PORT, false);
         // assert subscribe and publishes metrics
-        MonitoringUtil.assertSubscribesMetrics(client, operatorNamespace, METRICS_SERVICE_NAME, METRICS_SERVICE_PORT);
+        MonitoringUtil.assertSubscribesMetrics(client, operatorNamespace, metricsServiceName, METRICS_SERVICE_PORT);
     }
 
     private void assertAnnotationsAndLabels(

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/migration/HelmLegacyStatefulSetMigrationIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/migration/HelmLegacyStatefulSetMigrationIT.java
@@ -214,8 +214,6 @@ class HelmLegacyStatefulSetMigrationIT extends AbstractHelmChartIT {
         helmChartContainer.installPlatformChart(legacyReleaseName,
                 "-f",
                 "/files/migration-platform-stateful-set-values.yaml",
-                "--set",
-                "services[0].name=" + mqttServiceName,
                 "--namespace",
                 operatorNamespace);
 

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/monitoring/HelmMonitoringPlatformIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/monitoring/HelmMonitoringPlatformIT.java
@@ -17,8 +17,8 @@ class HelmMonitoringPlatformIT extends AbstractHelmMonitoringIT {
         assertPrometheusMetrics("com_hivemq_cluster_nodes_count",
                 response -> assertThat(response.data().result()).hasSize(2)
                         .extracting(result -> result.metric().get("pod"), result -> result.value().get(1))
-                        .containsExactlyInAnyOrder(tuple(PLATFORM_RELEASE_NAME + "-0", "2"),
-                                tuple(PLATFORM_RELEASE_NAME + "-1", "2")));
+                        .containsExactlyInAnyOrder(tuple(platformReleaseName + "-0", "2"),
+                                tuple(platformReleaseName + "-1", "2")));
         assertGrafanaDashboard("HiveMQ Platform (Prometheus)");
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/operator/CustomOperatorNamespacesIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/operator/CustomOperatorNamespacesIT.java
@@ -14,9 +14,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class CustomOperatorNamespacesIT extends AbstractHelmChartIT {
 
-    private static final @NotNull String PLATFORM_NAME_ALPHA = PLATFORM_RELEASE_NAME + "-alpha";
-    private static final @NotNull String PLATFORM_NAME_BETA = PLATFORM_RELEASE_NAME + "-beta";
-    private static final @NotNull String PLATFORM_NAME_GAMMA = PLATFORM_RELEASE_NAME + "-gamma";
+    private final @NotNull String platformNameAlpha = platformReleaseName + "-alpha";
+    private final @NotNull String platformNameBeta = platformReleaseName + "-beta";
+    private final @NotNull String platformNameGamma = platformReleaseName + "-gamma";
 
     private @NotNull String namespaceAlpha;
     private @NotNull String namespaceBeta;
@@ -51,9 +51,9 @@ class CustomOperatorNamespacesIT extends AbstractHelmChartIT {
     @AfterEach
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void tearDown() throws Exception {
-        helmChartContainer.uninstallRelease(PLATFORM_NAME_ALPHA, namespaceAlpha, true);
-        helmChartContainer.uninstallRelease(PLATFORM_NAME_BETA, namespaceBeta, true);
-        helmChartContainer.uninstallRelease(PLATFORM_NAME_GAMMA, namespaceGamma, true);
+        helmChartContainer.uninstallRelease(platformNameAlpha, namespaceAlpha, true);
+        helmChartContainer.uninstallRelease(platformNameBeta, namespaceBeta, true);
+        helmChartContainer.uninstallRelease(platformNameGamma, namespaceGamma, true);
     }
 
     @Test
@@ -64,34 +64,34 @@ class CustomOperatorNamespacesIT extends AbstractHelmChartIT {
         installPlatformOperatorChartAndWaitToBeRunning("--set",
                 "namespaces=%s\\,%s".formatted(namespaceAlpha, namespaceBeta));
 
-        helmChartContainer.installPlatformChart(PLATFORM_NAME_ALPHA,
+        helmChartContainer.installPlatformChart(platformNameAlpha,
                 "--namespace",
                 namespaceAlpha,
                 "--set",
                 "nodes.replicaCount=1");
-        helmChartContainer.installPlatformChart(PLATFORM_NAME_BETA,
+        helmChartContainer.installPlatformChart(platformNameBeta,
                 "--namespace",
                 namespaceBeta,
                 "--set",
                 "nodes.replicaCount=1");
-        helmChartContainer.installPlatformChart(PLATFORM_NAME_GAMMA,
+        helmChartContainer.installPlatformChart(platformNameGamma,
                 "--namespace",
                 namespaceGamma,
                 "--set",
                 "nodes.replicaCount=1");
-        K8sUtil.waitForHiveMQPlatformStateRunning(client, namespaceAlpha, PLATFORM_NAME_ALPHA);
-        K8sUtil.waitForHiveMQPlatformStateRunning(client, namespaceBeta, PLATFORM_NAME_BETA);
+        K8sUtil.waitForHiveMQPlatformStateRunning(client, namespaceAlpha, platformNameAlpha);
+        K8sUtil.waitForHiveMQPlatformStateRunning(client, namespaceBeta, platformNameBeta);
 
         // assert that all custom resources are present, but only two StatefulSets were created
-        assertThat(K8sUtil.getHiveMQPlatform(client, namespaceAlpha, PLATFORM_NAME_ALPHA).get()).isNotNull();
-        assertThat(K8sUtil.getHiveMQPlatform(client, namespaceBeta, PLATFORM_NAME_BETA).get()).isNotNull();
-        assertThat(K8sUtil.getHiveMQPlatform(client, namespaceGamma, PLATFORM_NAME_GAMMA).get()).isNotNull();
+        assertThat(K8sUtil.getHiveMQPlatform(client, namespaceAlpha, platformNameAlpha).get()).isNotNull();
+        assertThat(K8sUtil.getHiveMQPlatform(client, namespaceBeta, platformNameBeta).get()).isNotNull();
+        assertThat(K8sUtil.getHiveMQPlatform(client, namespaceGamma, platformNameGamma).get()).isNotNull();
         assertThat(client.apps().statefulSets().inNamespace(namespaceAlpha).list().getItems()).singleElement()
                 .satisfies(statefulSet -> assertThat(statefulSet.getMetadata().getName()) //
-                        .isEqualTo(PLATFORM_NAME_ALPHA));
+                        .isEqualTo(platformNameAlpha));
         assertThat(client.apps().statefulSets().inNamespace(namespaceBeta).list().getItems()).singleElement()
                 .satisfies(statefulSet -> assertThat(statefulSet.getMetadata().getName()) //
-                        .isEqualTo(PLATFORM_NAME_BETA));
+                        .isEqualTo(platformNameBeta));
         assertThat(client.apps().statefulSets().inNamespace(namespaceGamma).list().getItems()).isEmpty();
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/operator/CustomOperatorSelectorIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/operator/CustomOperatorSelectorIT.java
@@ -13,8 +13,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class CustomOperatorSelectorIT extends AbstractHelmChartIT {
 
-    private static final @NotNull String PLATFORM_NAME_ALPHA = PLATFORM_RELEASE_NAME + "-alpha";
-    private static final @NotNull String PLATFORM_NAME_BETA = PLATFORM_RELEASE_NAME + "-beta";
+    private final @NotNull String platformNameAlpha = platformReleaseName + "-alpha";
+    private final @NotNull String platformNameBeta = platformReleaseName + "-beta";
 
     @Override
     protected boolean installPlatformOperatorChart() {
@@ -29,8 +29,8 @@ class CustomOperatorSelectorIT extends AbstractHelmChartIT {
     @AfterEach
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void tearDown() throws Exception {
-        helmChartContainer.uninstallRelease(PLATFORM_NAME_ALPHA, platformNamespace);
-        helmChartContainer.uninstallRelease(PLATFORM_NAME_BETA, platformNamespace, true);
+        helmChartContainer.uninstallRelease(platformNameAlpha, platformNamespace);
+        helmChartContainer.uninstallRelease(platformNameBeta, platformNamespace, true);
     }
 
     @Test
@@ -39,15 +39,15 @@ class CustomOperatorSelectorIT extends AbstractHelmChartIT {
         // the operator should reconcile the alpha platform, but ignore the beta platform
         installPlatformOperatorChartAndWaitToBeRunning("--set", "selector=alpha");
 
-        installPlatformChart(PLATFORM_NAME_ALPHA, "--set", "nodes.replicaCount=1", "--set", "operator.selector=alpha");
-        installPlatformChart(PLATFORM_NAME_BETA, "--set", "nodes.replicaCount=1", "--set", "operator.selector=beta");
-        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, PLATFORM_NAME_ALPHA);
+        installPlatformChart(platformNameAlpha, "--set", "nodes.replicaCount=1", "--set", "operator.selector=alpha");
+        installPlatformChart(platformNameBeta, "--set", "nodes.replicaCount=1", "--set", "operator.selector=beta");
+        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, platformNameAlpha);
 
         // assert that all custom resources are present, but only one StatefulSet was created
-        assertThat(K8sUtil.getHiveMQPlatform(client, platformNamespace, PLATFORM_NAME_ALPHA).get()).isNotNull();
-        assertThat(K8sUtil.getHiveMQPlatform(client, platformNamespace, PLATFORM_NAME_BETA).get()).isNotNull();
+        assertThat(K8sUtil.getHiveMQPlatform(client, platformNamespace, platformNameAlpha).get()).isNotNull();
+        assertThat(K8sUtil.getHiveMQPlatform(client, platformNamespace, platformNameBeta).get()).isNotNull();
         assertThat(client.apps().statefulSets().inNamespace(platformNamespace).list().getItems()).singleElement()
                 .satisfies(statefulSet -> assertThat(statefulSet.getMetadata().getName()) //
-                        .isEqualTo(PLATFORM_NAME_ALPHA));
+                        .isEqualTo(platformNameAlpha));
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/operator/CustomOperatorSelectorsIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/operator/CustomOperatorSelectorsIT.java
@@ -13,9 +13,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class CustomOperatorSelectorsIT extends AbstractHelmChartIT {
 
-    private static final @NotNull String PLATFORM_NAME_ALPHA_TIER_1 = PLATFORM_RELEASE_NAME + "-alpha-tier1";
-    private static final @NotNull String PLATFORM_NAME_ALPHA_TIER_2 = PLATFORM_RELEASE_NAME + "-alpha-tier2";
-    private static final @NotNull String PLATFORM_NAME_ALPHA_TIER_3 = PLATFORM_RELEASE_NAME + "-alpha-tier3";
+    private final @NotNull String platformNameAlphaTier1 = platformReleaseName + "-alpha-tier1";
+    private final @NotNull String platformNameAlphaTier2 = platformReleaseName + "-alpha-tier2";
+    private final @NotNull String platformNameAlphaTier3 = platformReleaseName + "-alpha-tier3";
 
     @Override
     protected boolean installPlatformOperatorChart() {
@@ -30,9 +30,9 @@ class CustomOperatorSelectorsIT extends AbstractHelmChartIT {
     @AfterEach
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void tearDown() throws Exception {
-        helmChartContainer.uninstallRelease(PLATFORM_NAME_ALPHA_TIER_1, platformNamespace);
-        helmChartContainer.uninstallRelease(PLATFORM_NAME_ALPHA_TIER_2, platformNamespace);
-        helmChartContainer.uninstallRelease(PLATFORM_NAME_ALPHA_TIER_3, platformNamespace, true);
+        helmChartContainer.uninstallRelease(platformNameAlphaTier1, platformNamespace);
+        helmChartContainer.uninstallRelease(platformNameAlphaTier2, platformNamespace);
+        helmChartContainer.uninstallRelease(platformNameAlphaTier3, platformNamespace, true);
     }
 
     @Test
@@ -41,32 +41,32 @@ class CustomOperatorSelectorsIT extends AbstractHelmChartIT {
         // the operator should reconcile the tier two and three platforms, but ignore the tier one platform
         installPlatformOperatorChartAndWaitToBeRunning("--set", "selectors=group=alpha\\,tier!=one");
 
-        installPlatformChart(PLATFORM_NAME_ALPHA_TIER_1,
+        installPlatformChart(platformNameAlphaTier1,
                 "--set",
                 "nodes.replicaCount=1",
                 "--set",
                 "operator.labels.group=alpha,operator.labels.tier=one");
-        installPlatformChart(PLATFORM_NAME_ALPHA_TIER_2,
+        installPlatformChart(platformNameAlphaTier2,
                 "--set",
                 "nodes.replicaCount=1",
                 "--set",
                 "operator.labels.group=alpha,operator.labels.tier=two");
-        installPlatformChart(PLATFORM_NAME_ALPHA_TIER_3,
+        installPlatformChart(platformNameAlphaTier3,
                 "--set",
                 "nodes.replicaCount=1",
                 "--set",
                 "operator.labels.group=alpha,operator.labels.tier=three");
-        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, PLATFORM_NAME_ALPHA_TIER_2);
-        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, PLATFORM_NAME_ALPHA_TIER_3);
+        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, platformNameAlphaTier2);
+        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, platformNameAlphaTier3);
 
         // assert that all custom resources are present, but only two StatefulSets were created
-        assertThat(K8sUtil.getHiveMQPlatform(client, platformNamespace, PLATFORM_NAME_ALPHA_TIER_1).get()).isNotNull();
-        assertThat(K8sUtil.getHiveMQPlatform(client, platformNamespace, PLATFORM_NAME_ALPHA_TIER_2).get()).isNotNull();
-        assertThat(K8sUtil.getHiveMQPlatform(client, platformNamespace, PLATFORM_NAME_ALPHA_TIER_3).get()).isNotNull();
+        assertThat(K8sUtil.getHiveMQPlatform(client, platformNamespace, platformNameAlphaTier1).get()).isNotNull();
+        assertThat(K8sUtil.getHiveMQPlatform(client, platformNamespace, platformNameAlphaTier2).get()).isNotNull();
+        assertThat(K8sUtil.getHiveMQPlatform(client, platformNamespace, platformNameAlphaTier3).get()).isNotNull();
         assertThat(client.apps().statefulSets().inNamespace(platformNamespace).list().getItems()).hasSize(2)
                 .satisfiesExactlyInAnyOrder(statefulSet -> assertThat(statefulSet.getMetadata().getName()) //
-                                .isEqualTo(PLATFORM_NAME_ALPHA_TIER_2),
+                                .isEqualTo(platformNameAlphaTier2),
                         statefulSet -> assertThat(statefulSet.getMetadata().getName()) //
-                                .isEqualTo(PLATFORM_NAME_ALPHA_TIER_3));
+                                .isEqualTo(platformNameAlphaTier3));
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/operator/HelmRemoveNamespaceIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/operator/HelmRemoveNamespaceIT.java
@@ -27,7 +27,7 @@ class HelmRemoveNamespaceIT extends AbstractHelmChartIT {
     void withSingleOperator_hivemqRunningThenDelete() throws Exception {
         installPlatformChartAndWaitToBeRunning("/files/platform-values.yaml");
 
-        final var platform = K8sUtil.getHiveMQPlatform(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        final var platform = K8sUtil.getHiveMQPlatform(client, platformNamespace, platformReleaseName);
         assertThat(platform).isNotNull();
         final var namespaceDeletedFuture = client.namespaces()
                 .withName(platformNamespace)

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/operator/HelmUpgradeOperatorIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/operator/HelmUpgradeOperatorIT.java
@@ -43,7 +43,7 @@ class HelmUpgradeOperatorIT extends AbstractHelmChartIT {
                 .anyMatch(containerPort -> containerPort.getContainerPort() == 8080));
 
         // upgrade chart and wait to be ready
-        helmChartContainer.upgradePlatformOperatorChart(OPERATOR_RELEASE_NAME,
+        helmChartContainer.upgradePlatformOperatorChart(operatorReleaseName,
                 "--set",
                 "http.port=8081",
                 "--namespace",

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/AbstractHelmPlatformTlsIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/AbstractHelmPlatformTlsIT.java
@@ -26,14 +26,19 @@ class AbstractHelmPlatformTlsIT extends AbstractHelmChartIT {
     private static final @NotNull WebDriverContainerExtension WEB_DRIVER_CONTAINER_EXTENSION =
             new WebDriverContainerExtension(network);
 
-    static final @NotNull String MQTT_SERVICE_NAME_1884 = "hivemq-test-hivemq-platform-mqtt-1884";
     static final int MQTT_SERVICE_PORT_1884 = 1884;
-    static final @NotNull String MQTT_SERVICE_NAME_1885 = "hivemq-test-hivemq-platform-mqtt-1885";
     static final int MQTT_SERVICE_PORT_1885 = 1885;
-    static final @NotNull String MQTT_SERVICE_NAME_1886 = "hivemq-test-hivemq-platform-mqtt-1886";
     static final int MQTT_SERVICE_PORT_1886 = 1886;
-    static final @NotNull String HIVEMQ_CC_SERVICE_NAME = "hivemq-test-hivemq-platform-cc-8080";
     static final int HIVEMQ_CC_SERVICE_PORT = 8080;
+
+    final @NotNull String mqttServiceName1884 =
+            "hivemq-%s-mqtt-%s".formatted(platformReleaseName, MQTT_SERVICE_PORT_1884);
+    final @NotNull String mqttServiceName1885 =
+            "hivemq-%s-mqtt-%s".formatted(platformReleaseName, MQTT_SERVICE_PORT_1885);
+    final @NotNull String mqttServiceName1886 =
+            "hivemq-%s-mqtt-%s".formatted(platformReleaseName, MQTT_SERVICE_PORT_1886);
+    final @NotNull String hivemqCcServiceName =
+            "hivemq-%s-cc-%s".formatted(platformReleaseName, HIVEMQ_CC_SERVICE_PORT);
 
     @TempDir
     @NotNull Path tmp;
@@ -64,7 +69,7 @@ class AbstractHelmPlatformTlsIT extends AbstractHelmChartIT {
 
     void assertSecretMounted(final @NotNull KubernetesClient client, final @NotNull String name) {
         final var statefulSet =
-                client.apps().statefulSets().inNamespace(platformNamespace).withName(PLATFORM_RELEASE_NAME).get();
+                client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
         assertThat(statefulSet).isNotNull();
         final var volumes = statefulSet.getSpec().getTemplate().getSpec().getVolumes();
         assertThat(volumes).isNotEmpty();

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmCustomConfigIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmCustomConfigIT.java
@@ -26,7 +26,7 @@ class HelmCustomConfigIT extends AbstractHelmChartIT {
 
         await().atMost(ONE_MINUTE).untilAsserted(() -> {
             final var statefulSet =
-                    client.apps().statefulSets().inNamespace(platformNamespace).withName(PLATFORM_RELEASE_NAME).get();
+                    client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
             assertThat(statefulSet).isNotNull();
             final var foundContainer = statefulSet.getSpec()
                     .getTemplate()

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmCustomConfigMapIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmCustomConfigMapIT.java
@@ -29,12 +29,12 @@ class HelmCustomConfigMapIT extends AbstractHelmChartIT {
 
         await().atMost(ONE_MINUTE).untilAsserted(() -> {
             final var hivemqCustomResource =
-                    K8sUtil.getHiveMQPlatform(client, platformNamespace, PLATFORM_RELEASE_NAME).get();
+                    K8sUtil.getHiveMQPlatform(client, platformNamespace, platformReleaseName).get();
             assertThat(hivemqCustomResource.getAdditionalProperties().get("spec")).isNotNull()
                     .asString()
                     .containsIgnoringCase("configMapName=" + configMapName);
             final var statefulSet =
-                    client.apps().statefulSets().inNamespace(platformNamespace).withName(PLATFORM_RELEASE_NAME).get();
+                    client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
             assertThat(statefulSet).isNotNull();
             assertThat(K8sUtil.getHiveMQContainer(statefulSet.getSpec()).getVolumeMounts()) //
                     .anyMatch(volumeMount -> volumeMount.getName().equals("broker-configuration") &&

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmCustomConfigXmlIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmCustomConfigXmlIT.java
@@ -27,7 +27,7 @@ class HelmCustomConfigXmlIT extends AbstractHelmChartIT {
         await().atMost(ONE_MINUTE).untilAsserted(() -> {
             final var configmap = client.configMaps()
                     .inNamespace(platformNamespace)
-                    .withName("hivemq-configuration-" + PLATFORM_RELEASE_NAME)
+                    .withName("hivemq-configuration-" + platformReleaseName)
                     .get();
             assertThat(configmap).isNotNull();
             final var xmlConfig = configmap.getData().get("config.xml");

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmCustomEnvVarsIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmCustomEnvVarsIT.java
@@ -36,7 +36,7 @@ class HelmCustomEnvVarsIT extends AbstractHelmChartIT {
                         platformNamespace.equals(envVar.getValue()));
 
         // assert the custom platform configuration
-        final var statefulSet = K8sUtil.getStatefulSet(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        final var statefulSet = K8sUtil.getStatefulSet(client, platformNamespace, platformReleaseName);
         assertThat(K8sUtil.getHiveMQContainer(statefulSet.getSpec())
                 .getEnv()).anyMatch(envVar -> "MY_CUSTOM_ENV_VAR".equals(envVar.getName()) &&
                 "mycustomvalue".equals(envVar.getValue()));

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmCustomSecretConfigExistingIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmCustomSecretConfigExistingIT.java
@@ -30,13 +30,13 @@ class HelmCustomSecretConfigExistingIT extends AbstractHelmChartIT {
                 "config.createAs=Secret");
         await().atMost(ONE_MINUTE).untilAsserted(() -> {
             final var hivemqCustomResource =
-                    K8sUtil.getHiveMQPlatform(client, platformNamespace, PLATFORM_RELEASE_NAME).get();
+                    K8sUtil.getHiveMQPlatform(client, platformNamespace, platformReleaseName).get();
             assertThat(hivemqCustomResource.getAdditionalProperties().get("spec")).isNotNull()
                     .asString()
                     .containsIgnoringCase("secretName=" + secretName);
 
             final var statefulSet =
-                    client.apps().statefulSets().inNamespace(platformNamespace).withName(PLATFORM_RELEASE_NAME).get();
+                    client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
             assertThat(statefulSet).isNotNull();
             assertThat(K8sUtil.getHiveMQContainer(statefulSet.getSpec()).getVolumeMounts()) //
                     .anyMatch(volumeMount -> volumeMount.getName().equals("broker-configuration") &&

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmCustomSecretConfigIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmCustomSecretConfigIT.java
@@ -16,17 +16,17 @@ class HelmCustomSecretConfigIT extends AbstractHelmChartIT {
     @Test
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void withSecretConfig_hivemqRunning() throws Exception {
-        final var secretName = "hivemq-configuration-" + PLATFORM_RELEASE_NAME;
+        final var secretName = "hivemq-configuration-" + platformReleaseName;
         installPlatformChartAndWaitToBeRunning("--set", "config.createAs=Secret");
         await().atMost(ONE_MINUTE).untilAsserted(() -> {
             final var hivemqCustomResource =
-                    K8sUtil.getHiveMQPlatform(client, platformNamespace, PLATFORM_RELEASE_NAME).get();
+                    K8sUtil.getHiveMQPlatform(client, platformNamespace, platformReleaseName).get();
             assertThat(hivemqCustomResource.getAdditionalProperties().get("spec")).isNotNull()
                     .asString()
                     .containsIgnoringCase("secretName=" + secretName);
 
             final var statefulSet =
-                    client.apps().statefulSets().inNamespace(platformNamespace).withName(PLATFORM_RELEASE_NAME).get();
+                    client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
             assertThat(statefulSet).isNotNull();
             assertThat(K8sUtil.getHiveMQContainer(statefulSet.getSpec()).getVolumeMounts()) //
                     .anyMatch(volumeMount -> volumeMount.getName().equals("broker-configuration") &&

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmInstallRemoteImagesIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmInstallRemoteImagesIT.java
@@ -24,7 +24,7 @@ class HelmInstallRemoteImagesIT extends AbstractHelmChartIT {
         await().atMost(TWO_MINUTES).untilAsserted(() -> {
             // check the StatefulSet spec contains the same default "ghcr" imagePullSecrets as per the default created for the operator
             final var statefulSet =
-                    client.apps().statefulSets().inNamespace(platformNamespace).withName(PLATFORM_RELEASE_NAME).get();
+                    client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
             assertThat(statefulSet).isNotNull()
                     .extracting(StatefulSet::getSpec)
                     .satisfies(statefulSetSpec -> assertThat(statefulSetSpec.getTemplate().getSpec()) //

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmPlatformMutualTlsIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmPlatformMutualTlsIT.java
@@ -30,12 +30,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class HelmPlatformMutualTlsIT extends AbstractHelmChartIT {
 
+    private static final int MQTT_SERVICE_PORT_1884 = 1884;
+    private static final int MQTT_SERVICE_PORT_1885 = 1885;
+
     private static final @NotNull Logger LOG = LoggerFactory.getLogger(HelmPlatformMutualTlsIT.class);
 
-    private static final int MQTT_SERVICE_PORT_1884 = 1884;
-    private static final @NotNull String MQTT_SERVICE_NAME_1884 = "hivemq-test-hivemq-platform-mqtt-1884";
-    private static final int MQTT_SERVICE_PORT_1885 = 1885;
-    private static final @NotNull String MQTT_SERVICE_NAME_1885 = "hivemq-test-hivemq-platform-mqtt-1885";
+    private final @NotNull String mqttServiceName1884 =
+            "hivemq-%s-mqtt-%s".formatted(platformReleaseName, MQTT_SERVICE_PORT_1884);
+    private final @NotNull String mqttServiceName1885 =
+            "hivemq-%s-mqtt-%s".formatted(platformReleaseName, MQTT_SERVICE_PORT_1885);
 
     @TempDir
     private @NotNull Path tmp;
@@ -85,11 +88,11 @@ class HelmPlatformMutualTlsIT extends AbstractHelmChartIT {
         installPlatformChartAndWaitToBeRunning("/files/mtls-mqtt-values.yaml");
 
         final var statefulSet =
-                client.apps().statefulSets().inNamespace(platformNamespace).withName(PLATFORM_RELEASE_NAME).get();
+                client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
         assertThat(statefulSet).isNotNull();
 
         LOG.info("Connecting to MQTT listener with no mTLS/SSL on port {}", DEFAULT_MQTT_SERVICE_PORT);
-        assertMqttListener(DEFAULT_MQTT_SERVICE_NAME, DEFAULT_MQTT_SERVICE_PORT);
+        assertMqttListener(defaultMqttServiceName, DEFAULT_MQTT_SERVICE_PORT);
 
         final var sslConfig = MqttClientSslConfig.builder()
                 .keyManagerFactory(keyManagerFromKeystore(brokerCertificateStore.toFile(),
@@ -103,12 +106,12 @@ class HelmPlatformMutualTlsIT extends AbstractHelmChartIT {
         LOG.info("Connecting to MQTT listener mTLS/SSL on port {}", MQTT_SERVICE_PORT_1884);
         assertSecretMounted(statefulSet, "mqtts-keystore-1884");
         assertSecretMounted(statefulSet, "mqtts-truststore-1884");
-        assertMqttListener(MQTT_SERVICE_NAME_1884, MQTT_SERVICE_PORT_1884, sslConfig);
+        assertMqttListener(mqttServiceName1884, MQTT_SERVICE_PORT_1884, sslConfig);
 
         LOG.info("Connecting to MQTT listener mTLS/SSL on port {}", MQTT_SERVICE_PORT_1885);
         assertSecretMounted(statefulSet, "mqtts-keystore-1885");
         assertSecretMounted(statefulSet, "mqtts-truststore-1885");
-        assertMqttListener(MQTT_SERVICE_NAME_1885, MQTT_SERVICE_PORT_1885, sslConfig);
+        assertMqttListener(mqttServiceName1885, MQTT_SERVICE_PORT_1885, sslConfig);
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmPlatformTlsIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmPlatformTlsIT.java
@@ -54,13 +54,8 @@ class HelmPlatformTlsIT extends AbstractHelmPlatformTlsIT {
                 .hostnameVerifier((hostname, session) -> true)
                 .build();
 
-        assertMqttListener(DEFAULT_MQTT_SERVICE_NAME, DEFAULT_MQTT_SERVICE_PORT, sslConfig);
-        assertMqttListener(MQTT_SERVICE_NAME_1884, MQTT_SERVICE_PORT_1884, sslConfig);
-        assertLogin(client,
-                platformNamespace,
-                webDriverContainer,
-                HIVEMQ_CC_SERVICE_NAME,
-                HIVEMQ_CC_SERVICE_PORT,
-                true);
+        assertMqttListener(defaultMqttServiceName, DEFAULT_MQTT_SERVICE_PORT, sslConfig);
+        assertMqttListener(mqttServiceName1884, MQTT_SERVICE_PORT_1884, sslConfig);
+        assertLogin(client, platformNamespace, webDriverContainer, hivemqCcServiceName, HIVEMQ_CC_SERVICE_PORT, true);
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmPlatformTlsWithPrivateKeyIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmPlatformTlsWithPrivateKeyIT.java
@@ -50,8 +50,8 @@ class HelmPlatformTlsWithPrivateKeyIT extends AbstractHelmPlatformTlsIT {
                 .hostnameVerifier((hostname, session) -> true)
                 .build();
 
-        assertMqttListener(MQTT_SERVICE_NAME_1884, MQTT_SERVICE_PORT_1884, sslConfig);
-        assertMqttListener(MQTT_SERVICE_NAME_1885, MQTT_SERVICE_PORT_1885, sslConfig);
-        assertMqttListener(MQTT_SERVICE_NAME_1886, MQTT_SERVICE_PORT_1886);
+        assertMqttListener(mqttServiceName1884, MQTT_SERVICE_PORT_1884, sslConfig);
+        assertMqttListener(mqttServiceName1885, MQTT_SERVICE_PORT_1885, sslConfig);
+        assertMqttListener(mqttServiceName1886, MQTT_SERVICE_PORT_1886);
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmRollingUpgradePlatformIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmRollingUpgradePlatformIT.java
@@ -33,7 +33,7 @@ class HelmRollingUpgradePlatformIT extends AbstractHelmChartIT {
         LOG.info("Current platform chart: {}", helmChartContainer.getPlatformChart());
         LOG.info("Previous platform chart: {}", helmChartContainer.getPreviousPlatformChart());
 
-        helmChartContainer.installPlatformChart(PLATFORM_RELEASE_NAME,
+        helmChartContainer.installPlatformChart(platformReleaseName,
                 false,
                 "--set",
                 "nodes.replicaCount=1",
@@ -41,16 +41,16 @@ class HelmRollingUpgradePlatformIT extends AbstractHelmChartIT {
                 previousPlatformChart.getVersion().toString(),
                 "--namespace",
                 platformNamespace);
-        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, platformReleaseName);
         final var currentPodRevisionHash = client.pods()
                 .inNamespace(platformNamespace)
-                .withName(PLATFORM_RELEASE_NAME + "-0")
+                .withName(platformReleaseName + "-0")
                 .get()
                 .getMetadata()
                 .getLabels()
                 .get(STS_REVISION_HASH);
 
-        helmChartContainer.upgradePlatformChart(PLATFORM_RELEASE_NAME,
+        helmChartContainer.upgradePlatformChart(platformReleaseName,
                 true,
                 "--set",
                 "nodes.replicaCount=1",
@@ -63,7 +63,7 @@ class HelmRollingUpgradePlatformIT extends AbstractHelmChartIT {
                 // needed to avoid SSA conflicts on label changes in the platform that are managed by the operator
                 "--force-conflicts");
 
-        final var platform = K8sUtil.getHiveMQPlatform(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        final var platform = K8sUtil.getHiveMQPlatform(client, platformNamespace, platformReleaseName);
         final var requiresRollingRestart =
                 !previousPlatformChart.getAppVersion().equals(currentPlatformChart.getAppVersion());
         if (requiresRollingRestart) {
@@ -75,7 +75,7 @@ class HelmRollingUpgradePlatformIT extends AbstractHelmChartIT {
         platform.waitUntilCondition(K8sUtil.getCustomResourceStateCondition("RUNNING"), 3, TimeUnit.MINUTES);
         final var updatedPodRevisionHash = client.pods()
                 .inNamespace(platformNamespace)
-                .withName(PLATFORM_RELEASE_NAME + "-0")
+                .withName(platformReleaseName + "-0")
                 .get()
                 .getMetadata()
                 .getLabels()
@@ -88,7 +88,7 @@ class HelmRollingUpgradePlatformIT extends AbstractHelmChartIT {
                     .isNotEqualTo(currentPodRevisionHash);
             assertThat(client.pods()
                     .inNamespace(platformNamespace)
-                    .withName(PLATFORM_RELEASE_NAME + "-0")
+                    .withName(platformReleaseName + "-0")
                     .get()
                     .getSpec()
                     .getContainers()
@@ -101,7 +101,7 @@ class HelmRollingUpgradePlatformIT extends AbstractHelmChartIT {
                     .isEqualTo(currentPodRevisionHash);
             assertThat(client.pods()
                     .inNamespace(platformNamespace)
-                    .withName(PLATFORM_RELEASE_NAME + "-0")
+                    .withName(platformReleaseName + "-0")
                     .get()
                     .getSpec()
                     .getContainers()

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmUpgradePlatformIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/HelmUpgradePlatformIT.java
@@ -22,9 +22,9 @@ class HelmUpgradePlatformIT extends AbstractHelmChartIT {
         installPlatformChartAndWaitToBeRunning("--set", "nodes.replicaCount=1");
         LOG.debug("Platform ready");
 
-        upgradePlatformChart(PLATFORM_RELEASE_NAME, "--set", "nodes.replicaCount=2");
+        upgradePlatformChart(platformReleaseName, "--set", "nodes.replicaCount=2");
 
-        final var hivemqCustomResource = K8sUtil.getHiveMQPlatform(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        final var hivemqCustomResource = K8sUtil.getHiveMQPlatform(client, platformNamespace, platformReleaseName);
         hivemqCustomResource.waitUntilCondition(K8sUtil.getCustomResourceStateCondition("SCALING"),
                 2,
                 TimeUnit.MINUTES);
@@ -36,7 +36,7 @@ class HelmUpgradePlatformIT extends AbstractHelmChartIT {
         LOG.debug("Platform upgraded");
 
         final var upgradedStatefulSet =
-                client.apps().statefulSets().inNamespace(platformNamespace).withName(PLATFORM_RELEASE_NAME).get();
+                client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
         assertThat(upgradedStatefulSet.getStatus().getAvailableReplicas()).isEqualTo(2);
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/UpdateLogLevelIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/platform/UpdateLogLevelIT.java
@@ -50,7 +50,7 @@ class UpdateLogLevelIT extends AbstractHelmChartIT {
             installPlatformOperatorChartAndWaitToBeRunning();
         }
         installPlatformChartAndWaitToBeRunning("/files/platform-values.yaml");
-        final var hivemqCustomResource = K8sUtil.getHiveMQPlatform(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        final var hivemqCustomResource = K8sUtil.getHiveMQPlatform(client, platformNamespace, platformReleaseName);
 
         await().untilAsserted(() -> {
             LOG.info("Assert original logback.xml in pods");
@@ -59,12 +59,12 @@ class UpdateLogLevelIT extends AbstractHelmChartIT {
                     .list()
                     .getItems()
                     .stream()
-                    .filter(pod -> pod.getMetadata().getName().startsWith(PLATFORM_RELEASE_NAME + "-"))) //
+                    .filter(pod -> pod.getMetadata().getName().startsWith(platformReleaseName + "-"))) //
                     .allSatisfy(pod -> assertThatLogbackXmlContains(pod, "<root level=\"${HIVEMQ_LOG_LEVEL:-INFO}\">"));
         });
 
         LOG.info("Trigger update of log level");
-        upgradePlatformChart(PLATFORM_RELEASE_NAME, "--set", "nodes.replicaCount=1", "--set", "nodes.logLevel=WARN");
+        upgradePlatformChart(platformReleaseName, "--set", "nodes.replicaCount=1", "--set", "nodes.logLevel=WARN");
 
         hivemqCustomResource.waitUntilCondition(K8sUtil.getCustomResourceStateCondition("SET_LOG_LEVEL"),
                 1,
@@ -80,7 +80,7 @@ class UpdateLogLevelIT extends AbstractHelmChartIT {
                     .list()
                     .getItems()
                     .stream()
-                    .filter(pod -> pod.getMetadata().getName().startsWith(PLATFORM_RELEASE_NAME + "-"))) //
+                    .filter(pod -> pod.getMetadata().getName().startsWith(platformReleaseName + "-"))) //
                     .allSatisfy(pod -> assertThatLogbackXmlContains(pod, "<root level=\"WARN\">"));
         });
     }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/securitycontext/HelmContainerSecurityContextInstallPlatformIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/securitycontext/HelmContainerSecurityContextInstallPlatformIT.java
@@ -26,7 +26,7 @@ class HelmContainerSecurityContextInstallPlatformIT extends AbstractHelmContaine
     void installPlatform_withRootAndNonRootUsers_hivemqRunning(final @NotNull ChartValues chartValues)
             throws Exception {
         installPlatformOperatorChartAndWaitToBeRunning(chartValues.operator().valuesFile());
-        final var operatorLabels = K8sUtil.getHiveMQPlatformOperatorLabels(OPERATOR_RELEASE_NAME);
+        final var operatorLabels = K8sUtil.getHiveMQPlatformOperatorLabels(operatorReleaseName);
         assertUidAndGid(operatorNamespace,
                 operatorLabels,
                 "hivemq-platform-operator",
@@ -34,7 +34,7 @@ class HelmContainerSecurityContextInstallPlatformIT extends AbstractHelmContaine
                 chartValues.operator().gid());
 
         installPlatformChartAndWaitToBeRunning(chartValues.platform().valuesFile());
-        final var platformLabels = K8sUtil.getHiveMQPlatformLabels(PLATFORM_RELEASE_NAME);
+        final var platformLabels = K8sUtil.getHiveMQPlatformLabels(platformReleaseName);
         assertUidAndGid(platformNamespace,
                 platformLabels,
                 "hivemq",
@@ -50,7 +50,7 @@ class HelmContainerSecurityContextInstallPlatformIT extends AbstractHelmContaine
                 operatorChartNonRootUserValuesFile(),
                 "--set",
                 "containerSecurityContext.runAsUser=" + operatorUid);
-        final var operatorLabels = K8sUtil.getHiveMQPlatformOperatorLabels(OPERATOR_RELEASE_NAME);
+        final var operatorLabels = K8sUtil.getHiveMQPlatformOperatorLabels(operatorReleaseName);
         assertUidAndGid(operatorNamespace, operatorLabels, "hivemq-platform-operator", operatorUid, 0);
 
         final var platformUid = ThreadLocalRandom.current().nextInt(MIN_UID, MAX_UID);
@@ -58,7 +58,7 @@ class HelmContainerSecurityContextInstallPlatformIT extends AbstractHelmContaine
                 platformChartNonRootUserValuesFile(),
                 "--set",
                 "nodes.containerSecurityContext.runAsUser=" + platformUid);
-        final var platformLabels = K8sUtil.getHiveMQPlatformLabels(PLATFORM_RELEASE_NAME);
+        final var platformLabels = K8sUtil.getHiveMQPlatformLabels(platformReleaseName);
         assertUidAndGid(platformNamespace, //
                 platformLabels, //
                 "hivemq", //

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/securitycontext/HelmContainerSecurityContextUpgradeExtensionIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/securitycontext/HelmContainerSecurityContextUpgradeExtensionIT.java
@@ -14,6 +14,11 @@ import static org.awaitility.Durations.ONE_MINUTE;
 class HelmContainerSecurityContextUpgradeExtensionIT extends AbstractHelmContainerSecurityContextIT {
 
     @Override
+    protected @NotNull String getReleaseBaseName() {
+        return "container-sc-upgrade-extension";
+    }
+
+    @Override
     protected boolean installPlatformOperatorChart() {
         return false;
     }
@@ -34,7 +39,7 @@ class HelmContainerSecurityContextUpgradeExtensionIT extends AbstractHelmContain
     void updateExtensionConfigMap_withRootAndNonRootUsers_rollingRestart(final @NotNull ChartValues chartValues)
             throws Exception {
         installPlatformOperatorChartAndWaitToBeRunning(chartValues.operator().valuesFile());
-        final var operatorLabels = K8sUtil.getHiveMQPlatformOperatorLabels(OPERATOR_RELEASE_NAME);
+        final var operatorLabels = K8sUtil.getHiveMQPlatformOperatorLabels(operatorReleaseName);
         assertUidAndGid(operatorNamespace,
                 operatorLabels,
                 "hivemq-platform-operator",
@@ -46,7 +51,7 @@ class HelmContainerSecurityContextUpgradeExtensionIT extends AbstractHelmContain
                 ".*Extension \"HiveMQ Enterprise Distributed Tracing Extension\" version .* started successfully.");
 
         installPlatformChartAndWaitToBeRunning(chartValues.platform().valuesFile());
-        final var platformLabels = K8sUtil.getHiveMQPlatformLabels(PLATFORM_RELEASE_NAME);
+        final var platformLabels = K8sUtil.getHiveMQPlatformLabels(platformReleaseName);
         assertUidAndGid(platformNamespace,
                 platformLabels,
                 "hivemq",
@@ -58,7 +63,7 @@ class HelmContainerSecurityContextUpgradeExtensionIT extends AbstractHelmContain
         final var configurationUpdatedFuture = waitForPlatformLog(
                 ".*HiveMQ Enterprise Distributed Tracing Extension: Successfully updated configuration from '/opt/hivemq/extensions/hivemq-distributed-tracing-extension/conf/config.xml'.");
 
-        final var hivemqCustomResource = K8sUtil.getHiveMQPlatform(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        final var hivemqCustomResource = K8sUtil.getHiveMQPlatform(client, platformNamespace, platformReleaseName);
         hivemqCustomResource.waitUntilCondition(K8sUtil.getCustomResourceStateCondition("RESTART_EXTENSIONS"),
                 3,
                 TimeUnit.MINUTES);

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/securitycontext/HelmContainerSecurityContextUpgradePlatformIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/securitycontext/HelmContainerSecurityContextUpgradePlatformIT.java
@@ -11,6 +11,11 @@ import java.util.concurrent.TimeUnit;
 class HelmContainerSecurityContextUpgradePlatformIT extends AbstractHelmContainerSecurityContextIT {
 
     @Override
+    protected @NotNull String getReleaseBaseName() {
+        return "container-sc-upgrade-platform";
+    }
+
+    @Override
     protected boolean installPlatformOperatorChart() {
         return false;
     }
@@ -21,7 +26,7 @@ class HelmContainerSecurityContextUpgradePlatformIT extends AbstractHelmContaine
     void updateConfigMap_withRootAndNonRootUsers_rollingRestart(final @NotNull ChartValues chartValues)
             throws Exception {
         installPlatformOperatorChartAndWaitToBeRunning(chartValues.operator().valuesFile());
-        final var operatorLabels = K8sUtil.getHiveMQPlatformOperatorLabels(OPERATOR_RELEASE_NAME);
+        final var operatorLabels = K8sUtil.getHiveMQPlatformOperatorLabels(operatorReleaseName);
         assertUidAndGid(operatorNamespace,
                 operatorLabels,
                 "hivemq-platform-operator",
@@ -29,14 +34,17 @@ class HelmContainerSecurityContextUpgradePlatformIT extends AbstractHelmContaine
                 chartValues.operator().gid());
 
         installPlatformChartAndWaitToBeRunning(chartValues.platform().valuesFile());
-        final var platformLabels = K8sUtil.getHiveMQPlatformLabels(PLATFORM_RELEASE_NAME);
+        final var platformLabels = K8sUtil.getHiveMQPlatformLabels(platformReleaseName);
         assertUidAndGid(platformNamespace,
                 platformLabels,
                 "hivemq",
                 chartValues.platform().uid(),
                 chartValues.platform().gid());
 
-        K8sUtil.updateConfigMap(client, platformNamespace, "hivemq-config-map-update.yml");
-        K8sUtil.waitForHiveMQPlatformStateRunningAfterRollingRestart(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        K8sUtil.updateConfigMap(client,
+                platformNamespace,
+                "hivemq-config-map-update.yml",
+                "hivemq-configuration-" + platformReleaseName);
+        K8sUtil.waitForHiveMQPlatformStateRunningAfterRollingRestart(client, platformNamespace, platformReleaseName);
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/securitycontext/HelmPodSecurityContextInstallPlatformIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/securitycontext/HelmPodSecurityContextInstallPlatformIT.java
@@ -26,7 +26,7 @@ class HelmPodSecurityContextInstallPlatformIT extends AbstractHelmPodSecurityCon
     void installPlatform_withRootAndNonRootUsers_hivemqRunning(final @NotNull ChartValues chartValues)
             throws Exception {
         installPlatformOperatorChartAndWaitToBeRunning(chartValues.operator().valuesFile());
-        final var operatorLabels = K8sUtil.getHiveMQPlatformOperatorLabels(OPERATOR_RELEASE_NAME);
+        final var operatorLabels = K8sUtil.getHiveMQPlatformOperatorLabels(operatorReleaseName);
         assertUidAndGid(operatorNamespace,
                 operatorLabels,
                 "hivemq-platform-operator",
@@ -34,7 +34,7 @@ class HelmPodSecurityContextInstallPlatformIT extends AbstractHelmPodSecurityCon
                 chartValues.operator().gid());
 
         installPlatformChartAndWaitToBeRunning(chartValues.platform().valuesFile());
-        final var platformLabels = K8sUtil.getHiveMQPlatformLabels(PLATFORM_RELEASE_NAME);
+        final var platformLabels = K8sUtil.getHiveMQPlatformLabels(platformReleaseName);
         assertUidAndGid(platformNamespace,
                 platformLabels,
                 "hivemq",
@@ -50,7 +50,7 @@ class HelmPodSecurityContextInstallPlatformIT extends AbstractHelmPodSecurityCon
                 operatorChartNonRootUserValuesFile(),
                 "--set",
                 "podSecurityContext.runAsUser=" + operatorUid);
-        final var operatorLabels = K8sUtil.getHiveMQPlatformOperatorLabels(OPERATOR_RELEASE_NAME);
+        final var operatorLabels = K8sUtil.getHiveMQPlatformOperatorLabels(operatorReleaseName);
         assertUidAndGid(operatorNamespace, operatorLabels, "hivemq-platform-operator", operatorUid, 0);
 
         final var platformUid = ThreadLocalRandom.current().nextInt(MIN_UID, MAX_UID);
@@ -58,7 +58,7 @@ class HelmPodSecurityContextInstallPlatformIT extends AbstractHelmPodSecurityCon
                 platformChartNonRootUserValuesFile(),
                 "--set",
                 "nodes.podSecurityContext.runAsUser=" + platformUid);
-        final var platformLabels = K8sUtil.getHiveMQPlatformLabels(PLATFORM_RELEASE_NAME);
+        final var platformLabels = K8sUtil.getHiveMQPlatformLabels(platformReleaseName);
         assertUidAndGid(platformNamespace, //
                 platformLabels, //
                 "hivemq", //

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/securitycontext/HelmPodSecurityContextUpgradeExtensionIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/securitycontext/HelmPodSecurityContextUpgradeExtensionIT.java
@@ -34,7 +34,7 @@ class HelmPodSecurityContextUpgradeExtensionIT extends AbstractHelmPodSecurityCo
     void updateExtensionConfigMap_withRootAndNonRootUsers_rollingRestart(final @NotNull ChartValues chartValues)
             throws Exception {
         installPlatformOperatorChartAndWaitToBeRunning(chartValues.operator().valuesFile());
-        final var operatorLabels = K8sUtil.getHiveMQPlatformOperatorLabels(OPERATOR_RELEASE_NAME);
+        final var operatorLabels = K8sUtil.getHiveMQPlatformOperatorLabels(operatorReleaseName);
         assertUidAndGid(operatorNamespace,
                 operatorLabels,
                 "hivemq-platform-operator",
@@ -46,7 +46,7 @@ class HelmPodSecurityContextUpgradeExtensionIT extends AbstractHelmPodSecurityCo
                 ".*Extension \"HiveMQ Enterprise Distributed Tracing Extension\" version .* started successfully.");
 
         installPlatformChartAndWaitToBeRunning(chartValues.platform().valuesFile());
-        final var platformLabels = K8sUtil.getHiveMQPlatformLabels(PLATFORM_RELEASE_NAME);
+        final var platformLabels = K8sUtil.getHiveMQPlatformLabels(platformReleaseName);
         assertUidAndGid(platformNamespace,
                 platformLabels,
                 "hivemq",
@@ -58,7 +58,7 @@ class HelmPodSecurityContextUpgradeExtensionIT extends AbstractHelmPodSecurityCo
         final var configurationUpdatedFuture = waitForPlatformLog(
                 ".*HiveMQ Enterprise Distributed Tracing Extension: Successfully updated configuration from '/opt/hivemq/extensions/hivemq-distributed-tracing-extension/conf/config.xml'.");
 
-        final var hivemqCustomResource = K8sUtil.getHiveMQPlatform(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        final var hivemqCustomResource = K8sUtil.getHiveMQPlatform(client, platformNamespace, platformReleaseName);
         hivemqCustomResource.waitUntilCondition(K8sUtil.getCustomResourceStateCondition("RESTART_EXTENSIONS"),
                 3,
                 TimeUnit.MINUTES);

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/securitycontext/HelmPodSecurityContextUpgradePlatformIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/securitycontext/HelmPodSecurityContextUpgradePlatformIT.java
@@ -21,7 +21,7 @@ class HelmPodSecurityContextUpgradePlatformIT extends AbstractHelmPodSecurityCon
     void updateConfigMap_withRootAndNonRootUsers_rollingRestart(final @NotNull ChartValues chartValues)
             throws Exception {
         installPlatformOperatorChartAndWaitToBeRunning(chartValues.operator().valuesFile());
-        final var operatorLabels = K8sUtil.getHiveMQPlatformOperatorLabels(OPERATOR_RELEASE_NAME);
+        final var operatorLabels = K8sUtil.getHiveMQPlatformOperatorLabels(operatorReleaseName);
         assertUidAndGid(operatorNamespace,
                 operatorLabels,
                 "hivemq-platform-operator",
@@ -29,14 +29,17 @@ class HelmPodSecurityContextUpgradePlatformIT extends AbstractHelmPodSecurityCon
                 chartValues.operator().gid());
 
         installPlatformChartAndWaitToBeRunning(chartValues.platform().valuesFile());
-        final var platformLabels = K8sUtil.getHiveMQPlatformLabels(PLATFORM_RELEASE_NAME);
+        final var platformLabels = K8sUtil.getHiveMQPlatformLabels(platformReleaseName);
         assertUidAndGid(platformNamespace,
                 platformLabels,
                 "hivemq",
                 chartValues.platform().uid(),
                 chartValues.platform().gid());
 
-        K8sUtil.updateConfigMap(client, platformNamespace, "hivemq-config-map-update.yml");
-        K8sUtil.waitForHiveMQPlatformStateRunningAfterRollingRestart(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        K8sUtil.updateConfigMap(client,
+                platformNamespace,
+                "hivemq-config-map-update.yml",
+                "hivemq-configuration-" + platformReleaseName);
+        K8sUtil.waitForHiveMQPlatformStateRunningAfterRollingRestart(client, platformNamespace, platformReleaseName);
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/serviceaccount/HelmCustomServiceAccountCreateMissingPermissionsIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/serviceaccount/HelmCustomServiceAccountCreateMissingPermissionsIT.java
@@ -1,6 +1,7 @@
 package com.hivemq.helmcharts.serviceaccount;
 
 import com.hivemq.helmcharts.util.K8sUtil;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -11,19 +12,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class HelmCustomServiceAccountCreateMissingPermissionsIT extends AbstractHelmCustomServiceAccountIT {
 
+    @Override
+    protected @NotNull String getReleaseBaseName() {
+        return "custom-sa-create-missing-perm";
+    }
+
     @Test
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void platformCharts_withNonExistingPermissionsThenCreate_hivemqRunning() throws Exception {
         K8sUtil.createServiceAccount(client, platformNamespace, SERVICE_ACCOUNT_NAME);
 
-        helmChartContainer.installPlatformOperatorChart(OPERATOR_RELEASE_NAME,
+        helmChartContainer.installPlatformOperatorChart(operatorReleaseName,
                 "--set",
                 "hivemqPlatformServiceAccount.create=false",
                 "--set",
                 "hivemqPlatformServiceAccount.permissions.create=false",
                 "--namespace",
                 operatorNamespace);
-        helmChartContainer.installPlatformChart(PLATFORM_RELEASE_NAME,
+        helmChartContainer.installPlatformChart(platformReleaseName,
                 "--set",
                 "nodes.serviceAccountName=" + SERVICE_ACCOUNT_NAME,
                 "--set",
@@ -32,7 +38,7 @@ class HelmCustomServiceAccountCreateMissingPermissionsIT extends AbstractHelmCus
                 platformNamespace);
 
         final var hivemqCustomResource =
-                K8sUtil.waitForHiveMQPlatformState(client, platformNamespace, PLATFORM_RELEASE_NAME, "ERROR");
+                K8sUtil.waitForHiveMQPlatformState(client, platformNamespace, platformReleaseName, "ERROR");
         //noinspection unchecked
         assertThat((Map<String, String>) hivemqCustomResource.getAdditionalProperties().get("status")).containsValues(
                 "The ServiceAccount and its permissions are invalid: Found no RoleBinding or ClusterRoleBinding for ServiceAccount '%s'".formatted(
@@ -43,7 +49,7 @@ class HelmCustomServiceAccountCreateMissingPermissionsIT extends AbstractHelmCus
         createRole();
         createRoleBinding();
 
-        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, platformReleaseName);
 
         // assert that the ServiceAccount and permissions are working
         assertPlatformPodAnnotations();

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/serviceaccount/HelmCustomServiceAccountCreateMissingServiceAccountIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/serviceaccount/HelmCustomServiceAccountCreateMissingServiceAccountIT.java
@@ -1,6 +1,7 @@
 package com.hivemq.helmcharts.serviceaccount;
 
 import com.hivemq.helmcharts.util.K8sUtil;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -11,11 +12,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class HelmCustomServiceAccountCreateMissingServiceAccountIT extends AbstractHelmCustomServiceAccountIT {
 
+    @Override
+    protected @NotNull String getReleaseBaseName() {
+        return "custom-sa-create-missing-sa";
+    }
+
     @Test
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void platformCharts_withNonExistingCustomServiceAccountThenCreate_hivemqRunning() throws Exception {
-        helmChartContainer.installPlatformOperatorChart(OPERATOR_RELEASE_NAME, "--namespace", operatorNamespace);
-        helmChartContainer.installPlatformChart(PLATFORM_RELEASE_NAME,
+        helmChartContainer.installPlatformOperatorChart(operatorReleaseName, "--namespace", operatorNamespace);
+        helmChartContainer.installPlatformChart(platformReleaseName,
                 "--set",
                 "nodes.serviceAccountName=" + SERVICE_ACCOUNT_NAME,
                 "--set",
@@ -24,7 +30,7 @@ class HelmCustomServiceAccountCreateMissingServiceAccountIT extends AbstractHelm
                 platformNamespace);
 
         final var hivemqCustomResource =
-                K8sUtil.waitForHiveMQPlatformState(client, platformNamespace, PLATFORM_RELEASE_NAME, "ERROR");
+                K8sUtil.waitForHiveMQPlatformState(client, platformNamespace, platformReleaseName, "ERROR");
         //noinspection unchecked
         assertThat((Map<String, String>) hivemqCustomResource.getAdditionalProperties().get("status")).containsValues(
                 "The ServiceAccount and its permissions are invalid: The ServiceAccount '%s' does not exist".formatted(
@@ -34,7 +40,7 @@ class HelmCustomServiceAccountCreateMissingServiceAccountIT extends AbstractHelm
         // create missing ServiceAccount
         K8sUtil.createServiceAccount(client, platformNamespace, SERVICE_ACCOUNT_NAME);
 
-        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, platformReleaseName);
 
         // assert that the ServiceAccount and permissions are working
         assertPlatformPodAnnotations();

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/serviceaccount/HelmCustomServiceAccountDisabledCreationAndValidationCreateMissingServiceAccountIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/serviceaccount/HelmCustomServiceAccountDisabledCreationAndValidationCreateMissingServiceAccountIT.java
@@ -1,6 +1,7 @@
 package com.hivemq.helmcharts.serviceaccount;
 
 import com.hivemq.helmcharts.util.K8sUtil;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -9,10 +10,15 @@ import java.util.concurrent.TimeUnit;
 class HelmCustomServiceAccountDisabledCreationAndValidationCreateMissingServiceAccountIT
         extends AbstractHelmCustomServiceAccountIT {
 
+    @Override
+    protected @NotNull String getReleaseBaseName() {
+        return "custom-sa-disabled-create-miss";
+    }
+
     @Test
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void platformCharts_withCreateAndValidateDisabled_hivemqRunning() throws Exception {
-        helmChartContainer.installPlatformOperatorChart(OPERATOR_RELEASE_NAME,
+        helmChartContainer.installPlatformOperatorChart(operatorReleaseName,
                 "--set",
                 "hivemqPlatformServiceAccount.create=false",
                 "--set",
@@ -23,7 +29,7 @@ class HelmCustomServiceAccountDisabledCreationAndValidationCreateMissingServiceA
                 "hivemqPlatformServiceAccount.permissions.validate=false",
                 "--namespace",
                 operatorNamespace);
-        helmChartContainer.installPlatformChart(PLATFORM_RELEASE_NAME,
+        helmChartContainer.installPlatformChart(platformReleaseName,
                 "--set",
                 "nodes.serviceAccountName=" + SERVICE_ACCOUNT_NAME,
                 "--set",
@@ -36,7 +42,7 @@ class HelmCustomServiceAccountDisabledCreationAndValidationCreateMissingServiceA
         createRole();
         createRoleBinding();
 
-        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, platformReleaseName);
 
         // assert that the ServiceAccount and permissions are working
         assertPlatformPodAnnotations();

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/serviceaccount/HelmCustomServiceAccountDisabledCreationAndValidationIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/serviceaccount/HelmCustomServiceAccountDisabledCreationAndValidationIT.java
@@ -1,12 +1,18 @@
 package com.hivemq.helmcharts.serviceaccount;
 
 import com.hivemq.helmcharts.util.K8sUtil;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.TimeUnit;
 
 class HelmCustomServiceAccountDisabledCreationAndValidationIT extends AbstractHelmCustomServiceAccountIT {
+
+    @Override
+    protected @NotNull String getReleaseBaseName() {
+        return "custom-sa-disabled-validation";
+    }
 
     @Test
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
@@ -16,7 +22,7 @@ class HelmCustomServiceAccountDisabledCreationAndValidationIT extends AbstractHe
         createRole();
         createRoleBinding();
 
-        helmChartContainer.installPlatformOperatorChart(OPERATOR_RELEASE_NAME,
+        helmChartContainer.installPlatformOperatorChart(operatorReleaseName,
                 "--set",
                 "hivemqPlatformServiceAccount.create=false",
                 "--set",
@@ -27,7 +33,7 @@ class HelmCustomServiceAccountDisabledCreationAndValidationIT extends AbstractHe
                 "hivemqPlatformServiceAccount.permissions.validate=false",
                 "--namespace",
                 operatorNamespace);
-        helmChartContainer.installPlatformChart(PLATFORM_RELEASE_NAME,
+        helmChartContainer.installPlatformChart(platformReleaseName,
                 "--set",
                 "nodes.serviceAccountName=" + SERVICE_ACCOUNT_NAME,
                 "--set",
@@ -35,7 +41,7 @@ class HelmCustomServiceAccountDisabledCreationAndValidationIT extends AbstractHe
                 "--namespace",
                 platformNamespace);
 
-        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        K8sUtil.waitForHiveMQPlatformStateRunning(client, platformNamespace, platformReleaseName);
 
         // assert that the ServiceAccount and permissions are working
         assertPlatformPodAnnotations();

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/AbstractHelmControlCenterIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/AbstractHelmControlCenterIT.java
@@ -22,10 +22,11 @@ class AbstractHelmControlCenterIT extends AbstractHelmChartIT {
     static final int CC_SERVICE_PORT_8081 = 8081;
     static final int CC_SERVICE_PORT_8443 = 8443;
     static final int CC_SERVICE_PORT_8444 = 8444;
-    static final @NotNull String CC_SERVICE_NAME_8081 = "hivemq-test-hivemq-platform-cc-" + CC_SERVICE_PORT_8081;
-    static final @NotNull String CC_SERVICE_NAME_8443 = "hivemq-test-hivemq-platform-cc-" + CC_SERVICE_PORT_8443;
-    static final @NotNull String CC_SERVICE_NAME_8444 = "hivemq-test-hivemq-platform-cc-" + CC_SERVICE_PORT_8444;
     static final @NotNull String CC_CUSTOM_SERVICE_NAME = "control-center-service";
+
+    final @NotNull String ccServiceName8081 = "hivemq-%s-cc-%s".formatted(platformReleaseName, CC_SERVICE_PORT_8081);
+    final @NotNull String ccServiceName8443 = "hivemq-%s-cc-%s".formatted(platformReleaseName, CC_SERVICE_PORT_8443);
+    final @NotNull String ccServiceName8444 = "hivemq-%s-cc-%s".formatted(platformReleaseName, CC_SERVICE_PORT_8444);
 
     @TempDir
     @NotNull Path tmp;

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/CustomClusterDomainNameIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/CustomClusterDomainNameIT.java
@@ -16,15 +16,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 @AdditionalK3sCommands(commands = {"--cluster-domain=hivemq.com"})
 class CustomClusterDomainNameIT extends AbstractHelmChartIT {
 
-    private static final @NotNull String MQTT_SERVICE_NAME = "hivemq-test-hivemq-platform-mqtt-1884";
     private static final int MQTT_SERVICE_PORT = 1884;
+
+    private final @NotNull String mqttServiceName =
+            "hivemq-%s-mqtt-%s".formatted(platformReleaseName, MQTT_SERVICE_PORT);
 
     @Test
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void whenK8sHasCustomClusterDomainName_thenServicesAreRunning() throws Exception {
         installPlatformChartAndWaitToBeRunning("/files/mqtt-values.yaml");
-        K8sUtil.assertMqttService(client, platformNamespace, MQTT_SERVICE_NAME);
-        MqttUtil.assertMessages(client, platformNamespace, MQTT_SERVICE_NAME, MQTT_SERVICE_PORT);
+        K8sUtil.assertMqttService(client, platformNamespace, mqttServiceName);
+        MqttUtil.assertMessages(client, platformNamespace, mqttServiceName, MQTT_SERVICE_PORT);
 
         // assert cluster domain name is set as expected `hivemq.com` and does not contain default `cluster.local`
         client.pods().inNamespace(platformNamespace).list().getItems().forEach(pod -> {

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmControlCenterCredentialsSecretIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmControlCenterCredentialsSecretIT.java
@@ -30,7 +30,7 @@ class HelmControlCenterCredentialsSecretIT extends AbstractHelmControlCenterIT {
         assertLogin(client,
                 platformNamespace,
                 webDriverContainer,
-                CC_SERVICE_NAME_8081,
+                ccServiceName8081,
                 CC_SERVICE_PORT_8081,
                 "test-username",
                 "test-password");

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmControlCenterCustomCredentialsIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmControlCenterCustomCredentialsIT.java
@@ -16,7 +16,7 @@ class HelmControlCenterCustomCredentialsIT extends AbstractHelmControlCenterIT {
         assertLogin(client,
                 platformNamespace,
                 webDriverContainer,
-                CC_SERVICE_NAME_8081,
+                ccServiceName8081,
                 CC_SERVICE_PORT_8081,
                 "test-username",
                 "test-password");

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmControlCenterIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmControlCenterIT.java
@@ -13,6 +13,6 @@ class HelmControlCenterIT extends AbstractHelmControlCenterIT {
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void platformChart_whenControlCenterEnabled_thenAbleToLogin() throws Exception {
         installPlatformChartAndWaitToBeRunning("/files/control-center-values.yaml");
-        assertLogin(client, platformNamespace, webDriverContainer, CC_SERVICE_NAME_8081, CC_SERVICE_PORT_8081);
+        assertLogin(client, platformNamespace, webDriverContainer, ccServiceName8081, CC_SERVICE_PORT_8081);
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmControlCenterTlsIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmControlCenterTlsIT.java
@@ -41,8 +41,8 @@ class HelmControlCenterTlsIT extends AbstractHelmControlCenterIT {
 
         installPlatformChartAndWaitToBeRunning("/files/tls-cc-values.yaml");
 
-        assertLogin(client, platformNamespace, webDriverContainer, CC_SERVICE_NAME_8081, CC_SERVICE_PORT_8081);
-        assertLogin(client, platformNamespace, webDriverContainer, CC_SERVICE_NAME_8443, CC_SERVICE_PORT_8443, true);
-        assertLogin(client, platformNamespace, webDriverContainer, CC_SERVICE_NAME_8444, CC_SERVICE_PORT_8444, true);
+        assertLogin(client, platformNamespace, webDriverContainer, ccServiceName8081, CC_SERVICE_PORT_8081);
+        assertLogin(client, platformNamespace, webDriverContainer, ccServiceName8443, CC_SERVICE_PORT_8443, true);
+        assertLogin(client, platformNamespace, webDriverContainer, ccServiceName8444, CC_SERVICE_PORT_8444, true);
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmControlCenterTlsWithPrivateKeyIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmControlCenterTlsWithPrivateKeyIT.java
@@ -41,8 +41,8 @@ class HelmControlCenterTlsWithPrivateKeyIT extends AbstractHelmControlCenterIT {
 
         installPlatformChartAndWaitToBeRunning("/files/tls-cc-with-private-key-values.yaml");
 
-        assertLogin(client, platformNamespace, webDriverContainer, CC_SERVICE_NAME_8081, CC_SERVICE_PORT_8081);
-        assertLogin(client, platformNamespace, webDriverContainer, CC_SERVICE_NAME_8443, CC_SERVICE_PORT_8443, true);
-        assertLogin(client, platformNamespace, webDriverContainer, CC_SERVICE_NAME_8444, CC_SERVICE_PORT_8444, true);
+        assertLogin(client, platformNamespace, webDriverContainer, ccServiceName8081, CC_SERVICE_PORT_8081);
+        assertLogin(client, platformNamespace, webDriverContainer, ccServiceName8443, CC_SERVICE_PORT_8443, true);
+        assertLogin(client, platformNamespace, webDriverContainer, ccServiceName8444, CC_SERVICE_PORT_8444, true);
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmMetricsServiceIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmMetricsServiceIT.java
@@ -12,20 +12,21 @@ import java.util.concurrent.TimeUnit;
 class HelmMetricsServiceIT extends AbstractHelmChartIT {
 
     private static final int METRICS_SERVICE_PORT_9499 = 9499;
-    private static final @NotNull String METRICS_SERVICE_NAME =
-            "hivemq-test-hivemq-platform-metrics-" + METRICS_SERVICE_PORT_9499;
     private static final @NotNull String METRICS_SERVICE_PATH = "/metrics";
+
+    private final @NotNull String metricsServiceName9499 =
+            "hivemq-%s-metrics-%s".formatted(platformReleaseName, METRICS_SERVICE_PORT_9499);
 
     @Test
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void platformChart_withCustomMetrics_thenMetricsAvailable() throws Exception {
         installPlatformChartAndWaitToBeRunning("/files/metrics-values.yaml");
 
-        MqttUtil.assertMessages(client, platformNamespace, DEFAULT_MQTT_SERVICE_NAME, DEFAULT_MQTT_SERVICE_PORT);
+        MqttUtil.assertMessages(client, platformNamespace, defaultMqttServiceName, DEFAULT_MQTT_SERVICE_PORT);
 
         MonitoringUtil.assertSubscribesPublishesMetrics(client,
                 platformNamespace,
-                METRICS_SERVICE_NAME,
+                metricsServiceName9499,
                 METRICS_SERVICE_PORT_9499,
                 METRICS_SERVICE_PATH);
     }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmMqttAnnotationsIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmMqttAnnotationsIT.java
@@ -16,8 +16,9 @@ import static org.awaitility.Durations.ONE_MINUTE;
 class HelmMqttAnnotationsIT extends AbstractHelmChartIT {
 
     private static final int MQTT_SERVICE_PORT_1884 = 1884;
-    private static final @NotNull String MQTT_SERVICE_NAME =
-            "hivemq-test-hivemq-platform-mqtt-" + MQTT_SERVICE_PORT_1884;
+
+    private final @NotNull String mqttServiceName1884 =
+            "hivemq-%s-mqtt-%s".formatted(platformReleaseName, MQTT_SERVICE_PORT_1884);
 
     @Test
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
@@ -26,13 +27,13 @@ class HelmMqttAnnotationsIT extends AbstractHelmChartIT {
         await().atMost(ONE_MINUTE).untilAsserted(() -> {
             final var services = client.services().inNamespace(platformNamespace).list().getItems();
             assertThat(services).isNotEmpty()
-                    .filteredOn(service -> MQTT_SERVICE_NAME.equals(service.getMetadata().getName()))
+                    .filteredOn(service -> mqttServiceName1884.equals(service.getMetadata().getName()))
                     .allSatisfy(service -> assertThat(service.getMetadata()
                             .getAnnotations()).containsAllEntriesOf(Map.of("test-annotation-key",
                             "test-annotation-value",
                             "test-annotation-key/v1",
                             "test-annotation-value-v1")));
         });
-        MqttUtil.assertMessages(client, platformNamespace, MQTT_SERVICE_NAME, MQTT_SERVICE_PORT_1884);
+        MqttUtil.assertMessages(client, platformNamespace, mqttServiceName1884, MQTT_SERVICE_PORT_1884);
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmMqttIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmMqttIT.java
@@ -12,14 +12,15 @@ import java.util.concurrent.TimeUnit;
 class HelmMqttIT extends AbstractHelmChartIT {
 
     private static final int MQTT_SERVICE_PORT_1884 = 1884;
-    private static final @NotNull String MQTT_SERVICE_NAME =
-            "hivemq-test-hivemq-platform-mqtt-" + MQTT_SERVICE_PORT_1884;
+
+    private final @NotNull String mqttServiceName1884 =
+            "hivemq-%s-mqtt-%s".formatted(platformReleaseName, MQTT_SERVICE_PORT_1884);
 
     @Test
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void platformChart_whenMqttEnabled_thenSendsReceivesMessage() throws Exception {
         installPlatformChartAndWaitToBeRunning("/files/mqtt-values.yaml");
-        K8sUtil.assertMqttService(client, platformNamespace, MQTT_SERVICE_NAME);
-        MqttUtil.assertMessages(client, platformNamespace, MQTT_SERVICE_NAME, MQTT_SERVICE_PORT_1884);
+        K8sUtil.assertMqttService(client, platformNamespace, mqttServiceName1884);
+        MqttUtil.assertMessages(client, platformNamespace, mqttServiceName1884, MQTT_SERVICE_PORT_1884);
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmMqttLoadBalancerIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmMqttLoadBalancerIT.java
@@ -17,8 +17,9 @@ import static org.awaitility.Durations.ONE_MINUTE;
 class HelmMqttLoadBalancerIT extends AbstractHelmChartIT {
 
     private static final int MQTT_SERVICE_PORT_1884 = 1884;
-    private static final @NotNull String MQTT_SERVICE_NAME =
-            "hivemq-test-hivemq-platform-mqtt-" + MQTT_SERVICE_PORT_1884;
+
+    private final @NotNull String mqttServiceName1884 =
+            "hivemq-%s-mqtt-%s".formatted(platformReleaseName, MQTT_SERVICE_PORT_1884);
 
     @Test
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
@@ -27,11 +28,11 @@ class HelmMqttLoadBalancerIT extends AbstractHelmChartIT {
         await().atMost(ONE_MINUTE).untilAsserted(() -> {
             final var services = client.services().inNamespace(platformNamespace).list().getItems();
             assertThat(services).isNotEmpty()
-                    .filteredOn(service -> MQTT_SERVICE_NAME.equals(service.getMetadata().getName()))
+                    .filteredOn(service -> mqttServiceName1884.equals(service.getMetadata().getName()))
                     .extracting(Service::getSpec)
                     .extracting(ServiceSpec::getType)
                     .contains("LoadBalancer");
         });
-        MqttUtil.assertMessages(client, platformNamespace, MQTT_SERVICE_NAME, MQTT_SERVICE_PORT_1884);
+        MqttUtil.assertMessages(client, platformNamespace, mqttServiceName1884, MQTT_SERVICE_PORT_1884);
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmMqttNodePortIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmMqttNodePortIT.java
@@ -17,8 +17,9 @@ import static org.awaitility.Durations.ONE_MINUTE;
 class HelmMqttNodePortIT extends AbstractHelmChartIT {
 
     private static final int MQTT_SERVICE_PORT_1884 = 1884;
-    private static final @NotNull String MQTT_SERVICE_NAME =
-            "hivemq-test-hivemq-platform-mqtt-" + MQTT_SERVICE_PORT_1884;
+
+    private final @NotNull String mqttServiceName1884 =
+            "hivemq-%s-mqtt-%s".formatted(platformReleaseName, MQTT_SERVICE_PORT_1884);
 
     @Test
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
@@ -27,11 +28,11 @@ class HelmMqttNodePortIT extends AbstractHelmChartIT {
         await().atMost(ONE_MINUTE).untilAsserted(() -> {
             final var services = client.services().inNamespace(platformNamespace).list().getItems();
             assertThat(services).isNotEmpty()
-                    .filteredOn(service -> MQTT_SERVICE_NAME.equals(service.getMetadata().getName()))
+                    .filteredOn(service -> mqttServiceName1884.equals(service.getMetadata().getName()))
                     .extracting(Service::getSpec)
                     .extracting(ServiceSpec::getType)
                     .contains("NodePort");
         });
-        MqttUtil.assertMessages(client, platformNamespace, MQTT_SERVICE_NAME, MQTT_SERVICE_PORT_1884);
+        MqttUtil.assertMessages(client, platformNamespace, mqttServiceName1884, MQTT_SERVICE_PORT_1884);
     }
 }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmRestApiAuthIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmRestApiAuthIT.java
@@ -22,8 +22,9 @@ import static com.hivemq.helmcharts.util.CertificatesUtil.DEFAULT_KEYSTORE_PASSW
 class HelmRestApiAuthIT extends AbstractHelmChartIT {
 
     private static final int REST_API_SERVICE_PORT_8890 = 8890;
-    private static final @NotNull String REST_API_SERVICE_NAME_8890 =
-            "hivemq-test-hivemq-platform-rest-" + REST_API_SERVICE_PORT_8890;
+
+    private final @NotNull String restApiServiceName8890 =
+            "hivemq-%s-rest-%s".formatted(platformReleaseName, REST_API_SERVICE_PORT_8890);
 
     @TempDir
     private @NotNull Path tmp;
@@ -51,10 +52,10 @@ class HelmRestApiAuthIT extends AbstractHelmChartIT {
 
         installPlatformChartAndWaitToBeRunning("/files/rest-api-with-auth-values.yaml");
 
-        RestAPIUtil.assertAuth(client, platformNamespace, REST_API_SERVICE_NAME_8890, REST_API_SERVICE_PORT_8890, true);
+        RestAPIUtil.assertAuth(client, platformNamespace, restApiServiceName8890, REST_API_SERVICE_PORT_8890, true);
         RestAPIUtil.assertAuth(client,
                 platformNamespace,
-                REST_API_SERVICE_NAME_8890,
+                restApiServiceName8890,
                 REST_API_SERVICE_PORT_8890,
                 true,
                 "user",
@@ -62,7 +63,7 @@ class HelmRestApiAuthIT extends AbstractHelmChartIT {
                 HttpStatus.SC_UNAUTHORIZED);
         RestAPIUtil.assertAuth(client,
                 platformNamespace,
-                REST_API_SERVICE_NAME_8890,
+                restApiServiceName8890,
                 REST_API_SERVICE_PORT_8890,
                 true,
                 "/api/v1/management/backups",

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmRestApiIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmRestApiIT.java
@@ -13,8 +13,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 class HelmRestApiIT extends AbstractHelmChartIT {
 
     private static final int REST_API_SERVICE_PORT_8890 = 8890;
-    private static final @NotNull String REST_API_SERVICE_NAME_8890 =
-            "hivemq-test-hivemq-platform-rest-" + REST_API_SERVICE_PORT_8890;
+
+    private final @NotNull String restApiServiceName8890 =
+            "hivemq-%s-rest-%s".formatted(platformReleaseName, REST_API_SERVICE_PORT_8890);
 
     @Test
     @Timeout(value = 5, unit = TimeUnit.MINUTES)
@@ -23,7 +24,7 @@ class HelmRestApiIT extends AbstractHelmChartIT {
 
         assertThat(RestAPIUtil.getAllMqttClients(client,
                 platformNamespace,
-                REST_API_SERVICE_NAME_8890,
+                restApiServiceName8890,
                 REST_API_SERVICE_PORT_8890,
                 false)).isEmpty();
     }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmRestApiTlsIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmRestApiTlsIT.java
@@ -23,10 +23,11 @@ class HelmRestApiTlsIT extends AbstractHelmChartIT {
 
     private static final int REST_API_SERVICE_PORT_8890 = 8890;
     private static final int REST_API_SERVICE_PORT_8891 = 8891;
-    private static final @NotNull String REST_API_SERVICE_NAME_8890 =
-            "hivemq-test-hivemq-platform-rest-" + REST_API_SERVICE_PORT_8890;
-    private static final @NotNull String REST_API_SERVICE_NAME_8891 =
-            "hivemq-test-hivemq-platform-rest-" + REST_API_SERVICE_PORT_8891;
+
+    private final @NotNull String restApiServiceName8890 =
+            "hivemq-%s-rest-%s".formatted(platformReleaseName, REST_API_SERVICE_PORT_8890);
+    private final @NotNull String restApiServiceName8891 =
+            "hivemq-%s-rest-%s".formatted(platformReleaseName, REST_API_SERVICE_PORT_8891);
 
     @TempDir
     private @NotNull Path tmp;
@@ -53,12 +54,12 @@ class HelmRestApiTlsIT extends AbstractHelmChartIT {
 
         assertThat(RestAPIUtil.getAllMqttClients(client,
                 platformNamespace,
-                REST_API_SERVICE_NAME_8890,
+                restApiServiceName8890,
                 REST_API_SERVICE_PORT_8890,
                 true)).isEmpty();
         assertThat(RestAPIUtil.getAllMqttClients(client,
                 platformNamespace,
-                REST_API_SERVICE_NAME_8891,
+                restApiServiceName8891,
                 REST_API_SERVICE_PORT_8891,
                 true)).isEmpty();
     }

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmWebsocketsIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmWebsocketsIT.java
@@ -26,13 +26,17 @@ import static com.hivemq.helmcharts.util.K8sUtil.createSecret;
 
 class HelmWebsocketsIT extends AbstractHelmChartIT {
 
-    private static final @NotNull String WEBSOCKET_SERVICE_NAME_PORT_8002 = "hivemq-test-hivemq-platform-ws-8002";
     private static final int WEBSOCKET_SERVICE_PORT_8002 = 8002;
-    private static final @NotNull String WEBSOCKET_SERVICE_NAME_PORT_8003 = "hivemq-test-hivemq-platform-ws-8003";
     private static final int WEBSOCKET_SERVICE_PORT_8003 = 8003;
-    private static final @NotNull String WEBSOCKET_SERVICE_NAME_PORT_8004 = "hivemq-test-hivemq-platform-ws-8004";
     private static final int WEBSOCKET_SERVICE_PORT_8004 = 8004;
     private static final @NotNull String WEBSOCKET_SERVICE_PATH = "/mqtt";
+
+    private final @NotNull String websocketServiceNamePort8002 =
+            "hivemq-%s-ws-%s".formatted(platformReleaseName, WEBSOCKET_SERVICE_PORT_8002);
+    private final @NotNull String websocketServiceNamePort8003 =
+            "hivemq-%s-ws-%s".formatted(platformReleaseName, WEBSOCKET_SERVICE_PORT_8003);
+    private final @NotNull String websocketServiceNamePort8004 =
+            "hivemq-%s-ws-%s".formatted(platformReleaseName, WEBSOCKET_SERVICE_PORT_8004);
 
     @TempDir
     private @NotNull Path tmp;
@@ -75,9 +79,9 @@ class HelmWebsocketsIT extends AbstractHelmChartIT {
                 .hostnameVerifier((hostname, session) -> true)
                 .build();
 
-        assertWebSocketListener(WEBSOCKET_SERVICE_NAME_PORT_8002, WEBSOCKET_SERVICE_PORT_8002, null);
-        assertWebSocketListener(WEBSOCKET_SERVICE_NAME_PORT_8003, WEBSOCKET_SERVICE_PORT_8003, sslConfig);
-        assertWebSocketListener(WEBSOCKET_SERVICE_NAME_PORT_8004, WEBSOCKET_SERVICE_PORT_8004, sslConfig);
+        assertWebSocketListener(websocketServiceNamePort8002, WEBSOCKET_SERVICE_PORT_8002, null);
+        assertWebSocketListener(websocketServiceNamePort8003, WEBSOCKET_SERVICE_PORT_8003, sslConfig);
+        assertWebSocketListener(websocketServiceNamePort8004, WEBSOCKET_SERVICE_PORT_8004, sslConfig);
     }
 
     private void assertWebSocketListener(

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmWebsocketsWithPrivateKeyIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/services/HelmWebsocketsWithPrivateKeyIT.java
@@ -27,13 +27,17 @@ import static com.hivemq.helmcharts.util.K8sUtil.createSecret;
 
 class HelmWebsocketsWithPrivateKeyIT extends AbstractHelmChartIT {
 
-    private static final @NotNull String WEBSOCKET_SERVICE_NAME_PORT_8002 = "hivemq-test-hivemq-platform-ws-8002";
     private static final int WEBSOCKET_SERVICE_PORT_8002 = 8002;
-    private static final @NotNull String WEBSOCKET_SERVICE_NAME_PORT_8003 = "hivemq-test-hivemq-platform-ws-8003";
     private static final int WEBSOCKET_SERVICE_PORT_8003 = 8003;
-    private static final @NotNull String WEBSOCKET_SERVICE_NAME_PORT_8004 = "hivemq-test-hivemq-platform-ws-8004";
     private static final int WEBSOCKET_SERVICE_PORT_8004 = 8004;
     private static final @NotNull String WEBSOCKET_SERVICE_PATH = "/mqtt";
+
+    private final @NotNull String websocketServiceNamePort8002 =
+            "hivemq-%s-ws-%s".formatted(platformReleaseName, WEBSOCKET_SERVICE_PORT_8002);
+    private final @NotNull String websocketServiceNamePort8003 =
+            "hivemq-%s-ws-%s".formatted(platformReleaseName, WEBSOCKET_SERVICE_PORT_8003);
+    private final @NotNull String websocketServiceNamePort8004 =
+            "hivemq-%s-ws-%s".formatted(platformReleaseName, WEBSOCKET_SERVICE_PORT_8004);
 
     @TempDir
     private @NotNull Path tmp;
@@ -85,9 +89,9 @@ class HelmWebsocketsWithPrivateKeyIT extends AbstractHelmChartIT {
                 .hostnameVerifier((hostname, session) -> true)
                 .build();
 
-        assertWebSocketListener(WEBSOCKET_SERVICE_NAME_PORT_8002, WEBSOCKET_SERVICE_PORT_8002, null);
-        assertWebSocketListener(WEBSOCKET_SERVICE_NAME_PORT_8003, WEBSOCKET_SERVICE_PORT_8003, sslConfig);
-        assertWebSocketListener(WEBSOCKET_SERVICE_NAME_PORT_8004, WEBSOCKET_SERVICE_PORT_8004, sslConfig);
+        assertWebSocketListener(websocketServiceNamePort8002, WEBSOCKET_SERVICE_PORT_8002, null);
+        assertWebSocketListener(websocketServiceNamePort8003, WEBSOCKET_SERVICE_PORT_8003, sslConfig);
+        assertWebSocketListener(websocketServiceNamePort8004, WEBSOCKET_SERVICE_PORT_8004, sslConfig);
     }
 
     private void assertWebSocketListener(

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/util/K8sUtil.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/util/K8sUtil.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -36,6 +37,19 @@ import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.ONE_MINUTE;
 
 public class K8sUtil {
+
+    /**
+     * Maximum length for the release base name (before the {@code -pf}, {@code -op}, or {@code -lg} suffix).
+     * The tightest K8s resource name constraint is {@code hivemq-platform-<release>-dynamic-state} (30 chars
+     * overhead), which leaves 33 characters for the full release name (base + 3-character suffix).
+     */
+    public static final int MAX_RELEASE_BASE_NAME_LENGTH = 30;
+
+    /**
+     * Maximum length for the full release name (base + suffix), to ensure all derived K8s resource names stay
+     * within the 63-character limit.
+     */
+    public static final int MAX_RELEASE_NAME_LENGTH = MAX_RELEASE_BASE_NAME_LENGTH + 3;
 
     private static final @NotNull Logger LOG = LoggerFactory.getLogger(K8sUtil.class);
 
@@ -444,7 +458,7 @@ public class K8sUtil {
 
     private static @NotNull String getNamespaceName(final @NotNull Class<?> clazz, final @NotNull String suffix) {
         final var maxLength = 63 - suffix.length();
-        final var namespace = clazz.getSimpleName().toLowerCase();
+        final var namespace = clazz.getSimpleName().toLowerCase(Locale.ROOT);
         if (namespace.length() > maxLength) {
             return namespace.substring(0, maxLength) + suffix;
         }
@@ -457,6 +471,27 @@ public class K8sUtil {
      */
     public static @NotNull String getOperatorNamespaceName(final @NotNull Class<?> clazz) {
         return getNamespaceName(clazz, "-operator");
+    }
+
+    /**
+     * Returns the release base name derived from the test class name, up to
+     * {@value MAX_RELEASE_BASE_NAME_LENGTH} characters.
+     * <p>
+     * The leading "helm" prefix and trailing "it" suffix are stripped from the class name,
+     * and if the name is still too long, it is truncated from the end.
+     */
+    public static @NotNull String getReleaseBaseName(final @NotNull Class<?> clazz) {
+        var baseName = clazz.getSimpleName().toLowerCase(Locale.ROOT);
+        if (baseName.startsWith("helm")) {
+            baseName = baseName.substring(4);
+        }
+        if (baseName.endsWith("it")) {
+            baseName = baseName.substring(0, baseName.length() - 2);
+        }
+        if (baseName.length() > MAX_RELEASE_BASE_NAME_LENGTH) {
+            baseName = baseName.substring(0, MAX_RELEASE_BASE_NAME_LENGTH);
+        }
+        return baseName;
     }
 
     /**
@@ -538,6 +573,25 @@ public class K8sUtil {
             final @NotNull String namespace,
             final @NotNull String resourceName) {
         loadResource(client, namespace, resourceName, ConfigMap.class).update();
+    }
+
+    /**
+     * Updates a ConfigMap from the given resource file on the classpath, overriding the ConfigMap name.
+     *
+     * @param client        the Kubernetes client to use
+     * @param namespace     the namespace to update the custom resource in
+     * @param resourceName  the name of the resource file to use
+     * @param configMapName the name to set on the ConfigMap
+     */
+    public static void updateConfigMap(
+            final @NotNull KubernetesClient client,
+            final @NotNull String namespace,
+            final @NotNull String resourceName,
+            final @NotNull String configMapName) {
+        final var resource = loadResource(client, namespace, resourceName, ConfigMap.class);
+        final var item = resource.item();
+        item.getMetadata().setName(configMapName);
+        client.resource(item).inNamespace(namespace).update();
     }
 
     /**

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/volumes/HelmAdditionalVolumesIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/volumes/HelmAdditionalVolumesIT.java
@@ -46,7 +46,7 @@ class HelmAdditionalVolumesIT extends AbstractHelmChartIT {
 
         await().untilAsserted(() -> {
             final var statefulSet =
-                    client.apps().statefulSets().inNamespace(platformNamespace).withName(PLATFORM_RELEASE_NAME).get();
+                    client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
             assertThat(statefulSet).isNotNull();
             final var template = statefulSet.getSpec().getTemplate();
             assertThat(template.getSpec().getVolumes()).isNotEmpty()

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/volumes/HelmSharedPvcVolumeIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/volumes/HelmSharedPvcVolumeIT.java
@@ -40,7 +40,7 @@ class HelmSharedPvcVolumeIT extends AbstractHelmChartIT {
 
         // verify StatefulSet spec: volume, mount, env vars, and volumeClaimTemplates
         final var statefulSet =
-                client.apps().statefulSets().inNamespace(platformNamespace).withName(PLATFORM_RELEASE_NAME).get();
+                client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
         assertThat(statefulSet).isNotNull();
         final var template = statefulSet.getSpec().getTemplate();
 
@@ -74,7 +74,7 @@ class HelmSharedPvcVolumeIT extends AbstractHelmChartIT {
         assertThat(vct.getSpec().getResources().getRequests()).containsEntry("storage", new Quantity("1Gi"));
 
         // get the running pods
-        final var labels = K8sUtil.getHiveMQPlatformLabels(PLATFORM_RELEASE_NAME);
+        final var labels = K8sUtil.getHiveMQPlatformLabels(platformReleaseName);
         final var pods = client.pods().inNamespace(platformNamespace).withLabels(labels).list().getItems();
         assertThat(pods).hasSize(2);
 
@@ -108,8 +108,11 @@ class HelmSharedPvcVolumeIT extends AbstractHelmChartIT {
         }
 
         // trigger a rolling restart and verify files persist
-        K8sUtil.updateConfigMap(client, platformNamespace, "hivemq-config-map-update.yml");
-        K8sUtil.waitForHiveMQPlatformStateRunningAfterRollingRestart(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        K8sUtil.updateConfigMap(client,
+                platformNamespace,
+                "hivemq-config-map-update.yml",
+                "hivemq-configuration-" + platformReleaseName);
+        K8sUtil.waitForHiveMQPlatformStateRunningAfterRollingRestart(client, platformNamespace, platformReleaseName);
 
         // after restart, verify files are still present and isolated in all pods
         final var restartedPods = client.pods()

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/volumes/HelmVolumeClaimTemplatesIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/volumes/HelmVolumeClaimTemplatesIT.java
@@ -35,7 +35,7 @@ class HelmVolumeClaimTemplatesIT extends AbstractHelmChartIT {
         // assert StatefulSet
         await().untilAsserted(() -> {
             final var statefulSet =
-                    client.apps().statefulSets().inNamespace(platformNamespace).withName(PLATFORM_RELEASE_NAME).get();
+                    client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
             assertThat(statefulSet).isNotNull();
 
             // assert StatefulSet volumes
@@ -52,7 +52,7 @@ class HelmVolumeClaimTemplatesIT extends AbstractHelmChartIT {
         });
 
         // create files for each pod in their corresponding PVCs
-        final var labels = K8sUtil.getHiveMQPlatformLabels(PLATFORM_RELEASE_NAME);
+        final var labels = K8sUtil.getHiveMQPlatformLabels(platformReleaseName);
         client.pods().inNamespace(platformNamespace).withLabels(labels).list().getItems().forEach(pod -> {
             final var mountPath = pod.getSpec()
                     .getContainers()
@@ -72,8 +72,11 @@ class HelmVolumeClaimTemplatesIT extends AbstractHelmChartIT {
         });
 
         // Update ConfigMap to trigger a rolling restart to make sure the files are persisted in their corresponding PVCs
-        K8sUtil.updateConfigMap(client, platformNamespace, "hivemq-config-map-update.yml");
-        K8sUtil.waitForHiveMQPlatformStateRunningAfterRollingRestart(client, platformNamespace, PLATFORM_RELEASE_NAME);
+        K8sUtil.updateConfigMap(client,
+                platformNamespace,
+                "hivemq-config-map-update.yml",
+                "hivemq-configuration-" + platformReleaseName);
+        K8sUtil.waitForHiveMQPlatformStateRunningAfterRollingRestart(client, platformNamespace, platformReleaseName);
 
         // assert Platform pods
         await().untilAsserted(() -> client.pods()

--- a/tests-hivemq-platform-operator/src/integrationTest/resources/values/migration-platform-stateful-set-values.yaml
+++ b/tests-hivemq-platform-operator/src/integrationTest/resources/values/migration-platform-stateful-set-values.yaml
@@ -29,7 +29,6 @@ volumeClaimTemplates:
      volumeMode: Filesystem
 services:
   - type: "mqtt"
-    name: "hivemq-test-hivemq-legacy-platform-mqtt"
     annotations:
       service.spec.externalTrafficPolicy: Local
     exposed: true


### PR DESCRIPTION
## Summary

- Fix flaky integration test failures caused by ClusterRole ownership collisions between test classes sharing the same K3s cluster
- Derive Helm release names from the test class name (e.g., `customlogback-op`) instead of using a shared static constant (`test-hivemq-platform-operator`), mirroring the existing per-test-class namespace pattern
- Add `getReleaseName()`, `getPlatformReleaseName()`, `getOperatorReleaseName()`, and `getLegacyReleaseName()` helpers to `K8sUtil`
- Add overridable `getPlatformReleaseName()` / `getOperatorReleaseName()` / `getLegacyReleaseName()` methods in `AbstractHelmChartIT` for tests whose truncated names would collide
- Add a `baseSetUp()` assertion that all release names stay within the `MAX_RELEASE_NAME_LENGTH` (33 chars) limit

### Problem

All integration tests used the same hardcoded operator release name `test-hivemq-platform-operator`. The operator Helm chart creates cluster-scoped resources (ClusterRole, ClusterRoleBinding) whose names include the release name. When a test's teardown timed out (e.g., `baseTearDown() timed out after 5 minutes`), the ClusterRole was left behind with a `meta.helm.sh/release-namespace` annotation pointing to the previous test's namespace. The next test in the same split would then fail with:

> `ClusterRole "hivemq-platform-operator-role-test-hivemq-platform-operator"` exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key `meta.helm.sh/release-namespace` must equal `<new-namespace>`: current value is `<old-namespace>`

This cascading failure was observed in [run #669](https://github.com/hivemq/helm-charts/actions/runs/24129688090) where `HelmCustomLogbackIT` teardown timed out and `HelmMqttCustomServiceNameIT` failed as a consequence.

### Solution

Each test class now gets a unique release name derived from its class name (with `Helm` prefix and `IT` suffix stripped, truncated to fit), with short suffixes for log identification:
- Platform: `<classname>-pf` (e.g., `customlogback-pf`)
- Operator: `<classname>-op` (e.g., `customlogback-op`)
- Legacy: `<classname>-lg` (e.g., `legacystatefulsetmigration-lg`)

Release names are capped at 33 characters (`K8sUtil.MAX_RELEASE_NAME_LENGTH`) to ensure all derived K8s resource names (the tightest being `hivemq-platform-<release>-dynamic-state`) stay within the 63-character K8s name limit.

Six test classes with long names that would collide after truncation override `getPlatformReleaseName()` / `getOperatorReleaseName()` with custom short names. A length assertion in `baseSetUp()` catches any future violations at test startup.
