### PR TITLE
Fall back to base resource values for missing overrideLimits fields

### DIFF
--- a/charts/hivemq-platform/templates/NOTES.txt
+++ b/charts/hivemq-platform/templates/NOTES.txt
@@ -8,7 +8,7 @@ Documentation can be found here: https://docs.hivemq.com/hivemq-platform-operato
 `config.overrideInitContainers` value is deprecated and will be removed in future releases.
 Please, consider using `additionalInitContainers` value instead.
 {{- end }}
-{{- if hasKey .Values.nodes.resources "overrideLimits" }}
+{{- if .Values.nodes.resources.overrideLimits }}
 
 *** Warning ***
 `nodes.resources.overrideLimits` is not recommended for production use cases and may lead to unpredictable memory and cpu allocation for pods.

--- a/charts/hivemq-platform/templates/hivemq-custom-resource.yml
+++ b/charts/hivemq-platform/templates/hivemq-custom-resource.yml
@@ -212,11 +212,15 @@ spec:
                   containerPort: {{ printf "%d" (int64 $metricsPort) }}
                 {{- end }}
               resources:
-                {{- if hasKey .Values.nodes.resources "overrideLimits" }}
-                {{- with .Values.nodes.resources.overrideLimits }}
+                {{- if .Values.nodes.resources.overrideLimits }}
                 limits:
-                  {{- toYaml . | nindent 18 }}
-                {{- end }}
+                  cpu: {{ (.Values.nodes.resources.overrideLimits.cpu | default .Values.nodes.resources.cpu) | toString | trim | quote }}
+                  memory: {{ (.Values.nodes.resources.overrideLimits.memory | default .Values.nodes.resources.memory) | toString | trim | quote }}
+                  {{- $ephemeralStorageOverride := index .Values.nodes.resources.overrideLimits "ephemeral-storage" }}
+                  {{- $ephemeralStorage := .Values.nodes.resources.ephemeralStorage }}
+                  {{- with ($ephemeralStorageOverride | default $ephemeralStorage) }}
+                  ephemeral-storage: {{ . | toString | trim | quote }}
+                  {{- end }}
                 {{- else }}
                 limits:
                   cpu: {{ .Values.nodes.resources.cpu | toString | trim | quote }}

--- a/charts/hivemq-platform/tests/hivemq_platform_test.yaml
+++ b/charts/hivemq-platform/tests/hivemq_platform_test.yaml
@@ -571,6 +571,23 @@ tests:
           path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.ephemeral-storage
           value: "3"
 
+  - it: with override custom numeric resource limits as integer
+    set:
+      nodes.resources.overrideLimits:
+        cpu: 1
+        memory: 2
+        ephemeral-storage: 3
+    asserts:
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.cpu
+          value: "1"
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.memory
+          value: "2"
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.ephemeral-storage
+          value: "3"
+
   - it: with empty override resource limits
     set:
       nodes.resources.overrideLimits: {}
@@ -588,8 +605,14 @@ tests:
           value: 2048M
       - notExists:
           path: spec.statefulSet.spec.template.spec.containers[0].resources.requests.ephemeral-storage
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.cpu
+          value: "1000m"
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.memory
+          value: 2048M
       - notExists:
-          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.ephemeral-storage
 
   - it: with empty override resource limits and custom resource requests
     set:
@@ -612,8 +635,91 @@ tests:
       - equal:
           path: spec.statefulSet.spec.template.spec.containers[0].resources.requests.ephemeral-storage
           value: 1M
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.cpu
+          value: "1c"
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.memory
+          value: "1m"
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.ephemeral-storage
+          value: "1M"
+
+  - it: with partial override resource limits with only cpu
+    set:
+      nodes.resources.cpu: 1c
+      nodes.resources.memory: 1m
+      nodes.resources.ephemeralStorage: 1M
+      nodes.resources.overrideLimits:
+        cpu: 8c
+    asserts:
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.requests.cpu
+          value: 1c
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.requests.memory
+          value: 1m
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.requests.ephemeral-storage
+          value: 1M
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.cpu
+          value: "8c"
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.memory
+          value: "1m"
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.ephemeral-storage
+          value: "1M"
+
+  - it: with partial override resource limits with only memory
+    set:
+      nodes.resources.cpu: 1c
+      nodes.resources.memory: 1m
+      nodes.resources.overrideLimits:
+        memory: 8m
+    asserts:
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.requests.cpu
+          value: 1c
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.requests.memory
+          value: 1m
       - notExists:
-          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.requests.ephemeral-storage
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.cpu
+          value: "1c"
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.memory
+          value: "8m"
+      - notExists:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.ephemeral-storage
+
+  - it: with partial override resource limits with only ephemeral-storage
+    set:
+      nodes.resources.cpu: 1c
+      nodes.resources.memory: 1m
+      nodes.resources.overrideLimits:
+        ephemeral-storage: 8M
+    asserts:
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.requests.cpu
+          value: 1c
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.requests.memory
+          value: 1m
+      - notExists:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.requests.ephemeral-storage
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.cpu
+          value: "1c"
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.memory
+          value: "1m"
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].resources.limits.ephemeral-storage
+          value: "8M"
 
   - it: with default values, no volumes are defined
     asserts:

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/testcontainer/HelmChartContainer.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/testcontainer/HelmChartContainer.java
@@ -211,9 +211,9 @@ public class HelmChartContainer extends K3sContainer {
         final var regex = "*.%s*".formatted(currentChart.getDescription());
         final var platformCharts = executeHelmSearchCommand("hivemq/hivemq-platform",
                 Stream.of("--versions", "--regexp", regex, "--output", "yaml"));
-        final var platformChartsList = objectMapper.readValue(platformCharts.replaceAll("app_version", "appVersion"),
+        final var platformChartsList = objectMapper.readValue(platformCharts.replace("app_version", "appVersion"),
                 new TypeReference<List<Chart>>() {
-                });//
+                });
         return platformChartsList.stream()
                 .filter(chart -> chart.getVersion() != null)
                 .filter(chart -> !Objects.equals(chart.getVersion(), currentChart.getVersion()))
@@ -380,16 +380,12 @@ public class HelmChartContainer extends K3sContainer {
             final @NotNull Stream<String> additionalCommands,
             final boolean debugOnFailure) throws Exception {
         // helm --kubeconfig /etc/rancher/k3s/k3s.yaml <install|upgrade> test-operator /chart/hivemq-platform-operator --debug --wait=legacy --timeout 3m0s
-        final var helmCommandList = new ArrayList<>(List.of("helm",
-                "--kubeconfig",
-                "/etc/rancher/k3s/k3s.yaml",
-                helmCommand,
-                releaseName,
-                chartName != null ? chartName : "",
-                "--debug",
-                "--wait=legacy",
-                "--timeout",
-                "3m0s"));
+        final var helmCommandList =
+                new ArrayList<>(List.of("helm", "--kubeconfig", "/etc/rancher/k3s/k3s.yaml", helmCommand, releaseName));
+        if (chartName != null) {
+            helmCommandList.add(chartName);
+        }
+        helmCommandList.addAll(List.of("--debug", "--wait=legacy", "--timeout", "3m0s"));
         final var additionalCommandsList = additionalCommands.toList();
         helmCommandList.addAll(additionalCommandsList);
         if (chartName != null && withLocalCharts) {
@@ -600,7 +596,7 @@ public class HelmChartContainer extends K3sContainer {
             LOG.info("Received {} event for container {} in pod {} [{}]", reason, containerName, podName, podUid);
             try {
                 if (reason.equals("Created")) {
-                    logWatches.computeIfAbsent(podUid + "-" + podName + "-" + containerName, key -> {
+                    logWatches.computeIfAbsent(podUid + "-" + podName + "-" + containerName, _ -> {
                         // create log watcher for container
                         final var logWatch = client.pods()
                                 .inNamespace(namespace)


### PR DESCRIPTION
## Summary

- When `nodes.resources.overrideLimits` is set with only a subset of fields (e.g., only `cpu`), the missing fields now fall back to base `nodes.resources` values instead of being omitted
- `overrideLimits: {}` now falls back to base resource values (limits = requests) instead of producing no limits at all
- Added `toString` to `memory` and `ephemeral-storage` pipelines to handle integer values safely

Resolves [INT-204](https://linear.app/hivemq/issue/INT-204) / [HIVEMQ-6095](https://hivemq.atlassian.net/browse/HIVEMQ-6095)