### PR TITLE
test(INT-185): Edge-only skip-path validation, do not merge

### DIFF
--- a/charts/hivemq-edge/DEVELOPMENT.md
+++ b/charts/hivemq-edge/DEVELOPMENT.md
@@ -222,3 +222,6 @@ In order to run them, just simply execute the following Gradle command:
 ```bash
 ./gradlew integrationTest
 ```
+
+<!-- INT-185 skip-path validation marker -->
+


### PR DESCRIPTION
## Summary

Disposable draft PR to exercise the dispatcher's **skip path** before merging #899.

Targets `feature/int-185-helm-charts-skip-platform-jenkins-build-for-edge-only` so the diff is purely a single Edge file. The dispatcher should classify `needed=false`, run the `Skip Jenkins composite build` step, and `guibranco/github-status-action-v2` should publish `continuous-integration/jenkins/branch = success` directly on this PR's head SHA — pointing back at the GHA run, not at Jenkins.

Close without merging once observed.