### PR TITLE
test(INT-185): Edge-skip validation, do not merge

### DIFF
--- a/charts/hivemq-edge/DEVELOPMENT.md
+++ b/charts/hivemq-edge/DEVELOPMENT.md
@@ -222,3 +222,6 @@ In order to run them, just simply execute the following Gradle command:
 ```bash
 ./gradlew integrationTest
 ```
+
+<!-- INT-185 edge-skip validation marker -->
+


### PR DESCRIPTION
## Summary

Disposable draft PR exercising the dispatcher's **skip path** against the cleaned-up feature branch.

Targets `feature/int-185-helm-charts-skip-platform-jenkins-build-for-edge-only` so the diff is purely `charts/hivemq-edge/DEVELOPMENT.md`. Expected flow:

1. `Check whether Jenkins build is needed` → `needed=false` (only `edge-changes` matched; platform/operator/swarm empty).
2. `Build Jenkins webhook payload` — skipped.
3. `Trigger Jenkins composite build` — skipped (no webhook fired, no Jenkins build triggered).
4. `Print Jenkins webhook status` — skipped.
5. `Skip Jenkins composite build` — runs; `guibranco/github-status-action-v2` publishes `continuous-integration/jenkins/branch = success` on this PR head SHA.

Verification: no `hivemq-composite/test%2Fint-185-edge-skip-validation/*` entry should appear on Jenkins, and `gh api repos/hivemq/helm-charts/commits/83fd068c/statuses` should show the GHA-posted status with `target_url` pointing to the GHA run (not Jenkins).

Close without merging once observed.