### PR TITLE
verify(INT-185): Skip-path post-hardening, do not merge

### DIFF
--- a/charts/hivemq-edge/DEVELOPMENT.md
+++ b/charts/hivemq-edge/DEVELOPMENT.md
@@ -222,3 +222,6 @@ In order to run them, just simply execute the following Gradle command:
 ```bash
 ./gradlew integrationTest
 ```
+
+<!-- INT-185 skip-path security verification -->
+


### PR DESCRIPTION
## Summary

Disposable draft PR verifying the dispatcher's **skip path** after the security-hardening amend (`::add-mask::` on signature + delivery UUID, `Payload:` echo removed).

Diff: one-line marker in `charts/hivemq-edge/DEVELOPMENT.md`. Expected:

- `Check whether Jenkins build is needed` → `needed=false`
- `Build Jenkins webhook payload`, `Trigger Jenkins composite build` → skipped
- `Skip Jenkins composite build` → publishes `continuous-integration/jenkins/branch = success` via `guibranco/github-status-action-v2`

No Jenkins activity on this branch. Close + delete after observing.