### PR TITLE
Sign Harbor charts by tag and let cosign resolve the digest via the OCI registry endpoint

### DIFF
--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -6,6 +6,9 @@ on:
       - next-operator-release
     paths:
       - charts/hivemq-platform-operator/**
+concurrency:
+  group: publish-harbor-${{ github.ref }}
+  cancel-in-progress: true
 env:
   operator_chart_name: helm-charts/hivemq-platform-operator
 jobs:

--- a/scripts/sign-harbor-chart.sh
+++ b/scripts/sign-harbor-chart.sh
@@ -28,18 +28,8 @@ log_error() {
 
 # validate required binaries
 validate_binaries() {
-    local required_binaries=("cosign" "jq" "curl")
-    local missing_binaries=()
-
-    for binary in "${required_binaries[@]}"; do
-        if ! command -v "$binary" >/dev/null 2>&1; then
-            missing_binaries+=("$binary")
-        fi
-    done
-
-    if [[ ${#missing_binaries[@]} -gt 0 ]]; then
-        log_error "Missing required binaries:"
-        printf '  - %s\n' "${missing_binaries[@]}" >&2
+    if ! command -v cosign >/dev/null 2>&1; then
+        log_error "Missing required binary: cosign"
         exit 1
     fi
 }
@@ -47,75 +37,18 @@ validate_binaries() {
 # validate required environment variables
 validate_environment() {
     local missing_vars=()
-    
+
     for var in "${REQUIRED_ENV_VARS[@]}"; do
         if [[ -z "${!var:-}" ]]; then
             missing_vars+=("$var")
         fi
     done
-    
+
     if [[ ${#missing_vars[@]} -gt 0 ]]; then
         log_error "Missing required environment variables:"
         printf '  - %s\n' "${missing_vars[@]}" >&2
         exit 1
     fi
-}
-
-# Harbor API functions
-get_harbor_artifact() {
-    local chart="$1"
-    local version="$2"
-
-    local encoded_creds
-    if ! encoded_creds=$(echo -n "${HARBOR_API_USER}:${HARBOR_API_TOKEN}" | base64 | tr -d '\n'); then
-        log_error "Failed to base64 encode Harbor API credentials"
-        exit 1
-    fi
-    local auth_header="Basic ${encoded_creds}"
-
-    # URL-encode the repository path
-    local encoded_repository=$(echo -n "${chart}" | jq -sRr @uri)
-    local url="https://${HARBOR_REGISTRY_URL}/api/v2.0/projects/${HARBOR_PROJECT}/repositories/${encoded_repository}/artifacts/${version}"
-
-    local response
-    if ! response=$(curl -sSL \
-        --fail-with-body \
-        --max-time 30 \
-        --header 'Accept: application/json' \
-        --header "Authorization: ${auth_header}" \
-        "${url}"); then
-        log_error "Failed to fetch artifact information from Harbor API"
-        log_error "URL: ${url}"
-        exit 1
-    fi
-    
-    if ! echo "$response" | jq empty 2>/dev/null; then
-        log_error "Invalid JSON response from Harbor API"
-        log_error "Response: $response"
-        exit 1
-    fi
-    
-    echo "$response"
-}
-
-# extract digest from chart
-extract_digest() {
-    local artifact="$1"
-    
-    local digest
-    digest=$(echo "$artifact" | jq -r '.digest // empty')
-    
-    if [[ -z "$digest" || "$digest" == "null" ]]; then
-        log_error "Could not extract digest from artifact"
-        exit 1
-    fi
-    
-    if [[ ! "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
-        log_error "Invalid digest format: $digest"
-        exit 1
-    fi
-    
-    echo "$digest"
 }
 
 sign_chart() {
@@ -142,7 +75,7 @@ main() {
         log_error "Usage: $SCRIPT_NAME <CHART_NAME> <CHART_VERSION>"
         exit 1
     fi
-    
+
     validate_binaries
     validate_environment
 
@@ -150,18 +83,8 @@ main() {
     log_info "  Project: ${HARBOR_PROJECT}"
     log_info "  Chart: $chart_name"
     log_info "  Version: $chart_version"
-    
-    # get artifact information
-    local artifact
-    artifact=$(get_harbor_artifact "$chart_name" "$chart_version")
-    
-    # extract digest
-    local digest
-    digest=$(extract_digest "$artifact")
-    log_info "Chart digest: $digest"
-    
-    # sign the chart
-    local chart_ref="${HARBOR_REGISTRY_URL}/${HARBOR_PROJECT}/${chart_name}@${digest}"
+
+    local chart_ref="${HARBOR_REGISTRY_URL}/${HARBOR_PROJECT}/${chart_name}:${chart_version}"
     sign_chart "$chart_ref"
 }
 


### PR DESCRIPTION
## Summary

Backport from `next-operator-release` (commit 38524a45).

The new repo-scoped Harbor robot account does not have `read-artifact` permission on Harbor's admin API (`/api/v2.0/...`), which the previous version of `sign-harbor-chart.sh` used to fetch the chart digest before signing. This caused signing to fail with HTTP 403.

This change drops the digest pre-fetch and lets `cosign sign` resolve the digest via the standard OCI registry endpoint (`/v2/.../manifests/...`), which only requires the `pull` permission already implied by the robot's push access.

The `concurrency: cancel-in-progress` rule on the workflow keeps the tag-vs-digest TOCTOU window closed in practice.