### PR TITLE
Add priorityClassName, nodeSelector and PodDisruptionBudget support

### DIFF
--- a/charts/hivemq-platform/templates/_helpers.tpl
+++ b/charts/hivemq-platform/templates/_helpers.tpl
@@ -373,6 +373,37 @@ Usage: {{ include "hivemq-platform.validate-extensions" . }}
 {{- end -}}
 
 {{/*
+Checks whether a PodDisruptionBudget value is set (key exists in the map and value is non-empty).
+Returns "true" if the value is set, empty string otherwise.
+Usage: {{ include "hivemq-platform.has-pdb-value" (dict "pdb" .Values.podDisruptionBudget "field" "minAvailable") }}
+*/}}
+{{- define "hivemq-platform.has-pdb-value" -}}
+{{- if and (hasKey .pdb .field) (ne (toString (get .pdb .field)) "") -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validates the podDisruptionBudget configuration:
+- If enabled, at least one of minAvailable/maxUnavailable must be set.
+- minAvailable and maxUnavailable are mutually exclusive (K8s policy API requirement).
+Usage: {{ include "hivemq-platform.validate-pod-disruption-budget" . }}
+*/}}
+{{- define "hivemq-platform.validate-pod-disruption-budget" -}}
+{{- $pdb := .Values.podDisruptionBudget -}}
+{{- if $pdb.enabled -}}
+  {{- $hasMin := include "hivemq-platform.has-pdb-value" (dict "pdb" $pdb "field" "minAvailable") -}}
+  {{- $hasMax := include "hivemq-platform.has-pdb-value" (dict "pdb" $pdb "field" "maxUnavailable") -}}
+  {{- if and (not $hasMin) (not $hasMax) -}}
+    {{- fail "`podDisruptionBudget.enabled` is `true` but neither `minAvailable` nor `maxUnavailable` was set. Set exactly one." -}}
+  {{- end -}}
+  {{- if and $hasMin $hasMax -}}
+    {{- fail "`podDisruptionBudget.minAvailable` and `podDisruptionBudget.maxUnavailable` are mutually exclusive. Set exactly one." -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Validates there is no duplicated extension names defined.
 Usage: {{ include "hivemq-platform.validate-duplicated-extension-names" . }}
 */}}

--- a/charts/hivemq-platform/templates/hivemq-custom-resource.yml
+++ b/charts/hivemq-platform/templates/hivemq-custom-resource.yml
@@ -297,6 +297,13 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.podScheduling.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.podScheduling.priorityClassName }}
+          priorityClassName: {{ . }}
+          {{- end }}
       {{- with .Values.volumeClaimTemplates }}
       volumeClaimTemplates:
         {{- toYaml . | nindent 12 }}

--- a/charts/hivemq-platform/templates/hivemq-platform-pod-disruption-budget.yml
+++ b/charts/hivemq-platform/templates/hivemq-platform-pod-disruption-budget.yml
@@ -1,0 +1,23 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- include "hivemq-platform.validate-pod-disruption-budget" . -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "hivemq-platform.name" (dict "name" "pdb" "releaseName" .Release.Name) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hivemq-platform.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "hivemq-platform.selector-labels" . | nindent 6 }}
+  {{- if include "hivemq-platform.has-pdb-value" (dict "pdb" .Values.podDisruptionBudget "field" "minAvailable") }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if include "hivemq-platform.has-pdb-value" (dict "pdb" .Values.podDisruptionBudget "field" "maxUnavailable") }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/hivemq-platform/tests/hivemq_platform_test.yaml
+++ b/charts/hivemq-platform/tests/hivemq_platform_test.yaml
@@ -1500,33 +1500,6 @@ tests:
     asserts:
       - failedTemplate: {}
 
-  - it: with pod scheduling values set
-    values:
-      - pod-scheduling-values.yaml
-    asserts:
-      - exists:
-          path: spec.statefulSet.spec.template.spec.affinity
-      - isSubset:
-          path: spec.statefulSet.spec.template.spec.affinity
-          content:
-            podAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchExpressions:
-                      - key: app
-                        operator: In
-                        values:
-                          - my-app
-                  topologyKey: "kubernetes.io/hostname"
-      - exists:
-          path: spec.statefulSet.spec.template.spec.tolerations
-      - contains:
-          path: spec.statefulSet.spec.template.spec.tolerations
-          content:
-            effect: NoSchedule
-            key: my-key
-            operator: Exists
-
   - it: with custom pod annotations
     set:
       nodes:

--- a/charts/hivemq-platform/tests/pod-disruption-budget/hivemq_pdb_test.yaml
+++ b/charts/hivemq-platform/tests/pod-disruption-budget/hivemq_pdb_test.yaml
@@ -1,0 +1,281 @@
+suite: HiveMQ Platform - Pod Disruption Budget tests
+templates:
+  - hivemq-platform-pod-disruption-budget.yml
+release:
+  name: test-hivemq-platform
+  namespace: test-hivemq-platform-namespace
+chart:
+  version: 0.0.1
+  appVersion: 1.0.0
+tests:
+
+  - it: with podDisruptionBudget disabled by default, no PDB is rendered
+    asserts:
+      - notFailedTemplate: {}
+      - hasDocuments:
+          count: 0
+
+  - it: with podDisruptionBudget enabled, default PDB resource created
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+    asserts:
+      - containsDocument:
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          name: hivemq-platform-pdb-test-hivemq-platform
+
+  - it: with podDisruptionBudget enabled, PDB metadata created with default values
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            helm.sh/chart: hivemq-platform-0.0.1
+            app.kubernetes.io/name: "hivemq-platform"
+            app.kubernetes.io/instance: "test-hivemq-platform"
+            app.kubernetes.io/version: "1.0.0"
+            app.kubernetes.io/managed-by: Helm
+      - equal:
+          path: metadata.namespace
+          value: test-hivemq-platform-namespace
+      - isSubset:
+          path: spec.selector
+          content:
+            matchLabels:
+              app.kubernetes.io/name: "hivemq-platform"
+              app.kubernetes.io/instance: "test-hivemq-platform"
+
+  - it: with custom release name and namespace, PDB metadata created with custom values
+    release:
+      name: custom-release
+      namespace: custom-namespace
+    chart:
+      version: 0.1.0
+      appVersion: 2.0.0
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+    asserts:
+      - containsDocument:
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          name: hivemq-platform-pdb-custom-release
+      - isSubset:
+          path: metadata.labels
+          content:
+            helm.sh/chart: hivemq-platform-0.1.0
+            app.kubernetes.io/name: "hivemq-platform"
+            app.kubernetes.io/instance: "custom-release"
+            app.kubernetes.io/version: "2.0.0"
+            app.kubernetes.io/managed-by: Helm
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: "custom-release"
+
+  - it: with long release name, PDB name is truncated
+    release:
+      name: a-very-long-hivemq-platform-release-name-for-testing
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+    asserts:
+      - equal:
+          path: metadata.name
+          value: hivemq-platform-pdb-a-very-long-hivemq-platform-release-name-fo
+
+  - it: with podDisruptionBudget enabled but neither minAvailable nor maxUnavailable set, validation fails
+    set:
+      podDisruptionBudget:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: '`podDisruptionBudget.enabled` is `true` but neither `minAvailable` nor `maxUnavailable` was set'
+
+  - it: with podDisruptionBudget enabled and both minAvailable and maxUnavailable set, validation fails
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+        maxUnavailable: 1
+    asserts:
+      - failedTemplate:
+          errorPattern: '`podDisruptionBudget.minAvailable` and `podDisruptionBudget.maxUnavailable` are mutually exclusive'
+
+  - it: with podDisruptionBudget enabled and minAvailable as integer, PDB is rendered
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - notExists:
+          path: spec.maxUnavailable
+      - notExists:
+          path: spec.unhealthyPodEvictionPolicy
+
+  - it: with podDisruptionBudget enabled and minAvailable as zero, schema validation fails
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: 'minimum'
+
+  - it: with podDisruptionBudget enabled and minAvailable as percentage, PDB is rendered with minAvailable percentage
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: "50%"
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: "50%"
+
+  - it: with podDisruptionBudget enabled and maxUnavailable as integer, PDB is rendered
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+
+  - it: with podDisruptionBudget enabled and maxUnavailable as zero, PDB is rendered with maxUnavailable zero
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 0
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.maxUnavailable
+          value: 0
+
+  - it: with podDisruptionBudget enabled and maxUnavailable as percentage, PDB is rendered with maxUnavailable percentage
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: "25%"
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: "25%"
+
+  - it: with podDisruptionBudget enabled and unhealthyPodEvictionPolicy AlwaysAllow, policy is rendered
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+        unhealthyPodEvictionPolicy: "AlwaysAllow"
+    asserts:
+      - equal:
+          path: spec.unhealthyPodEvictionPolicy
+          value: "AlwaysAllow"
+
+  - it: with podDisruptionBudget enabled and unhealthyPodEvictionPolicy IfHealthyBudget, policy is rendered
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+        unhealthyPodEvictionPolicy: "IfHealthyBudget"
+    asserts:
+      - equal:
+          path: spec.unhealthyPodEvictionPolicy
+          value: "IfHealthyBudget"
+
+  - it: with minAvailable as invalid string, schema validation fails
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: "foo"
+    asserts:
+      - failedTemplate:
+          errorPattern: 'does not match pattern'
+
+  - it: with minAvailable as numeric string without percent, schema validation fails
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: "2"
+    asserts:
+      - failedTemplate:
+          errorPattern: 'does not match pattern'
+
+  - it: with minAvailable as negative integer, schema validation fails
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: -1
+    asserts:
+      - failedTemplate:
+          errorPattern: 'minimum'
+
+  - it: with minAvailable as one, PDB is rendered with minAvailable one
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.minAvailable
+          value: 1
+
+  - it: with maxUnavailable as invalid string, schema validation fails
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: "invalid"
+    asserts:
+      - failedTemplate:
+          errorPattern: 'does not match pattern'
+
+  - it: with maxUnavailable as numeric string without percent, schema validation fails
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: "1"
+    asserts:
+      - failedTemplate:
+          errorPattern: 'does not match pattern'
+
+  - it: with maxUnavailable as negative integer, schema validation fails
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: -5
+    asserts:
+      - failedTemplate:
+          errorPattern: 'minimum'
+
+  - it: with unhealthyPodEvictionPolicy as invalid value, schema validation fails
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+        unhealthyPodEvictionPolicy: "Invalid"
+    asserts:
+      - failedTemplate:
+          errorPattern: 'value must be one of'

--- a/charts/hivemq-platform/tests/statefulset/hivemq_pod_scheduling_test.yaml
+++ b/charts/hivemq-platform/tests/statefulset/hivemq_pod_scheduling_test.yaml
@@ -1,0 +1,171 @@
+suite: HiveMQ Platform - Pod Scheduling tests
+templates:
+  - hivemq-custom-resource.yml
+tests:
+
+  - it: with defaults, no priorityClassName is set
+    asserts:
+      - notExists:
+          path: spec.statefulSet.spec.template.spec.priorityClassName
+
+  - it: with defaults, no nodeSelector is set
+    asserts:
+      - notExists:
+          path: spec.statefulSet.spec.template.spec.nodeSelector
+
+  - it: with defaults, no affinity is set
+    asserts:
+      - notExists:
+          path: spec.statefulSet.spec.template.spec.affinity
+
+  - it: with defaults, no tolerations are set
+    asserts:
+      - notExists:
+          path: spec.statefulSet.spec.template.spec.tolerations
+
+  - it: with priorityClassName set, priorityClassName is rendered
+    set:
+      podScheduling.priorityClassName: "high-priority"
+    asserts:
+      - exists:
+          path: spec.statefulSet.spec.template.spec.priorityClassName
+      - equal:
+          path: spec.statefulSet.spec.template.spec.priorityClassName
+          value: "high-priority"
+
+  - it: with empty priorityClassName, priorityClassName is not rendered
+    set:
+      podScheduling.priorityClassName: ""
+    asserts:
+      - notExists:
+          path: spec.statefulSet.spec.template.spec.priorityClassName
+
+  - it: with nodeSelector set, nodeSelector is rendered
+    set:
+      podScheduling:
+        nodeSelector:
+          disktype: ssd
+          workload: hivemq
+    asserts:
+      - exists:
+          path: spec.statefulSet.spec.template.spec.nodeSelector
+      - equal:
+          path: spec.statefulSet.spec.template.spec.nodeSelector.disktype
+          value: "ssd"
+      - equal:
+          path: spec.statefulSet.spec.template.spec.nodeSelector.workload
+          value: "hivemq"
+
+  - it: with empty nodeSelector, nodeSelector is not rendered
+    set:
+      podScheduling.nodeSelector: {}
+    asserts:
+      - notExists:
+          path: spec.statefulSet.spec.template.spec.nodeSelector
+
+  - it: with affinity set, affinity is rendered
+    set:
+      podScheduling:
+        affinity:
+          podAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - my-app
+                topologyKey: "kubernetes.io/hostname"
+    asserts:
+      - exists:
+          path: spec.statefulSet.spec.template.spec.affinity
+      - isSubset:
+          path: spec.statefulSet.spec.template.spec.affinity
+          content:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - my-app
+                  topologyKey: "kubernetes.io/hostname"
+
+  - it: with empty affinity, affinity is not rendered
+    set:
+      podScheduling.affinity: {}
+    asserts:
+      - notExists:
+          path: spec.statefulSet.spec.template.spec.affinity
+
+  - it: with tolerations set, tolerations are rendered
+    set:
+      podScheduling:
+        tolerations:
+          - key: "my-key"
+            operator: "Exists"
+            effect: "NoSchedule"
+    asserts:
+      - exists:
+          path: spec.statefulSet.spec.template.spec.tolerations
+      - contains:
+          path: spec.statefulSet.spec.template.spec.tolerations
+          content:
+            effect: NoSchedule
+            key: my-key
+            operator: Exists
+
+  - it: with empty tolerations, tolerations are not rendered
+    set:
+      podScheduling.tolerations: []
+    asserts:
+      - notExists:
+          path: spec.statefulSet.spec.template.spec.tolerations
+
+  - it: with both priorityClassName and nodeSelector set, both are rendered
+    set:
+      podScheduling:
+        priorityClassName: "critical"
+        nodeSelector:
+          kubernetes.io/os: linux
+    asserts:
+      - equal:
+          path: spec.statefulSet.spec.template.spec.priorityClassName
+          value: "critical"
+      - equal:
+          path: spec.statefulSet.spec.template.spec.nodeSelector["kubernetes.io/os"]
+          value: "linux"
+
+  - it: with all pod scheduling values set
+    values:
+      - pod-scheduling-values.yaml
+    asserts:
+      - exists:
+          path: spec.statefulSet.spec.template.spec.affinity
+      - isSubset:
+          path: spec.statefulSet.spec.template.spec.affinity
+          content:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - my-app
+                  topologyKey: "kubernetes.io/hostname"
+      - exists:
+          path: spec.statefulSet.spec.template.spec.tolerations
+      - contains:
+          path: spec.statefulSet.spec.template.spec.tolerations
+          content:
+            effect: NoSchedule
+            key: my-key
+            operator: Exists
+      - equal:
+          path: spec.statefulSet.spec.template.spec.nodeSelector.disktype
+          value: "ssd"
+      - equal:
+          path: spec.statefulSet.spec.template.spec.priorityClassName
+          value: "high-priority"

--- a/charts/hivemq-platform/tests/statefulset/pod-scheduling-values.yaml
+++ b/charts/hivemq-platform/tests/statefulset/pod-scheduling-values.yaml
@@ -13,3 +13,6 @@ podScheduling:
     - key: "my-key"
       operator: "Exists"
       effect: "NoSchedule"
+  nodeSelector:
+    disktype: ssd
+  priorityClassName: "high-priority"

--- a/charts/hivemq-platform/values.schema.json
+++ b/charts/hivemq-platform/values.schema.json
@@ -933,6 +933,33 @@
       },
       "type" : "object"
     },
+    "podDisruptionBudget" : {
+      "description" : "Configures a PodDisruptionBudget for the HiveMQ Platform pods to control voluntary disruptions such as node drains or cluster autoscaler scale-down events.",
+      "properties" : {
+        "enabled" : {
+          "description" : "Defines whether the PodDisruptionBudget resource is created for the HiveMQ Platform pods. Requires either minAvailable or maxUnavailable (but not both) to also be set.",
+          "type" : "boolean"
+        },
+        "maxUnavailable" : {
+          "description" : "Maximum number of HiveMQ Platform pods that can be unavailable during voluntary disruptions. Accepts an integer or a percentage string (for example, `1` or `\"25%\"`). Mutually exclusive with `minAvailable`.",
+          "minimum" : 0,
+          "pattern" : "^[0-9]+%$",
+          "type" : ["integer", "string"]
+        },
+        "minAvailable" : {
+          "description" : "Minimum number of HiveMQ Platform pods that must remain available during voluntary disruptions. Accepts an integer or a percentage string (for example, `2` or `\"50%\"`). Mutually exclusive with `maxUnavailable`.",
+          "minimum" : 1,
+          "pattern" : "^[0-9]+%$",
+          "type" : ["integer", "string"]
+        },
+        "unhealthyPodEvictionPolicy" : {
+          "description" : "Controls how the PodDisruptionBudget treats unhealthy HiveMQ Platform pods. Requires Kubernetes 1.26 or newer. Leave empty to use the cluster default. `IfHealthyBudget` only allows eviction of unhealthy pods if the budget is satisfied (can deadlock if pods crashloop). `AlwaysAllow` always allows eviction of unhealthy pods.",
+          "enum" : ["", "IfHealthyBudget", "AlwaysAllow"],
+          "type" : "string"
+        }
+      },
+      "type" : "object"
+    },
     "podScheduling" : {
       "description" : "Configures how the HiveMQ Platform pods are placed on your Kubernetes nodes.",
       "properties" : {

--- a/charts/hivemq-platform/values.schema.json
+++ b/charts/hivemq-platform/values.schema.json
@@ -934,11 +934,22 @@
       "type" : "object"
     },
     "podScheduling" : {
+      "description" : "Configures how the HiveMQ Platform pods are placed on your Kubernetes nodes.",
       "properties" : {
         "affinity" : {
+          "description" : "Optional setting that defines the affinity configuration for your HiveMQ Platform pods. Any valid `affinity` Kubernetes configuration can be used.",
           "type" : "object"
         },
+        "nodeSelector" : {
+          "description" : "Optional setting that defines the node selector configuration for your HiveMQ Platform pods. Constrains the HiveMQ Platform pods to run on Kubernetes nodes with matching labels.",
+          "type" : "object"
+        },
+        "priorityClassName" : {
+          "description" : "Optional setting that defines the priority class name for your HiveMQ Platform pods. The referenced Kubernetes `PriorityClass` must already exist in the cluster. Protects HiveMQ Platform pods from being preempted during cluster events such as node upgrades or autoscaling.",
+          "type" : "string"
+        },
         "tolerations" : {
+          "description" : "Optional setting that defines the pod tolerations configuration for your HiveMQ Platform pods.",
           "items" : {
             "type" : "object"
           },

--- a/charts/hivemq-platform/values.yaml
+++ b/charts/hivemq-platform/values.yaml
@@ -221,6 +221,23 @@ podScheduling:
   # Protects HiveMQ Platform pods from being preempted during cluster events such as node upgrades or autoscaling.
   priorityClassName: ""
 
+# Configures a PodDisruptionBudget for the HiveMQ Platform pods to control voluntary disruptions such as node drains or cluster autoscaler scale-down events.
+podDisruptionBudget:
+  # Defines whether the PodDisruptionBudget resource is created for the HiveMQ Platform pods.
+  # Requires either minAvailable or maxUnavailable (but not both) to also be set.
+  enabled: false
+  # Minimum number of HiveMQ Platform pods that must remain available during voluntary disruptions.
+  # Accepts an integer or a percentage string (for example, `2` or `"50%"`). Mutually exclusive with `maxUnavailable`.
+  # minAvailable: 2
+  # Maximum number of HiveMQ Platform pods that can be unavailable during voluntary disruptions.
+  # Accepts an integer or a percentage string (for example, `1` or `"25%"`). Mutually exclusive with `minAvailable`.
+  # maxUnavailable: "25%"
+  # Controls how the PodDisruptionBudget treats unhealthy HiveMQ Platform pods.
+  # Requires Kubernetes 1.26 or newer. Leave empty to use the cluster default:
+  #   - `IfHealthyBudget` only allows eviction of unhealthy pods if the budget is satisfied (can deadlock if pods crashloop).
+  #   - `AlwaysAllow` always allows eviction of unhealthy pods.
+  # unhealthyPodEvictionPolicy: "AlwaysAllow"
+
 # Monitoring settings used by the HiveMQ Prometheus extension.
 metrics:
   # Set to disable or enable the HiveMQ Prometheus extension.

--- a/charts/hivemq-platform/values.yaml
+++ b/charts/hivemq-platform/values.yaml
@@ -190,9 +190,9 @@ operator:
   # Annotations to add to the HiveMQ Platform custom resource.
   annotations: {}
 
-# Configures how the HiveMQ platform pods should be scheduled on the Kubernetes worker nodes.
+# Configures how the HiveMQ Platform pods are placed on your Kubernetes nodes.
 podScheduling:
-  # Configures the affinity for the Platform pods
+  # Optional setting that defines the affinity configuration for your HiveMQ Platform pods. Any valid `affinity` Kubernetes configuration can be used.
   affinity: {}
   # podAffinity:
   #    requiredDuringSchedulingIgnoredDuringExecution:
@@ -204,11 +204,22 @@ podScheduling:
   #                - my-app
   #        topologyKey: "kubernetes.io/hostname"
 
-  # Configures the tolerations for the Platform pods
+  # Optional setting that defines the pod tolerations configuration for your HiveMQ Platform pods.
   tolerations: []
   #  - key: "example-key"
   #    operator: "Exists"
   #    effect: "NoSchedule"
+
+  # Optional setting that defines the node selector configuration for your HiveMQ Platform pods.
+  # Constrains the HiveMQ Platform pods to run on Kubernetes nodes with matching labels.
+  nodeSelector: {}
+  #  disktype: "ssd"
+  #  kubernetes.io/os: "linux"
+
+  # Optional setting that defines the priority class name for your HiveMQ Platform pods.
+  # The referenced Kubernetes `PriorityClass` must already exist in the cluster.
+  # Protects HiveMQ Platform pods from being preempted during cluster events such as node upgrades or autoscaling.
+  priorityClassName: ""
 
 # Monitoring settings used by the HiveMQ Prometheus extension.
 metrics:


### PR DESCRIPTION
## Summary

Addresses #777. Adds native Helm values for pod scheduling and disruption controls in the `hivemq-platform` chart:

- Expose `podScheduling.priorityClassName` and `podScheduling.nodeSelector` as pass-through fields to the `HiveMQPlatform` CRD's native `StatefulSetSpec` (already supported end-to-end by the operator)
- Add new top-level `podDisruptionBudget` block rendering a `policy/v1` PodDisruptionBudget resource with the chart's standard selector labels
- Add `hivemq-platform.validate-pod-disruption-budget` helper enforcing mutual exclusion between `minAvailable` and `maxUnavailable`
- Expose optional `unhealthyPodEvictionPolicy` field (K8s 1.26+; empty by default to maintain 1.24 minimum support)
- Move all `podScheduling` tests (affinity, tolerations, nodeSelector, priorityClassName) into a dedicated test suite

### Changes

| Area | Details |
|---|---|
| `podScheduling` | `nodeSelector: {}` and `priorityClassName: ""` added as pass-through to CRD |
| `podDisruptionBudget` | New `policy/v1` PDB template with validation helper; `enabled`, `minAvailable`, `maxUnavailable`, `unhealthyPodEvictionPolicy` values |
| Schema | Descriptions for all fields; `minimum: 0` + `pattern: ^[0-9]+%$` on min/maxAvailable; `enum` on `unhealthyPodEvictionPolicy` |
| Tests | 14 pod-scheduling tests + 20 PDB tests (validation, rendering, schema enforcement) |
| No operator/CRD changes | PDB rendered by the chart; operator's rolling restart uses direct `pod.delete()` and is unaffected by PDB |