### PR TITLE
test(INT-185): Platform+Edge mixed-change trigger validation, do not merge

### DIFF
--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -216,12 +216,115 @@ jobs:
             echo "needed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Trigger Jenkins composite build
+      - name: Build Jenkins webhook payload
+        id: payload
         if: steps.jenkins-build.outputs.needed == 'true'
-        uses: distributhor/workflow-webhook@2381f0e9c7b6bf061fb1405bd0804b8706116369 # v3
+        env:
+          REPO_FULL_NAME: ${{ github.repository }}
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          BEFORE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '0000000000000000000000000000000000000000' }}
+          JENKINS_WEBHOOK_SECRET: ${{ secrets.JENKINS_WEBHOOK_SECRET }}
+        run: |
+          set -euo pipefail
+          PAYLOAD=$(jq -nc \
+            --arg ref "refs/heads/$BRANCH" \
+            --arg before "$BEFORE_SHA" \
+            --arg after "$HEAD_SHA" \
+            --arg full_name "$REPO_FULL_NAME" \
+            '{
+              ref: $ref,
+              before: $before,
+              after: $after,
+              repository: {
+                id: 273000293,
+                node_id: "MDEwOlJlcG9zaXRvcnkyNzMwMDAyOTM=",
+                name: "helm-charts",
+                full_name: $full_name,
+                private: false,
+                owner: {
+                  name: "hivemq",
+                  login: "hivemq",
+                  id: 4578332,
+                  node_id: "MDEyOk9yZ2FuaXphdGlvbjQ1NzgzMzI=",
+                  type: "Organization",
+                  html_url: "https://github.com/hivemq",
+                  url: "https://api.github.com/users/hivemq"
+                },
+                html_url: ("https://github.com/" + $full_name),
+                url: ("https://api.github.com/repos/" + $full_name),
+                clone_url: ("https://github.com/" + $full_name + ".git"),
+                git_url: ("git://github.com/" + $full_name + ".git"),
+                ssh_url: ("git@github.com:" + $full_name + ".git"),
+                svn_url: ("https://github.com/" + $full_name),
+                default_branch: "master",
+                master_branch: "master",
+                organization: "hivemq"
+              },
+              pusher: { name: "github-actions[bot]", email: "github-actions[bot]@users.noreply.github.com" },
+              sender: { login: "github-actions[bot]", id: 41898282, type: "Bot" },
+              organization: { login: "hivemq", id: 4578332 },
+              forced: false,
+              created: false,
+              deleted: false,
+              base_ref: null,
+              compare: ("https://github.com/" + $full_name + "/compare/" + ($before[0:7]) + "..." + ($after[0:7])),
+              commits: [],
+              head_commit: {
+                id: $after,
+                tree_id: $after,
+                distinct: true,
+                message: "GHA-dispatched build",
+                timestamp: (now | todateiso8601),
+                url: ("https://github.com/" + $full_name + "/commit/" + $after),
+                author: { name: "github-actions[bot]", email: "github-actions[bot]@users.noreply.github.com", username: "github-actions[bot]" },
+                committer: { name: "github-actions[bot]", email: "github-actions[bot]@users.noreply.github.com", username: "github-actions[bot]" },
+                added: [],
+                removed: [],
+                modified: []
+              }
+            }')
+          SIGNATURE_256="sha256=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$JENKINS_WEBHOOK_SECRET" -hex | awk '{print $NF}')"
+          DELIVERY=$(cat /proc/sys/kernel/random/uuid)
+          echo "Delivery ID: $DELIVERY"
+          echo "Payload:"; echo "$PAYLOAD" | jq .
+          {
+            echo "body<<__END__"
+            echo "$PAYLOAD"
+            echo "__END__"
+            echo "signature=$SIGNATURE_256"
+            echo "delivery=$DELIVERY"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Jenkins composite build
+        id: trigger
+        if: steps.jenkins-build.outputs.needed == 'true'
+        uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
         with:
-          webhook_url: ${{ secrets.JENKINS_WEBHOOK_PAYLOAD_URL }}
-          webhook_secret: ${{ secrets.JENKINS_WEBHOOK_SECRET }}
+          url: ${{ secrets.JENKINS_WEBHOOK_PAYLOAD_URL }}
+          method: 'POST'
+          contentType: 'application/json'
+          data: ${{ steps.payload.outputs.body }}
+          customHeaders: |
+            {
+              "X-GitHub-Event": "push",
+              "X-Hub-Signature-256": "${{ steps.payload.outputs.signature }}",
+              "X-GitHub-Delivery": "${{ steps.payload.outputs.delivery }}",
+              "User-Agent": "GitHub-Hookshot/gha-dispatcher"
+            }
+
+      - name: Print Jenkins webhook response
+        if: steps.jenkins-build.outputs.needed == 'true'
+        env:
+          STATUS: ${{ steps.trigger.outputs.status }}
+          HEADERS: ${{ steps.trigger.outputs.headers }}
+          RESPONSE: ${{ steps.trigger.outputs.response }}
+        run: |
+          echo "HTTP status: $STATUS"
+          echo "Response headers:"
+          echo "$HEADERS"
+          echo "Response body:"
+          echo "$RESPONSE"
 
       - name: Skip Jenkins composite build
         if: steps.jenkins-build.outputs.needed == 'false'

--- a/charts/hivemq-edge/DEVELOPMENT.md
+++ b/charts/hivemq-edge/DEVELOPMENT.md
@@ -222,3 +222,6 @@ In order to run them, just simply execute the following Gradle command:
 ```bash
 ./gradlew integrationTest
 ```
+
+<!-- INT-185 platform+edge mixed-change trigger validation marker -->
+

--- a/charts/hivemq-platform/DEVELOPMENT.md
+++ b/charts/hivemq-platform/DEVELOPMENT.md
@@ -41,3 +41,6 @@ In order to run them, just simply execute the following Gradle command:
 ```bash
 ./gradlew integrationTest
 ```
+
+<!-- INT-185 platform+edge mixed-change trigger validation marker -->
+


### PR DESCRIPTION
## Summary

Disposable draft PR exercising the dispatcher's **trigger path** with a mixed Edge+Platform diff.

Targets `feature/int-185-helm-charts-skip-platform-jenkins-build-for-edge-only` so the diff is purely two doc files:

- `charts/hivemq-platform/DEVELOPMENT.md`
- `charts/hivemq-edge/DEVELOPMENT.md`

Expected flow:

1. `Check whether Jenkins build is needed` → `needed=true` (`platform-changes` *and* `edge-changes` both match; the presence of platform alone forces the trigger path).
2. `Build Jenkins webhook payload` — runs, constructs the GitHub-shaped push payload.
3. `Trigger Jenkins composite build` — POSTs via `joelwmale/webhook-action`.
4. `Skip Jenkins composite build` — **skipped** (`if: needed == 'false'`).

Verification:

- Jenkins UI shows a new `hivemq-triggers/helm-charts/job/test%252Fint-185-platform-edge-trigger-validation/<N>` build entry.
- `gh api repos/hivemq/helm-charts/commits/dca1670d/statuses` shows a `continuous-integration/jenkins/branch` status from `hivemq-composite/...` once the downstream composite finishes.

Close without merging once observed.