### PR TITLE
Dispatch Jenkins build from dispatcher GitHub workflow

### DIFF
--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -185,3 +185,50 @@ jobs:
         run: |
           echo "There are test failures."
           exit 1
+
+  jenkins-composite-dispatch:
+    name: Jenkins composite dispatch
+    runs-on: ubuntu-latest
+    needs:
+      - edge-changes
+      - swarm-changes
+      - platform-changes
+      - platform-operator-changes
+    if: >
+      needs.edge-changes.result == 'success' &&
+      needs.swarm-changes.result == 'success' &&
+      needs.platform-changes.result == 'success' &&
+      needs.platform-operator-changes.result == 'success'
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - name: Check whether Jenkins build is needed
+        id: jenkins-build
+        env:
+          PLATFORM: ${{ needs.platform-changes.outputs.should-run }}
+          OPERATOR: ${{ needs.platform-operator-changes.outputs.should-run }}
+          SWARM: ${{ needs.swarm-changes.outputs.should-run }}
+        run: |
+          if [[ "$PLATFORM" == "true" || "$OPERATOR" == "true" || "$SWARM" == "true" ]]; then
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger Jenkins composite build
+        if: steps.jenkins-build.outputs.needed == 'true'
+        uses: distributhor/workflow-webhook@2381f0e9c7b6bf061fb1405bd0804b8706116369 # v3
+        with:
+          webhook_url: ${{ secrets.JENKINS_WEBHOOK_PAYLOAD_URL }}
+          webhook_secret: ${{ secrets.JENKINS_WEBHOOK_SECRET }}
+
+      - name: Skip Jenkins composite build
+        if: steps.jenkins-build.outputs.needed == 'false'
+        uses: guibranco/github-status-action-v2@e8a8fa568b768f554cfe1d34e27e917aed4c6127 # v1.2.1
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: "continuous-integration/jenkins/branch"
+          state: "success"
+          sha: ${{ github.event.pull_request.head.sha || github.sha }}
+          target_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -216,12 +216,80 @@ jobs:
             echo "needed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Trigger Jenkins composite build
+      - name: Build Jenkins webhook payload
+        id: payload
         if: steps.jenkins-build.outputs.needed == 'true'
-        uses: distributhor/workflow-webhook@2381f0e9c7b6bf061fb1405bd0804b8706116369 # v3
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          BEFORE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '0000000000000000000000000000000000000000' }}
+          REPOSITORY_JSON: ${{ toJSON(github.event.repository) }}
+          ORGANIZATION_JSON: ${{ toJSON(github.event.organization) }}
+          JENKINS_WEBHOOK_SECRET: ${{ secrets.JENKINS_WEBHOOK_SECRET }}
+        run: |
+          set -euo pipefail
+          PAYLOAD=$(jq -nc \
+            --arg ref "refs/heads/$BRANCH" \
+            --arg before "$BEFORE_SHA" \
+            --arg after "$HEAD_SHA" \
+            --argjson repository "$REPOSITORY_JSON" \
+            --argjson organization "$ORGANIZATION_JSON" \
+            '{
+              ref: $ref,
+              before: $before,
+              after: $after,
+              repository: $repository,
+              pusher: { name: "github-actions[bot]", email: "github-actions[bot]@users.noreply.github.com" },
+              sender: { login: "github-actions[bot]", id: 41898282, type: "Bot" },
+              organization: $organization,
+              forced: false,
+              created: false,
+              deleted: false,
+              base_ref: null,
+              compare: ($repository.html_url + "/compare/" + ($before[0:7]) + "..." + ($after[0:7])),
+              commits: [],
+              head_commit: {
+                id: $after,
+                tree_id: $after,
+                distinct: true,
+                message: "GHA-dispatched build",
+                timestamp: (now | todateiso8601),
+                url: ($repository.html_url + "/commit/" + $after),
+                author: { name: "github-actions[bot]", email: "github-actions[bot]@users.noreply.github.com", username: "github-actions[bot]" },
+                committer: { name: "github-actions[bot]", email: "github-actions[bot]@users.noreply.github.com", username: "github-actions[bot]" },
+                added: [],
+                removed: [],
+                modified: []
+              }
+            }')
+          SIGNATURE_256="sha256=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$JENKINS_WEBHOOK_SECRET" -hex | awk '{print $NF}')"
+          echo "::add-mask::$SIGNATURE_256"
+          DELIVERY=$(cat /proc/sys/kernel/random/uuid)
+          echo "::add-mask::$DELIVERY"
+          {
+            echo "body<<__END__"
+            echo "$PAYLOAD"
+            echo "__END__"
+            echo "signature=$SIGNATURE_256"
+            echo "delivery=$DELIVERY"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Jenkins composite build
+        id: trigger
+        if: steps.jenkins-build.outputs.needed == 'true'
+        uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2
         with:
-          webhook_url: ${{ secrets.JENKINS_WEBHOOK_PAYLOAD_URL }}
-          webhook_secret: ${{ secrets.JENKINS_WEBHOOK_SECRET }}
+          url: ${{ secrets.JENKINS_WEBHOOK_PAYLOAD_URL }}
+          method: 'POST'
+          contentType: 'application/json'
+          data: ${{ steps.payload.outputs.body }}
+          customHeaders: |
+            {
+              "X-GitHub-Event": "push",
+              "X-Hub-Signature-256": "${{ steps.payload.outputs.signature }}",
+              "X-GitHub-Delivery": "${{ steps.payload.outputs.delivery }}",
+              "User-Agent": "GitHub-Hookshot/gha-dispatcher"
+            }
 
       - name: Skip Jenkins composite build
         if: steps.jenkins-build.outputs.needed == 'false'

--- a/CompositeJenkinsfile
+++ b/CompositeJenkinsfile
@@ -14,6 +14,9 @@ pipeline {
                     if (isEdgeOnlyChange()) {
                         currentBuild.description = 'Skipped: Edge-only changes'
                         echo 'Edge-only changes detected; skipping composite build.'
+                        githubNotify context: 'continuous-integration/jenkins/branch',
+                                     status: 'SUCCESS',
+                                     description: 'Skipped: Edge-only PR, no platform composite needed'
                         return
                     }
 

--- a/CompositeJenkinsfile
+++ b/CompositeJenkinsfile
@@ -11,6 +11,12 @@ pipeline {
         stage('Trigger build') {
             steps {
                 script {
+                    if (isEdgeOnlyChange()) {
+                        currentBuild.description = 'Skipped: Edge-only changes'
+                        echo 'Edge-only changes detected; skipping composite build.'
+                        return
+                    }
+
                     def multiBranchJobPath = '../../hivemq-composite'
                     def branchJobName = BRANCH_NAME.replace('/', '%2F')
                     try {
@@ -32,4 +38,33 @@ pipeline {
             }
         }
     }
+}
+
+boolean isEdgeOnlyChange() {
+    if (!env.CHANGE_TARGET) {
+        return false
+    }
+    def edgeOnly = false
+    dir('.scope-check') {
+        try {
+            checkout scm
+            sh "git fetch origin ${env.CHANGE_TARGET} --depth=50"
+            def changedFiles = sh(
+                script: "git diff --name-only origin/${env.CHANGE_TARGET}...HEAD",
+                returnStdout: true
+            ).trim().split('\n').findAll { it }
+            echo "Changed files (${changedFiles.size()}):\n${changedFiles.join('\n')}"
+            if (changedFiles) {
+                edgeOnly = changedFiles.every { f ->
+                    f.startsWith('charts/hivemq-edge/') ||
+                    f.startsWith('manifests/hivemq-edge/') ||
+                    f.startsWith('tests-hivemq-edge/') ||
+                    f.startsWith('.github/workflows/edge-')
+                }
+            }
+        } finally {
+            deleteDir()
+        }
+    }
+    return edgeOnly
 }


### PR DESCRIPTION
## Summary

- `dispatcher.yml` now triggers the Jenkins composite: Edge-only PRs publish `continuous-integration/jenkins/branch = success` directly from GHA; platform/operator/swarm PRs fire the existing Jenkins `/github-webhook/`.
- Merge in lockstep with disabling the helm-charts → Jenkins GitHub webhook. Follow-up needed: `push:` trigger for `master` / `next-operator-release`.

Closes [INT-185](https://linear.app/hivemq/issue/INT-185).