### PR TITLE
tmp(INT-185): Skip-path verification, do not merge

### DIFF
--- a/charts/hivemq-edge/DEVELOPMENT.md
+++ b/charts/hivemq-edge/DEVELOPMENT.md
@@ -222,3 +222,6 @@ In order to run them, just simply execute the following Gradle command:
 ```bash
 ./gradlew integrationTest
 ```
+
+<!-- INT-185 fjogeleit skip-path verification -->
+


### PR DESCRIPTION
## Summary

Disposable draft PR verifying the dispatcher's **skip path** with the cleaned-up feature branch (no `Print Jenkins webhook response` step, no webhook fired).

Diff: a one-line marker in `charts/hivemq-edge/DEVELOPMENT.md`. Expected:

- `Check whether Jenkins build is needed` → `needed=false`
- `Build Jenkins webhook payload` / `Trigger Jenkins composite build` → skipped
- `Skip Jenkins composite build` → publishes `continuous-integration/jenkins/branch = success` directly

No Jenkins entry should appear; the status on this PR head SHA should be GHA-posted (target_url → GHA run, not Jenkins).

Close without merging once observed.