### PR TITLE
Make platform-operator readiness/liveness probe settings configurable

### DIFF
--- a/charts/hivemq-platform-operator/templates/deployment.yml
+++ b/charts/hivemq-platform-operator/templates/deployment.yml
@@ -166,15 +166,15 @@ spec:
           image: "{{ .Values.image.repository}}/{{ .Values.image.name }}:{{.Values.image.tag}}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
-            failureThreshold: 3
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             httpGet:
               path: /health/liveness
               port: {{ .Values.http.port }}
               scheme: HTTP
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             successThreshold: 1
-            timeoutSeconds: 10
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           ports:
             - name: {{ printf "http-%s" .Release.Name | lower | trunc 15 | trimSuffix "-" }}
               containerPort: {{ .Values.http.port }}
@@ -183,15 +183,15 @@ spec:
               containerPort: {{ .Values.https.port }}
               protocol: TCP
           readinessProbe:
-            failureThreshold: 3
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             httpGet:
               path: /health/readiness
               port: {{ .Values.http.port }}
               scheme: HTTP
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 10
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           resources:
             {{- if hasKey .Values.resources "overrideLimits" }}
             {{- with .Values.resources.overrideLimits }}

--- a/charts/hivemq-platform-operator/tests/hivemq_operator_deployment_test.yaml
+++ b/charts/hivemq-platform-operator/tests/hivemq_operator_deployment_test.yaml
@@ -1479,3 +1479,85 @@ tests:
           content:
             name: HIVEMQ_PLATFORM_OPERATOR_SKIP_HTTPS_CERTIFICATE_VALIDATION
             value: "false"
+
+  - it: with default values, default livenessProbe values are set
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            failureThreshold: 3
+            httpGet:
+              path: /health/liveness
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+
+  - it: with default values, default readinessProbe values are set
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            failureThreshold: 3
+            httpGet:
+              path: /health/readiness
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+
+  - it: with custom livenessProbe values
+    set:
+      livenessProbe.initialDelaySeconds: 15
+      livenessProbe.periodSeconds: 30
+      livenessProbe.timeoutSeconds: 20
+      livenessProbe.failureThreshold: 5
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            failureThreshold: 5
+            httpGet:
+              path: /health/liveness
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 20
+
+  - it: with custom readinessProbe values
+    set:
+      readinessProbe.initialDelaySeconds: 10
+      readinessProbe.periodSeconds: 20
+      readinessProbe.timeoutSeconds: 15
+      readinessProbe.successThreshold: 1
+      readinessProbe.failureThreshold: 6
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            failureThreshold: 6
+            httpGet:
+              path: /health/readiness
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            successThreshold: 1
+            timeoutSeconds: 15
+
+  - it: with custom http port, probe port is updated
+    set:
+      http.port: 9090
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 9090
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 9090

--- a/charts/hivemq-platform-operator/values.schema.json
+++ b/charts/hivemq-platform-operator/values.schema.json
@@ -166,6 +166,32 @@
     "javaOpts" : {
       "type" : "string"
     },
+    "livenessProbe" : {
+      "description" : "Configures the liveness probe for the HiveMQ Platform Operator container.",
+      "properties" : {
+        "failureThreshold" : {
+          "description" : "Number of consecutive failures before the container is considered unhealthy.",
+          "minimum" : 1,
+          "type" : "integer"
+        },
+        "initialDelaySeconds" : {
+          "description" : "Number of seconds after the container has started before the probe is initiated.",
+          "minimum" : 0,
+          "type" : "integer"
+        },
+        "periodSeconds" : {
+          "description" : "How often (in seconds) to perform the probe.",
+          "minimum" : 1,
+          "type" : "integer"
+        },
+        "timeoutSeconds" : {
+          "description" : "Number of seconds after which the probe times out.",
+          "minimum" : 1,
+          "type" : "integer"
+        }
+      },
+      "type" : "object"
+    },
     "logConfiguration" : {
       "description" : "Logs the configuration values at operator startup. Sensitive values are redacted.",
       "type" : "boolean"
@@ -287,6 +313,37 @@
       "properties" : {
         "create" : {
           "type" : "boolean"
+        }
+      },
+      "type" : "object"
+    },
+    "readinessProbe" : {
+      "description" : "Configures the readiness probe for the HiveMQ Platform Operator container.",
+      "properties" : {
+        "failureThreshold" : {
+          "description" : "Number of consecutive failures before the container is considered not ready.",
+          "minimum" : 1,
+          "type" : "integer"
+        },
+        "initialDelaySeconds" : {
+          "description" : "Number of seconds after the container has started before the probe is initiated.",
+          "minimum" : 0,
+          "type" : "integer"
+        },
+        "periodSeconds" : {
+          "description" : "How often (in seconds) to perform the probe.",
+          "minimum" : 1,
+          "type" : "integer"
+        },
+        "successThreshold" : {
+          "description" : "Minimum consecutive successes for the probe to be considered successful after having failed.",
+          "minimum" : 1,
+          "type" : "integer"
+        },
+        "timeoutSeconds" : {
+          "description" : "Number of seconds after which the probe times out.",
+          "minimum" : 1,
+          "type" : "integer"
         }
       },
       "type" : "object"

--- a/charts/hivemq-platform-operator/values.yaml
+++ b/charts/hivemq-platform-operator/values.yaml
@@ -37,6 +37,21 @@ https:
   skipCertificateValidation: false
   skipHostnameVerification: false
 
+# Configures the liveness probe for the HiveMQ Platform Operator container.
+livenessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 3
+
+# Configures the readiness probe for the HiveMQ Platform Operator container.
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 10
+  successThreshold: 1
+  failureThreshold: 3
+
 # Configures the Java JVM runtime options for the process.
 javaOpts: "-XX:+UnlockExperimentalVMOptions -XX:InitialRAMPercentage=75 -XX:MaxRAMPercentage=75"
 


### PR DESCRIPTION
## Summary
- Expose `livenessProbe` and `readinessProbe` settings as configurable Helm values in the HiveMQ Platform Operator chart
- Replace hardcoded probe values in the Deployment template with Helm value references
- Add JSON schema validation and unit tests for probe settings
- `livenessProbe.successThreshold` is hardcoded to `1` as required by Kubernetes; all other fields are configurable

Default values preserve current behavior (non-breaking change).

Resolves hivemq/helm-charts#841