### PR TITLE
Disable setup-gradle Enhanced Caching and delegate to setup-java

### DIFF
--- a/.github/workflows/edge-release-pr.yml
+++ b/.github/workflows/edge-release-pr.yml
@@ -44,11 +44,14 @@ jobs:
       - name: ☕ Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
+          cache: gradle
           distribution: temurin
           java-version: 21
 
       - name: 🔧 Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
 
       - name: 🔄 Update Edge chart version
         env:

--- a/.github/workflows/platform-integration-tests.yml
+++ b/.github/workflows/platform-integration-tests.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
 
       - name: Warmup Gradle cache
         if: steps.setup-java.outputs.cache-hit == 'false'
@@ -106,6 +108,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
 
       - name: Compile integration tests
         working-directory: helm-charts

--- a/.github/workflows/platform-smoke-test.yml
+++ b/.github/workflows/platform-smoke-test.yml
@@ -38,16 +38,14 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
+          cache: gradle
           distribution: temurin
           java-version: 21
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
         with:
-          gradle-home-cache-includes: |
-            caches
-            notifications
-            jdks
+          cache-disabled: true
 
       - name: Create K8s Kind Cluster
         id: kind

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,16 +28,14 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
+          cache: gradle
           distribution: temurin
           java-version: 21
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
         with:
-          gradle-home-cache-includes: |
-            caches
-            notifications
-            jdks
+          cache-disabled: true
 
       - name: Add dependency chart repos
         run: |


### PR DESCRIPTION
## Summary

- Disable `setup-gradle` proprietary Enhanced Caching (`cache-disabled: true`) across all workflows
- Delegate caching to `setup-java` with `cache: gradle` (MIT-licensed, writes on all branches)
- Remove `gradle-home-cache-includes` blocks (Enhanced-only, no longer needed)

Tracked by [INT-247](https://linear.app/hivemq/issue/INT-247)