### PR TITLE
Add generic CSI volume type support to additionalVolumes

### DIFF
--- a/charts/hivemq-platform-operator/tests/hivemq_operator_deployment_test.yaml
+++ b/charts/hivemq-platform-operator/tests/hivemq_operator_deployment_test.yaml
@@ -728,8 +728,7 @@ tests:
         runAsUser: 185
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499 
-            `runAsNonRoot` is set to `false` but `runAsUser` is not set to `0` \(root\)
+          errorPattern: '`runAsNonRoot` is set to `false` but `runAsUser` is not set to `0` \(root\)'
 
   - it: with pod security context runAsNonRoot true, and runAsUser root, then validation fails
     set:
@@ -739,8 +738,7 @@ tests:
         runAsUser: 0
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `runAsNonRoot` is set to `true` but `runAsUser` is set to `0` \(root\)
+          errorPattern: '`runAsNonRoot` is set to `true` but `runAsUser` is set to `0` \(root\)'
 
   - it: with defaults, no container security context set
     asserts:
@@ -975,8 +973,7 @@ tests:
         runAsUser: 185
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `runAsNonRoot` is set to `false` but `runAsUser` is not set to `0` \(root\)
+          errorPattern: '`runAsNonRoot` is set to `false` but `runAsUser` is not set to `0` \(root\)'
 
   - it: with container security context runAsNonRoot true, and runAsUser root, then validation fails
     set:
@@ -985,8 +982,7 @@ tests:
         runAsUser: 0
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `runAsNonRoot` is set to `true` but `runAsUser` is set to `0` \(root\)
+          errorPattern: '`runAsNonRoot` is set to `true` but `runAsUser` is set to `0` \(root\)'
 
 
   - it: with pod scheduling values set

--- a/charts/hivemq-platform/templates/_helpers.tpl
+++ b/charts/hivemq-platform/templates/_helpers.tpl
@@ -766,6 +766,7 @@ Usage: {{- include "hivemq-platform.validate-additional-volumes" . }}
 {{- $volumeMountNameList := list }}
 {{- $volumeMountPathList := list }}
 {{- $volumeTypesDict := dict }}
+{{- $csiConfigs := dict }}
 
 {{- /* validate at most one sharedPersistentVolumeClaim is defined as we cannot have duplicated EnvVars for the same */ -}}
 {{- $sharedPvcCount := 0 }}
@@ -818,6 +819,25 @@ Usage: {{- include "hivemq-platform.validate-additional-volumes" . }}
     {{- end -}}
     {{- if and (not (eq $additionalVolume.type "projected")) (hasKey $additionalVolume "projectedSources") }}
         {{- fail (printf "\n`projectedSources` value is only available for type \"projected\"") }}
+    {{- end -}}
+    {{- if and (eq $additionalVolume.type "csi") (not (hasKey $additionalVolume "csi")) }}
+        {{- fail (printf "\n`csi` value is required for type \"csi\"") }}
+    {{- end -}}
+    {{- if and (not (eq $additionalVolume.type "csi")) (hasKey $additionalVolume "csi") }}
+        {{- fail (printf "\n`csi` value is only available for type \"csi\"") }}
+    {{- end -}}
+    {{- if and (eq $additionalVolume.type "csi") (hasKey $additionalVolume "csi") (not (hasKey $additionalVolume.csi "driver")) }}
+        {{- fail (printf "\n`csi.driver` value is required for type \"csi\"") }}
+    {{- end -}}
+    {{- if and (eq $additionalVolume.type "csi") (hasKey $additionalVolume "csi") }}
+        {{- $csiVolumeName := $additionalVolume.mountName | default $additionalVolume.name }}
+        {{- if hasKey $csiConfigs $csiVolumeName }}
+            {{- if ne (toJson (get $csiConfigs $csiVolumeName)) (toJson $additionalVolume.csi) }}
+                {{- fail (printf "\n`csi` configuration for volume %q must be identical across all `additionalVolumes` entries that share the same `mountName`" $csiVolumeName) }}
+            {{- end }}
+        {{- else }}
+            {{- $_ := set $csiConfigs $csiVolumeName $additionalVolume.csi }}
+        {{- end }}
     {{- end -}}
     {{- if and (not (eq $additionalVolume.type "sharedPersistentVolumeClaim")) (hasKey $additionalVolume "hivemqFolders") }}
         {{- fail (printf "\n`hivemqFolders` value is only available for type \"sharedPersistentVolumeClaim\"") }}
@@ -1521,6 +1541,23 @@ Usage: {{ include "hivemq-platform.get-additional-volumes" . }}
       {{- with $volume.projectedSources }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
+  {{- else if eq $volumeType "csi" }}
+  csi:
+    driver: {{ $volume.csi.driver }}
+    {{- if hasKey $volume.csi "readOnly" }}
+    readOnly: {{ $volume.csi.readOnly }}
+    {{- end }}
+    {{- if $volume.csi.fsType }}
+    fsType: {{ $volume.csi.fsType }}
+    {{- end }}
+    {{- if $volume.csi.volumeAttributes }}
+    volumeAttributes:
+      {{- toYaml $volume.csi.volumeAttributes | nindent 6 }}
+    {{- end }}
+    {{- if $volume.csi.nodePublishSecretRef }}
+    nodePublishSecretRef:
+      name: {{ $volume.csi.nodePublishSecretRef }}
+    {{- end }}
   {{- end }}
 {{- $volumeList = $volumeKey | append $volumeList}}
 {{- end }}

--- a/charts/hivemq-platform/tests/additional-volumes-values.yaml
+++ b/charts/hivemq-platform/tests/additional-volumes-values.yaml
@@ -52,6 +52,14 @@ additionalVolumes:
           audience: api
           expirationSeconds: 3600
           path: token
+  - type: csi
+    mountName: test-csi-volume
+    path: /additional-csi-volume
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: my-secret-provider
 volumeClaimTemplates:
   - kind: PersistentVolumeClaim
     apiVersion: v1

--- a/charts/hivemq-platform/tests/configuration/configmap/hivemq_platform_license_configuration_test.yaml
+++ b/charts/hivemq-platform/tests/configuration/configmap/hivemq_platform_license_configuration_test.yaml
@@ -69,5 +69,4 @@ tests:
     template: hivemq-configuration.yml
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            Both `licenseKey` and `overrideLicenseConfig` values are set for the HiveMQ Platform license configuration. Please, use only one of them
+          errorPattern: 'Both `licenseKey` and `overrideLicenseConfig` values are set for the HiveMQ Platform license configuration. Please, use only one of them'

--- a/charts/hivemq-platform/tests/configuration/secret/hivemq_platform_license_configuration_test.yaml
+++ b/charts/hivemq-platform/tests/configuration/secret/hivemq_platform_license_configuration_test.yaml
@@ -71,5 +71,4 @@ tests:
     template: hivemq-configuration.yml
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            Both `licenseKey` and `overrideLicenseConfig` values are set for the HiveMQ Platform license configuration. Please, use only one of them
+          errorPattern: 'Both `licenseKey` and `overrideLicenseConfig` values are set for the HiveMQ Platform license configuration. Please, use only one of them'

--- a/charts/hivemq-platform/tests/hivemq_platform_test.yaml
+++ b/charts/hivemq-platform/tests/hivemq_platform_test.yaml
@@ -736,7 +736,7 @@ tests:
           path: spec.statefulSet.spec.template.spec.volumes
       - lengthEqual:
           path: spec.statefulSet.spec.template.spec.volumes
-          count: 8
+          count: 9
       - contains:
           path: spec.statefulSet.spec.template.spec.volumes
           content:
@@ -801,7 +801,7 @@ tests:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
       - lengthEqual:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
-          count: 7
+          count: 8
       - contains:
           path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
           content:
@@ -840,6 +840,20 @@ tests:
           content:
             name: test-projected-volume
             mountPath: /additional-projected-volume
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: test-csi-volume
+            csi:
+              driver: secrets-store.csi.k8s.io
+              readOnly: true
+              volumeAttributes:
+                secretProviderClass: my-secret-provider
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: test-csi-volume
+            mountPath: /additional-csi-volume
       - contains:
           path: spec.statefulSet.spec.template.spec.volumes
           content:
@@ -1368,6 +1382,254 @@ tests:
       - failedTemplate:
           errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499  
             `projectedSources` value is only available for type "projected"
+
+  - it: with additional volume type `csi` but missing `name`, then succeeds
+    set:
+      additionalVolumes:
+        - type: csi
+          path: /additional-csi-volume
+          mountName: test-csi-mount-volume
+          csi:
+            driver: secrets-store.csi.k8s.io
+    asserts:
+      - exists:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+      - contains:
+          path: spec.statefulSet.spec.template.spec.containers[0].volumeMounts
+          content:
+            name: test-csi-mount-volume
+            mountPath: /additional-csi-volume
+      - exists:
+          path: spec.statefulSet.spec.template.spec.volumes
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: test-csi-mount-volume
+            csi:
+              driver: secrets-store.csi.k8s.io
+
+  - it: with additional volume type `csi` with volumeAttributes, then succeeds
+    set:
+      additionalVolumes:
+        - type: csi
+          path: /additional-csi-volume
+          mountName: test-csi-mount-volume
+          csi:
+            driver: secrets-store.csi.k8s.io
+            volumeAttributes:
+              secretProviderClass: my-provider
+              key1: value1
+    asserts:
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: test-csi-mount-volume
+            csi:
+              driver: secrets-store.csi.k8s.io
+              volumeAttributes:
+                secretProviderClass: my-provider
+                key1: value1
+
+  - it: with additional volume type `csi` and string `volumeAttributes` values that look like YAML booleans or numbers, then they are preserved as strings
+    set:
+      additionalVolumes:
+        - type: csi
+          path: /additional-csi-volume
+          mountName: test-csi-mount-volume
+          csi:
+            driver: secrets-store.csi.k8s.io
+            volumeAttributes:
+              boolean: "true"
+              number: "123"
+              string: "yes"
+    asserts:
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: test-csi-mount-volume
+            csi:
+              driver: secrets-store.csi.k8s.io
+              volumeAttributes:
+                boolean: "true"
+                number: "123"
+                string: "yes"
+
+  - it: with additional volume type `csi` and non-string `volumeAttributes` values, then fails
+    set:
+      additionalVolumes:
+        - type: csi
+          path: /additional-csi-volume
+          mountName: test-csi-mount-volume
+          csi:
+            driver: secrets-store.csi.k8s.io
+            volumeAttributes:
+              boolean: true
+              number: 123
+    asserts:
+      - failedTemplate:
+          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
+            got boolean, want string
+
+  - it: with additional volume type `csi` with readOnly true, then succeeds
+    set:
+      additionalVolumes:
+        - type: csi
+          path: /additional-csi-volume
+          mountName: test-csi-mount-volume
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+    asserts:
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: test-csi-mount-volume
+            csi:
+              driver: secrets-store.csi.k8s.io
+              readOnly: true
+
+  - it: with additional volume type `csi` with readOnly false, then succeeds
+    set:
+      additionalVolumes:
+        - type: csi
+          path: /additional-csi-volume
+          mountName: test-csi-mount-volume
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: false
+    asserts:
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: test-csi-mount-volume
+            csi:
+              driver: secrets-store.csi.k8s.io
+              readOnly: false
+
+  - it: with additional volume type `csi` with fsType, then succeeds
+    set:
+      additionalVolumes:
+        - type: csi
+          path: /additional-csi-volume
+          mountName: test-csi-mount-volume
+          csi:
+            driver: my-csi-driver
+            fsType: ext4
+    asserts:
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: test-csi-mount-volume
+            csi:
+              driver: my-csi-driver
+              fsType: ext4
+
+  - it: with additional volume type `csi` with nodePublishSecretRef, then succeeds
+    set:
+      additionalVolumes:
+        - type: csi
+          path: /additional-csi-volume
+          mountName: test-csi-mount-volume
+          csi:
+            driver: my-csi-driver
+            nodePublishSecretRef: my-secret
+    asserts:
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: test-csi-mount-volume
+            csi:
+              driver: my-csi-driver
+              nodePublishSecretRef:
+                name: my-secret
+
+  - it: with additional volume type `csi` but missing `csi` field, then fails
+    set:
+      additionalVolumes:
+        - type: csi
+          path: /fake-volume-path
+          mountName: fake-volume-mount-name
+    asserts:
+      - failedTemplate:
+          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
+            `csi` value is required for type "csi"
+
+  - it: with additional volume type `csi` but missing `csi.driver`, then fails
+    set:
+      additionalVolumes:
+        - type: csi
+          path: /fake-volume-path
+          mountName: fake-volume-mount-name
+          csi:
+            readOnly: true
+    asserts:
+      - failedTemplate:
+          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
+            `csi.driver` value is required for type "csi"
+
+  - it: with additional volume type different than `csi` but `csi` is present, then fails
+    set:
+      additionalVolumes:
+        - type: emptyDir
+          path: /fake-volume-path
+          mountName: fake-volume-mount-name
+          csi:
+            driver: secrets-store.csi.k8s.io
+    asserts:
+      - failedTemplate:
+          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
+            `csi` value is only available for type "csi"
+
+  - it: with multiple additional volumes of type `csi` sharing the same `mountName` and identical `csi` config, then succeeds
+    set:
+      additionalVolumes:
+        - type: csi
+          mountName: shared-csi-volume
+          path: /mnt/primary
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: my-provider
+        - type: csi
+          mountName: shared-csi-volume
+          containerName: sidecar-container
+          path: /mnt/secondary
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: my-provider
+    asserts:
+      - contains:
+          path: spec.statefulSet.spec.template.spec.volumes
+          content:
+            name: shared-csi-volume
+            csi:
+              driver: secrets-store.csi.k8s.io
+              readOnly: true
+              volumeAttributes:
+                secretProviderClass: my-provider
+          count: 1
+
+  - it: with multiple additional volumes of type `csi` sharing the same `mountName` but with different `csi` configurations, then fails
+    set:
+      additionalVolumes:
+        - type: csi
+          mountName: shared-csi-volume
+          path: /mnt/primary
+          csi:
+            driver: driver-a
+        - type: csi
+          mountName: shared-csi-volume
+          containerName: sidecar-container
+          path: /mnt/secondary
+          csi:
+            driver: driver-b
+    asserts:
+      - failedTemplate:
+          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
+            `csi` configuration for volume "shared-csi-volume" must be identical across all `additionalVolumes` entries that share the same `mountName`
 
   - it: with default settings, no volume claim template is set
     asserts:

--- a/charts/hivemq-platform/tests/hivemq_platform_test.yaml
+++ b/charts/hivemq-platform/tests/hivemq_platform_test.yaml
@@ -904,8 +904,7 @@ tests:
           path: /additional-configmap-volume-2
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            VolumeMount `foobar-mount-volume` (name: `test-configmap-volume-2` value, mountName: `foobar-mount-volume` value) is duplicated for container `hivemq`
+          errorPattern: 'VolumeMount `foobar-mount-volume` (name: `test-configmap-volume-2` value, mountName: `foobar-mount-volume` value) is duplicated for container `hivemq`'
 
   - it: with duplicated additionalVolumes `mountName` value in same `foobar` container, then fails
     set:
@@ -922,8 +921,7 @@ tests:
           path: /additional-configmap-volume-2
     asserts:
       - failedTemplate:
-          errorPattern: |- 
-            VolumeMount `foobar-mount-volume` (name: `test-configmap-volume-2` value, mountName: `foobar-mount-volume` value) is duplicated for container `foobar`
+          errorPattern: 'VolumeMount `foobar-mount-volume` (name: `test-configmap-volume-2` value, mountName: `foobar-mount-volume` value) is duplicated for container `foobar`'
 
   - it: with duplicated additionalVolumes `mountName` value but different containers, then succeeds
     set:
@@ -972,8 +970,7 @@ tests:
           path: /additional-configmap-volume-2
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            VolumeMount `foobar-mount-volume` (name: `foobar-mount-volume` value, mountName: `` value) is duplicated for container `hivemq`
+          errorPattern: 'VolumeMount `foobar-mount-volume` (name: `foobar-mount-volume` value, mountName: `` value) is duplicated for container `hivemq`'
 
   - it: with duplicated additionalVolumes `name` value in same `foobar` container, then fails
     set:
@@ -988,8 +985,7 @@ tests:
           path: /additional-configmap-volume-2
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            VolumeMount `foobar-mount-volume` (name: `foobar-mount-volume` value, mountName: `` value) is duplicated for container `foobar`
+          errorPattern: 'VolumeMount `foobar-mount-volume` (name: `foobar-mount-volume` value, mountName: `` value) is duplicated for container `foobar`'
 
   - it: with duplicated additionalVolumes `path` for the default container, then fails
     set:
@@ -1002,8 +998,7 @@ tests:
           path: /additional-configmap-volume
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            VolumeMount path `/additional-configmap-volume` (path: `/additional-configmap-volume` value, subPath: `` value) is duplicated for container `hivemq`
+          errorPattern: 'VolumeMount path `/additional-configmap-volume` (path: `/additional-configmap-volume` value, subPath: `` value) is duplicated for container `hivemq`'
 
   - it: with duplicated additionalVolumes `subPath` for the default container, then fails
     set:
@@ -1018,8 +1013,7 @@ tests:
           subPath: subpath
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            VolumeMount path `/additional-configmap-volume/subpath` (path: `/additional-configmap-volume` value, subPath: `subpath` value) is duplicated for container `hivemq`
+          errorPattern: 'VolumeMount path `/additional-configmap-volume/subpath` (path: `/additional-configmap-volume` value, subPath: `subpath` value) is duplicated for container `hivemq`'
 
   - it: with duplicated additionalVolumes `path` but different `subPath` for the default container, then succeeds
     set:
@@ -1049,8 +1043,7 @@ tests:
           path: /additional-configmap-volume
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            VolumeMount path `/additional-configmap-volume` (path: `/additional-configmap-volume` value, subPath: `` value) is duplicated for container `foobar`
+          errorPattern: 'VolumeMount path `/additional-configmap-volume` (path: `/additional-configmap-volume` value, subPath: `` value) is duplicated for container `foobar`'
 
   - it: with duplicated additionalVolumes `subPath` for the same `foobar` container, then fails
     set:
@@ -1067,8 +1060,7 @@ tests:
           subPath: subpath
     asserts:
       - failedTemplate:
-          errorPattern: |- 
-            VolumeMount path `/additional-configmap-volume/subpath` (path: `/additional-configmap-volume` value, subPath: `subpath` value) is duplicated for container `foobar`
+          errorPattern: 'VolumeMount path `/additional-configmap-volume/subpath` (path: `/additional-configmap-volume` value, subPath: `subpath` value) is duplicated for container `foobar`'
 
   - it: with duplicated additionalVolumes `path` but different `subPath` for the same `foobar` container, then succeeds
     set:
@@ -1168,8 +1160,7 @@ tests:
           path: /additional-configmap-volume-2
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            Volume `foobar-mount-volume` (name: `foobar-mount-volume` value, mountName: `` value) is defined more than once but with different types
+          errorPattern: 'Volume `foobar-mount-volume` (name: `foobar-mount-volume` value, mountName: `` value) is defined more than once but with different types'
 
   - it: with invalid additional volume `type`, then schema validation fails
     set:
@@ -1202,8 +1193,7 @@ tests:
           path: /fake-volume-path
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `type` value is mandatory for all of the `additionalVolumes` defined
+          errorPattern: '`type` value is mandatory for all of the `additionalVolumes` defined'
 
   - it: with missing mandatory additional volume `type` for `foobar` container, then fails
     set:
@@ -1213,8 +1203,7 @@ tests:
           containerName: foobar
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `type` value is mandatory for all of the `additionalVolumes` defined
+          errorPattern: '`type` value is mandatory for all of the `additionalVolumes` defined'
 
   - it: with missing mandatory additional volume `path` for `hivemq` container, then fails
     set:
@@ -1223,8 +1212,7 @@ tests:
           type: configMap
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `path` values is mandatory for all of the `additionalVolumes` defined for the `hivemq` container
+          errorPattern: '`path` values is mandatory for all of the `additionalVolumes` defined for the `hivemq` container'
 
   - it: with missing mandatory additional volume `path` for `foobar` container, then succeeds
     set:
@@ -1260,8 +1248,7 @@ tests:
           mountName: fake-volume-mount-name
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `name` value is required for types "configMap", "secret", "persistentVolumeClaim" and "sharedPersistentVolumeClaim"
+          errorPattern: '`name` value is required for types "configMap", "secret", "persistentVolumeClaim" and "sharedPersistentVolumeClaim"'
 
   - it: with additional volume type `secret` but missing `name`, then fails
     set:
@@ -1271,8 +1258,7 @@ tests:
           mountName: fake-volume-mount-name
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `name` value is required for types "configMap", "secret", "persistentVolumeClaim" and "sharedPersistentVolumeClaim"
+          errorPattern: '`name` value is required for types "configMap", "secret", "persistentVolumeClaim" and "sharedPersistentVolumeClaim"'
 
   - it: with additional volume type `persistentVolumeClaim` but missing `name`, then fails
     set:
@@ -1282,8 +1268,7 @@ tests:
           mountName: fake-volume-mount-name
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `name` value is required for types "configMap", "secret", "persistentVolumeClaim" and "sharedPersistentVolumeClaim"
+          errorPattern: '`name` value is required for types "configMap", "secret", "persistentVolumeClaim" and "sharedPersistentVolumeClaim"'
 
   - it: with additional volume type `emptyDir` but missing `name`, then succeeds
     set:
@@ -1363,8 +1348,7 @@ tests:
           mountName: fake-volume-mount-name
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499  
-            `projectedSources` value is required for type "projected"
+          errorPattern: '`projectedSources` value is required for type "projected"'
 
   - it: with additional volume type different than `projected` but `projectedSources` is present, then fails
     set:
@@ -1380,8 +1364,7 @@ tests:
                     path: my-config
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499  
-            `projectedSources` value is only available for type "projected"
+          errorPattern: '`projectedSources` value is only available for type "projected"'
 
   - it: with additional volume type `csi` but missing `name`, then succeeds
     set:
@@ -1467,8 +1450,7 @@ tests:
               number: 123
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            got boolean, want string
+          errorPattern: 'got boolean, want string'
 
   - it: with additional volume type `csi` with readOnly true, then succeeds
     set:
@@ -1551,8 +1533,7 @@ tests:
           mountName: fake-volume-mount-name
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `csi` value is required for type "csi"
+          errorPattern: '`csi` value is required for type "csi"'
 
   - it: with additional volume type `csi` but missing `csi.driver`, then fails
     set:
@@ -1564,8 +1545,7 @@ tests:
             readOnly: true
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `csi.driver` value is required for type "csi"
+          errorPattern: '`csi.driver` value is required for type "csi"'
 
   - it: with additional volume type different than `csi` but `csi` is present, then fails
     set:
@@ -1577,8 +1557,7 @@ tests:
             driver: secrets-store.csi.k8s.io
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `csi` value is only available for type "csi"
+          errorPattern: '`csi` value is only available for type "csi"'
 
   - it: with multiple additional volumes of type `csi` sharing the same `mountName` and identical `csi` config, then succeeds
     set:
@@ -1628,8 +1607,7 @@ tests:
             driver: driver-b
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `csi` configuration for volume "shared-csi-volume" must be identical across all `additionalVolumes` entries that share the same `mountName`
+          errorPattern: '`csi` configuration for volume "shared-csi-volume" must be identical across all `additionalVolumes` entries that share the same `mountName`'
 
   - it: with default settings, no volume claim template is set
     asserts:
@@ -1823,8 +1801,7 @@ tests:
           path: " /opt/hivemq/config"
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            values don't meet the specifications of the schema
+          errorPattern: 'values don''t meet the specifications of the schema'
 
   - it: with additionalVolumes path not starting with slash, then fails schema validation
     set:
@@ -1834,8 +1811,7 @@ tests:
           path: opt/hivemq/config
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            values don't meet the specifications of the schema
+          errorPattern: 'values don''t meet the specifications of the schema'
 
   - it: with additionalVolumes path containing special characters, then fails schema validation
     set:
@@ -1845,8 +1821,7 @@ tests:
           path: /opt/hivemq/con@fig
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            values don't meet the specifications of the schema
+          errorPattern: 'values don''t meet the specifications of the schema'
 
   - it: with additionalVolumes path containing spaces, then fails schema validation
     set:
@@ -1856,8 +1831,7 @@ tests:
           path: /opt/hivemq/my config
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            values don't meet the specifications of the schema
+          errorPattern: 'values don''t meet the specifications of the schema'
 
   - it: with additionalVolumes path with valid characters, then succeeds
     set:
@@ -1881,8 +1855,7 @@ tests:
           subPath: /my-file.xml
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            values don't meet the specifications of the schema
+          errorPattern: 'values don''t meet the specifications of the schema'
 
   - it: with additionalVolumes subPath starting with dot, then fails schema validation
     set:
@@ -1893,8 +1866,7 @@ tests:
           subPath: .hidden
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            values don't meet the specifications of the schema
+          errorPattern: 'values don''t meet the specifications of the schema'
 
   - it: with additionalVolumes subPath containing special characters, then fails schema validation
     set:
@@ -1905,8 +1877,7 @@ tests:
           subPath: my@file
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            values don't meet the specifications of the schema
+          errorPattern: 'values don''t meet the specifications of the schema'
 
   - it: with additionalVolumes subPath containing spaces, then fails schema validation
     set:
@@ -1917,8 +1888,7 @@ tests:
           subPath: my file
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            values don't meet the specifications of the schema
+          errorPattern: 'values don''t meet the specifications of the schema'
 
   - it: with additionalVolumes subPath with valid characters, then succeeds
     set:
@@ -2255,8 +2225,7 @@ tests:
           path: /opt/hivemq/pvc
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            `name` value is required for types "configMap", "secret", "persistentVolumeClaim" and "sharedPersistentVolumeClaim"
+          errorPattern: '`name` value is required for types "configMap", "secret", "persistentVolumeClaim" and "sharedPersistentVolumeClaim"'
 
   - it: with `hivemqFolders` on non-sharedPersistentVolumeClaim type, then fails
     set:
@@ -2268,8 +2237,7 @@ tests:
             data: data
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            `hivemqFolders` value is only available for type "sharedPersistentVolumeClaim"
+          errorPattern: '`hivemqFolders` value is only available for type "sharedPersistentVolumeClaim"'
 
   - it: with `subPath` on sharedPersistentVolumeClaim, then fails
     set:
@@ -2280,8 +2248,7 @@ tests:
           subPath: data
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            `subPath` value is not allowed for type "sharedPersistentVolumeClaim". Use `hivemqFolders` instead
+          errorPattern: '`subPath` value is not allowed for type "sharedPersistentVolumeClaim". Use `hivemqFolders` instead'
 
   - it: with sharedPersistentVolumeClaim and non-hivemq containerName, then fails
     set:
@@ -2292,8 +2259,7 @@ tests:
           path: /opt/hivemq/pvc
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            `sharedPersistentVolumeClaim` volume type is only allowed for the `hivemq` container
+          errorPattern: '`sharedPersistentVolumeClaim` volume type is only allowed for the `hivemq` container'
 
   - it: with sharedPersistentVolumeClaim and mountName matching volumeClaimTemplates, then succeeds
     set:
@@ -2357,8 +2323,7 @@ tests:
             volumeMode: Filesystem
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            `sharedPersistentVolumeClaim` volume type requires a matching `volumeClaimTemplates` entry with name `custom-mount`
+          errorPattern: '`sharedPersistentVolumeClaim` volume type requires a matching `volumeClaimTemplates` entry with name `custom-mount`'
 
   - it: with sharedPersistentVolumeClaim without volumeClaimTemplates, then fails
     set:
@@ -2370,8 +2335,7 @@ tests:
             data: data
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            `sharedPersistentVolumeClaim` volume type requires a matching `volumeClaimTemplates` entry with name `hivemqpvc`
+          errorPattern: '`sharedPersistentVolumeClaim` volume type requires a matching `volumeClaimTemplates` entry with name `hivemqpvc`'
 
   - it: with sharedPersistentVolumeClaim without matching volumeClaimTemplates name, then fails
     set:
@@ -2395,8 +2359,7 @@ tests:
             volumeMode: Filesystem
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            `sharedPersistentVolumeClaim` volume type requires a matching `volumeClaimTemplates` entry with name `hivemqpvc`
+          errorPattern: '`sharedPersistentVolumeClaim` volume type requires a matching `volumeClaimTemplates` entry with name `hivemqpvc`'
 
   - it: with sharedPersistentVolumeClaim path set to /opt/hivemq, then fails
     set:
@@ -2418,8 +2381,7 @@ tests:
             volumeMode: Filesystem
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            `path` value `/opt/hivemq` is not allowed for `sharedPersistentVolumeClaim` volume type. Use a subdirectory instead
+          errorPattern: '`path` value `/opt/hivemq` is not allowed for `sharedPersistentVolumeClaim` volume type. Use a subdirectory instead'
 
   - it: with HIVEMQ_DATA_FOLDER in nodes.env and hivemqFolders.data, then fails
     set:
@@ -2446,8 +2408,7 @@ tests:
           value: /custom/path
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            `HIVEMQ_DATA_FOLDER` environment variable cannot be set via `.nodes.env` when using the `sharedPersistentVolumeClaim` volume type
+          errorPattern: '`HIVEMQ_DATA_FOLDER` environment variable cannot be set via `.nodes.env` when using the `sharedPersistentVolumeClaim` volume type'
 
   - it: with HIVEMQ_LOG_FOLDER in nodes.env and hivemqFolders.log, then fails
     set:
@@ -2474,8 +2435,7 @@ tests:
           value: /custom/path
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            `HIVEMQ_LOG_FOLDER` environment variable cannot be set via `.nodes.env` when using the `sharedPersistentVolumeClaim` volume type
+          errorPattern: '`HIVEMQ_LOG_FOLDER` environment variable cannot be set via `.nodes.env` when using the `sharedPersistentVolumeClaim` volume type'
 
   - it: with HIVEMQ_HEAPDUMP_FOLDER in nodes.env and hivemqFolders.heapDump, then fails
     set:
@@ -2502,8 +2462,7 @@ tests:
           value: /custom/path
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            `HIVEMQ_HEAPDUMP_FOLDER` environment variable cannot be set via `.nodes.env` when using the `sharedPersistentVolumeClaim` volume type
+          errorPattern: '`HIVEMQ_HEAPDUMP_FOLDER` environment variable cannot be set via `.nodes.env` when using the `sharedPersistentVolumeClaim` volume type'
 
   - it: with HIVEMQ_BACKUP_FOLDER in nodes.env and hivemqFolders.backup, then fails
     set:
@@ -2530,8 +2489,7 @@ tests:
           value: /custom/path
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            `HIVEMQ_BACKUP_FOLDER` environment variable cannot be set via `.nodes.env` when using the `sharedPersistentVolumeClaim` volume type
+          errorPattern: '`HIVEMQ_BACKUP_FOLDER` environment variable cannot be set via `.nodes.env` when using the `sharedPersistentVolumeClaim` volume type'
 
   - it: with HIVEMQ_AUDIT_FOLDER in nodes.env and hivemqFolders.audit, then fails
     set:
@@ -2558,8 +2516,7 @@ tests:
           value: /custom/path
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            `HIVEMQ_AUDIT_FOLDER` environment variable cannot be set via `.nodes.env` when using the `sharedPersistentVolumeClaim` volume type
+          errorPattern: '`HIVEMQ_AUDIT_FOLDER` environment variable cannot be set via `.nodes.env` when using the `sharedPersistentVolumeClaim` volume type'
 
   - it: with HIVEMQ_DATA_FOLDER in nodes.env without sharedPersistentVolumeClaim, then succeeds
     set:
@@ -2641,8 +2598,7 @@ tests:
             volumeMode: Filesystem
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            `hivemqFolders` is required for `sharedPersistentVolumeClaim` volume type
+          errorPattern: '`hivemqFolders` is required for `sharedPersistentVolumeClaim` volume type'
 
   - it: with sharedPersistentVolumeClaim with empty hivemqFolders, then fails
     set:
@@ -2665,8 +2621,7 @@ tests:
             volumeMode: Filesystem
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            `hivemqFolders` must contain at least one key (data, log, heapDump, backup, audit) for `sharedPersistentVolumeClaim` volume type
+          errorPattern: '`hivemqFolders` must contain at least one key (data, log, heapDump, backup, audit) for `sharedPersistentVolumeClaim` volume type'
 
   - it: with sharedPersistentVolumeClaim with unknown hivemqFolders key, then fails schema validation
     set:
@@ -2678,8 +2633,7 @@ tests:
             foo: bar
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            values don't meet the specifications of the schema
+          errorPattern: 'values don''t meet the specifications of the schema'
 
   - it: with sharedPersistentVolumeClaim with empty string hivemqFolders value, then fails schema validation
     set:
@@ -2691,8 +2645,7 @@ tests:
             data: ""
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            values don't meet the specifications of the schema
+          errorPattern: 'values don''t meet the specifications of the schema'
 
   - it: with multiple sharedPersistentVolumeClaim entries, then fails
     set:
@@ -2705,8 +2658,7 @@ tests:
           path: /opt/hivemq/pvc2
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            Only one `sharedPersistentVolumeClaim` volume type is allowed but 2 were defined
+          errorPattern: 'Only one `sharedPersistentVolumeClaim` volume type is allowed but 2 were defined'
 
   - it: with duplicate hivemqFolders values in sharedPersistentVolumeClaim, then fails
     set:
@@ -2731,8 +2683,7 @@ tests:
             volumeMode: Filesystem
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            Duplicate subfolder name `shared` in `hivemqFolders` for `sharedPersistentVolumeClaim`
+          errorPattern: 'Duplicate subfolder name `shared` in `hivemqFolders` for `sharedPersistentVolumeClaim`'
 
   - it: with sharedPersistentVolumeClaim subPath starting with slash, then fails schema validation
     set:
@@ -2744,8 +2695,7 @@ tests:
             data: /my-data
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            values don't meet the specifications of the schema
+          errorPattern: 'values don''t meet the specifications of the schema'
 
   - it: with sharedPersistentVolumeClaim subPath containing spaces, then fails schema validation
     set:
@@ -2757,8 +2707,7 @@ tests:
             log: my data
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            values don't meet the specifications of the schema
+          errorPattern: 'values don''t meet the specifications of the schema'
 
   - it: with sharedPersistentVolumeClaim subPath starting with dot, then fails schema validation
     set:
@@ -2770,8 +2719,7 @@ tests:
             heapDump: .hidden
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            values don't meet the specifications of the schema
+          errorPattern: 'values don''t meet the specifications of the schema'
 
   - it: with sharedPersistentVolumeClaim subPath starting with hyphen, then fails schema validation
     set:
@@ -2783,8 +2731,7 @@ tests:
             backup: -backup
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            values don't meet the specifications of the schema
+          errorPattern: 'values don''t meet the specifications of the schema'
 
   - it: with sharedPersistentVolumeClaim subPath containing special characters, then fails schema validation
     set:
@@ -2796,8 +2743,7 @@ tests:
             audit: my@data
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            values don't meet the specifications of the schema
+          errorPattern: 'values don''t meet the specifications of the schema'
 
   - it: with sharedPersistentVolumeClaim nested subPath containing special characters, then fails schema validation
     set:
@@ -2809,8 +2755,7 @@ tests:
             data: foo/@invalid
     asserts:
       - failedTemplate:
-          errorPattern: |-
-            values don't meet the specifications of the schema
+          errorPattern: 'values don''t meet the specifications of the schema'
 
   - it: with sharedPersistentVolumeClaim subPath with valid characters (dots, underscores, hyphens), then succeeds
     set:

--- a/charts/hivemq-platform/tests/statefulset/hivemq_security_context_test.yaml
+++ b/charts/hivemq-platform/tests/statefulset/hivemq_security_context_test.yaml
@@ -197,8 +197,7 @@ tests:
           runAsUser: 10000
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `runAsNonRoot` is set to `false` but `runAsUser` is not set to `0` \(root\)
+          errorPattern: '`runAsNonRoot` is set to `false` but `runAsUser` is not set to `0` \(root\)'
 
   - it: with security context runAsNonRoot true, and runAsUser root, then validation fails
     set:
@@ -209,8 +208,7 @@ tests:
           runAsUser: 0
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `runAsNonRoot` is set to `true` but `runAsUser` is set to `0` \(root\)
+          errorPattern: '`runAsNonRoot` is set to `true` but `runAsUser` is set to `0` \(root\)'
 
   - it: with defaults, no container security context set
     asserts:
@@ -450,8 +448,7 @@ tests:
           runAsUser: 10000
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `runAsNonRoot` is set to `false` but `runAsUser` is not set to `0` \(root\)
+          errorPattern: '`runAsNonRoot` is set to `false` but `runAsUser` is not set to `0` \(root\)'
 
   - it: with container security context runAsNonRoot true, and runAsUser root, then validation fails
     set:
@@ -461,5 +458,4 @@ tests:
           runAsUser: 0
     asserts:
       - failedTemplate:
-          errorPattern: |- # FIXME: |- character can be removed once the Helm Unittest plugin issue is fixed https://github.com/helm-unittest/helm-unittest/issues/499
-            `runAsNonRoot` is set to `true` but `runAsUser` is set to `0` \(root\)
+          errorPattern: '`runAsNonRoot` is set to `true` but `runAsUser` is set to `0` \(root\)'

--- a/charts/hivemq-platform/values.schema.json
+++ b/charts/hivemq-platform/values.schema.json
@@ -70,12 +70,44 @@
             "description" : "The optional name of the container to which the volume is mounted. The default container name is `hivemq`.",
             "type" : "string"
           },
+          "csi" : {
+            "description" : "Configures the Container Storage Interface (CSI) volume source. Required for type `csi`.",
+            "properties" : {
+              "driver" : {
+                "description" : "The name of the CSI driver to use (e.g. `secrets-store.csi.k8s.io`).",
+                "minLength" : 1,
+                "type" : "string"
+              },
+              "fsType" : {
+                "description" : "The filesystem type to mount (e.g. `ext4`, `xfs`, `ntfs`). The value is passed through to the CSI driver and the supported types depend on the driver and the host operating system.",
+                "minLength" : 1,
+                "type" : "string"
+              },
+              "nodePublishSecretRef" : {
+                "description" : "The name of the Kubernetes Secret to pass to the CSI driver for `NodePublishVolume`.",
+                "minLength" : 1,
+                "type" : "string"
+              },
+              "readOnly" : {
+                "description" : "Mounts the CSI volume as read-only.",
+                "type" : "boolean"
+              },
+              "volumeAttributes" : {
+                "additionalProperties" : {
+                  "type" : "string"
+                },
+                "description" : "Driver-specific key-value attributes passed through to the CSI driver.",
+                "type" : "object"
+              }
+            },
+            "type" : "object"
+          },
           "mountName" : {
             "description" : "Defines the name of the volume mount to be used for the StatefulSet spec. For type `sharedPersistentVolumeClaim`, the `mountName` (or `name`, if not set) must match a `volumeClaimTemplates` entry.",
             "type" : "string"
           },
           "name" : {
-            "description" : "The name of the Kubernetes resource backing the volume. Required for types `configMap`, `secret`, `persistentVolumeClaim` and `sharedPersistentVolumeClaim`. For `persistentVolumeClaim` and `sharedPersistentVolumeClaim`, this entry is used as the PersistentVolumeClaim name. The `name` field is ignored for types `emptyDir` and `projected`.",
+            "description" : "The name of the Kubernetes resource backing the volume. Required for types `configMap`, `secret`, `persistentVolumeClaim` and `sharedPersistentVolumeClaim`. For `persistentVolumeClaim` and `sharedPersistentVolumeClaim`, this entry is used as the PersistentVolumeClaim name. For types `csi`, `emptyDir` and `projected`, `name` is used as the volume identifier only when `mountName` is not set (prefer setting `mountName`).",
             "type" : "string"
           },
           "path" : {
@@ -138,6 +170,7 @@
             "description" : "Defines the type of volume to be mounted.",
             "enum" : [
               "configMap",
+              "csi",
               "emptyDir",
               "persistentVolumeClaim",
               "projected",

--- a/charts/hivemq-platform/values.yaml
+++ b/charts/hivemq-platform/values.yaml
@@ -765,6 +765,15 @@ additionalVolumes: []
 #    hivemqFolders:
 #      data: my-data                    # → HIVEMQ_DATA_FOLDER=/opt/hivemq/pvc/my-data
 #      heapDump: my-dump                # → HIVEMQ_HEAPDUMP_FOLDER=/opt/hivemq/pvc/my-dump
+## Example of an additional volume using a CSI driver (e.g. Secrets Store CSI driver for Azure Key Vault, AWS Secrets Manager, or HashiCorp Vault):
+#  - type: csi
+#    mountName: secrets-store
+#    path: /mnt/secrets
+#    csi:
+#      driver: secrets-store.csi.k8s.io
+#      readOnly: true
+#      volumeAttributes:
+#        secretProviderClass: my-secret-provider
 
 # type: Choose a type of volume that you want to mount.
 # name: The name used for the Secret, the ConfigMap or the PersistentVolumeClaim to be mounted.
@@ -787,6 +796,13 @@ additionalVolumes: []
 #             "backup"   → HIVEMQ_BACKUP_FOLDER,
 #             "audit"    → HIVEMQ_AUDIT_FOLDER.
 #       A matching `volumeClaimTemplates` entry is required when using "sharedPersistentVolumeClaim".
+# csi: Required for type "csi". Configures the Container Storage Interface (CSI) volume source.
+#       Supported fields:
+#         "driver"               (required)  → The name of the CSI driver to use (e.g. "secrets-store.csi.k8s.io").
+#         "fsType"               (optional)  → The filesystem type to mount (e.g. "ext4", "xfs", "ntfs"). Passed through to the CSI driver; supported types depend on the driver.
+#         "nodePublishSecretRef" (optional)  → The name of the Kubernetes Secret to pass to the CSI driver for NodePublishVolume.
+#         "readOnly"             (optional)  → Mounts the CSI volume as read-only.
+#         "volumeAttributes"     (optional)  → Driver-specific key-value attributes passed through to the CSI driver.
 
 # List of PersistentVolumeClaims that pods are allowed to reference. Every claim in this list must have at least one matching (by name)
 # volumeMount in one container in the StatefulSet template. This can be achieved by defining an `additionalVolumes` entry of type


### PR DESCRIPTION
## Summary

- Adds `csi` as a new volume type in `additionalVolumes` for the HiveMQ Platform Helm chart
- Supports the full Kubernetes `CSIVolumeSource` spec: `driver`, `readOnly`, `fsType`, `volumeAttributes`, and `nodePublishSecretRef`
- Enables integration with the Secrets Store CSI driver (CNCF project) for Azure Key Vault, AWS Secrets Manager, GCP Secret Manager, and HashiCorp Vault
- Includes schema validation, template rendering, bidirectional validation checks, and 12 unit tests
- Validated end-to-end on Minikube (HashiCorp Vault) and AKS (Azure Key Vault with Workload Identity)

Resolves INT-162