### PR TITLE
test(INT-185): Edge-only validation, do not merge

### DIFF
--- a/CompositeJenkinsfile
+++ b/CompositeJenkinsfile
@@ -14,6 +14,9 @@ pipeline {
                     if (isEdgeOnlyChange()) {
                         currentBuild.description = 'Skipped: Edge-only changes'
                         echo 'Edge-only changes detected; skipping composite build.'
+                        githubNotify context: 'continuous-integration/jenkins/branch',
+                                     status: 'SUCCESS',
+                                     description: 'Skipped: Edge-only PR, no platform composite needed'
                         return
                     }
 

--- a/CompositeJenkinsfile
+++ b/CompositeJenkinsfile
@@ -11,6 +11,12 @@ pipeline {
         stage('Trigger build') {
             steps {
                 script {
+                    if (isEdgeOnlyChange()) {
+                        currentBuild.description = 'Skipped: Edge-only changes'
+                        echo 'Edge-only changes detected; skipping composite build.'
+                        return
+                    }
+
                     def multiBranchJobPath = '../../hivemq-composite'
                     def branchJobName = BRANCH_NAME.replace('/', '%2F')
                     try {
@@ -32,4 +38,33 @@ pipeline {
             }
         }
     }
+}
+
+boolean isEdgeOnlyChange() {
+    if (!env.CHANGE_TARGET) {
+        return false
+    }
+    def edgeOnly = false
+    dir('.scope-check') {
+        try {
+            checkout scm
+            sh "git fetch origin ${env.CHANGE_TARGET} --depth=50"
+            def changedFiles = sh(
+                script: "git diff --name-only origin/${env.CHANGE_TARGET}...HEAD",
+                returnStdout: true
+            ).trim().split('\n').findAll { it }
+            echo "Changed files (${changedFiles.size()}):\n${changedFiles.join('\n')}"
+            if (changedFiles) {
+                edgeOnly = changedFiles.every { f ->
+                    f.startsWith('charts/hivemq-edge/') ||
+                    f.startsWith('manifests/hivemq-edge/') ||
+                    f.startsWith('tests-hivemq-edge/') ||
+                    f.startsWith('.github/workflows/edge-')
+                }
+            }
+        } finally {
+            deleteDir()
+        }
+    }
+    return edgeOnly
 }

--- a/charts/hivemq-edge/DEVELOPMENT.md
+++ b/charts/hivemq-edge/DEVELOPMENT.md
@@ -222,3 +222,6 @@ In order to run them, just simply execute the following Gradle command:
 ```bash
 ./gradlew integrationTest
 ```
+
+<!-- INT-185 Edge-only validation marker -->
+

--- a/charts/hivemq-edge/DEVELOPMENT.md
+++ b/charts/hivemq-edge/DEVELOPMENT.md
@@ -224,4 +224,5 @@ In order to run them, just simply execute the following Gradle command:
 ```
 
 <!-- INT-185 Edge-only validation marker -->
+<!-- INT-185 retest: Jenkinsfile now includes githubNotify on skip path -->
 


### PR DESCRIPTION
## Summary

Disposable draft PR to validate the Edge-only skip path in #899 before merging that PR.

- Targets `feature/int-185-helm-charts-skip-platform-jenkins-build-for-edge-only` (not `master`) so the diff is purely the Edge file and the new `CompositeJenkinsfile` from #899 is in effect.
- Expected: Jenkins trigger build logs `Edge-only changes detected; skipping composite build.`, exits success, and `continuous-integration/jenkins/branch` turns green automatically.
- If the check stays pending, the helm-charts trigger job has `Skip build status notifications` enabled and we'll need to publish the status explicitly via `githubNotify` in #899.

Close this PR without merging once the observation is recorded.