### PR TITLE
test(INT-185): Platform-trigger validation, do not merge

### DIFF
--- a/charts/hivemq-platform/DEVELOPMENT.md
+++ b/charts/hivemq-platform/DEVELOPMENT.md
@@ -41,3 +41,6 @@ In order to run them, just simply execute the following Gradle command:
 ```bash
 ./gradlew integrationTest
 ```
+
+<!-- INT-185 platform-trigger validation marker -->
+


### PR DESCRIPTION
## Summary

Disposable draft PR exercising the dispatcher's **trigger path** against the cleaned-up feature branch.

Targets `feature/int-185-helm-charts-skip-platform-jenkins-build-for-edge-only` so the diff is purely `charts/hivemq-platform/DEVELOPMENT.md`. Expected flow:

1. `Check whether Jenkins build is needed` → `needed=true`
2. `Build Jenkins webhook payload` constructs a GitHub-shaped push payload (mirroring real delivery schema with full repo metadata, owner, organization, head_commit, etc.), signs HMAC-SHA256
3. `Trigger Jenkins composite build` POSTs via `joelwmale/webhook-action@v2.4.1` with proper headers (`X-GitHub-Event: push`, `X-Hub-Signature-256`, `X-GitHub-Delivery`, `User-Agent: GitHub-Hookshot/gha-dispatcher`)
4. Jenkins multibranch picks it up → trigger build → composite build → `continuous-integration/jenkins/branch` status posted on this PR head SHA

Close without merging once observed.