### PR TITLE
Add rollingRestart.lastPodMinAgeSeconds to HiveMQ Platform chart

### DIFF
--- a/charts/hivemq-platform-operator/crds/hivemq-platforms.hivemq.com-v1.yml
+++ b/charts/hivemq-platform-operator/crds/hivemq-platforms.hivemq.com-v1.yml
@@ -141,6 +141,15 @@ spec:
                 type: "array"
               operatorRestApiPort:
                 type: "integer"
+              rollingRestart:
+                properties:
+                  lastPodMinAgeSeconds:
+                    description: "The minimum age in seconds that the last restarted\
+                      \ Pod must have before the next Pod can be restarted during\
+                      \ a rolling restart. Overrides the global operator configuration.\
+                      \ If not set, the global operator configuration is used."
+                    type: "integer"
+                type: "object"
               secretName:
                 type: "string"
               services:

--- a/charts/hivemq-platform/templates/hivemq-custom-resource.yml
+++ b/charts/hivemq-platform/templates/hivemq-custom-resource.yml
@@ -52,6 +52,12 @@ spec:
       {{- end }}
     {{- end }}
   {{- end }}
+  {{- with .Values.rollingRestart }}
+  {{- if hasKey . "lastPodMinAgeSeconds" }}
+  rollingRestart:
+    lastPodMinAgeSeconds: {{ .lastPodMinAgeSeconds }}
+  {{- end }}
+  {{- end }}
   statefulSet:
     {{- if not .Values.config.overrideStatefulSet }}
     spec:

--- a/charts/hivemq-platform/tests/rolling-restart/hivemq_rolling_restart_test.yaml
+++ b/charts/hivemq-platform/tests/rolling-restart/hivemq_rolling_restart_test.yaml
@@ -1,0 +1,49 @@
+suite: HiveMQ Platform - Rolling Restart Configuration tests
+templates:
+  - hivemq-custom-resource.yml
+release:
+  name: test-hivemq-platform
+chart:
+  version: 0.0.1
+tests:
+
+  - it: should not render rollingRestart field when not defined
+    asserts:
+      - notExists:
+          path: spec.rollingRestart
+
+  - it: should not render rollingRestart field when empty object
+    set:
+      rollingRestart: {}
+    asserts:
+      - notExists:
+          path: spec.rollingRestart
+
+  - it: should render rollingRestart with lastPodMinAgeSeconds
+    set:
+      rollingRestart:
+        lastPodMinAgeSeconds: 300
+    asserts:
+      - exists:
+          path: spec.rollingRestart
+      - equal:
+          path: spec.rollingRestart.lastPodMinAgeSeconds
+          value: 300
+
+  - it: should render rollingRestart with lastPodMinAgeSeconds set to zero
+    set:
+      rollingRestart:
+        lastPodMinAgeSeconds: 0
+    asserts:
+      - exists:
+          path: spec.rollingRestart
+      - equal:
+          path: spec.rollingRestart.lastPodMinAgeSeconds
+          value: 0
+
+  - it: should fail when lastPodMinAgeSeconds is negative
+    set:
+      rollingRestart:
+        lastPodMinAgeSeconds: -1
+    asserts:
+      - failedTemplate: {}

--- a/charts/hivemq-platform/values.schema.json
+++ b/charts/hivemq-platform/values.schema.json
@@ -714,6 +714,17 @@
       },
       "type" : "object"
     },
+    "rollingRestart" : {
+      "description" : "Configures the rolling restart behavior for this HiveMQ Platform.",
+      "properties" : {
+        "lastPodMinAgeSeconds" : {
+          "description" : "The minimum age in seconds that the last restarted Pod must have before the next Pod can be restarted during a rolling restart. When set, this overrides the global operator configuration. If not set, the global operator default of 30 seconds is used.",
+          "type" : "integer",
+          "minimum" : 0
+        }
+      },
+      "type" : "object"
+    },
     "monitoredResources" : {
       "description" : "Configures Kubernetes resources (ConfigMaps and Secrets) to monitor for changes. When one of the files in a monitored resource changes, the HiveMQ Platform pods will perform a rolling restart.",
       "items" : {

--- a/charts/hivemq-platform/values.yaml
+++ b/charts/hivemq-platform/values.yaml
@@ -808,6 +808,13 @@ pulse:
   # Overrides the HiveMQ Pulse configuration via file using --set-file pulse.overridePulseConfig=your-pulse-config.xml.
   overridePulseConfig: ""
 
+# Configures the rolling restart behavior for this HiveMQ Platform.
+rollingRestart: {}
+  # The minimum age in seconds that the last restarted pod must have before the next pod can be restarted
+  # during a rolling restart. When set, this overrides the global operator configuration.
+  # If not set, the global operator default of 30 seconds is used.
+  # lastPodMinAgeSeconds: 300
+
 # Configures Kubernetes resources (ConfigMaps and Secrets) to monitor for changes.
 # When one of the files in a monitored resource changes, the HiveMQ Platform pods will perform a rolling restart.
 # This is useful for automatically restarting pods when configurations change.


### PR DESCRIPTION
## Summary

- Adds `rollingRestart.lastPodMinAgeSeconds` to `values.yaml` (optional, empty by default)
- Renders `rollingRestart` block in CR only when `lastPodMinAgeSeconds` is explicitly set
- JSON schema validation enforces `minimum: 0`
- 5 helm-unittest tests covering all scenarios

## Linear

[INT-132](https://linear.app/hivemq/issue/INT-132)