### PR TITLE
verify(INT-185): Trigger-path post-hardening, do not merge

### DIFF
--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -216,12 +216,103 @@ jobs:
             echo "needed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Trigger Jenkins composite build
+      - name: Build Jenkins webhook payload
+        id: payload
         if: steps.jenkins-build.outputs.needed == 'true'
-        uses: distributhor/workflow-webhook@2381f0e9c7b6bf061fb1405bd0804b8706116369 # v3
+        env:
+          REPO_FULL_NAME: ${{ github.repository }}
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          BEFORE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '0000000000000000000000000000000000000000' }}
+          JENKINS_WEBHOOK_SECRET: ${{ secrets.JENKINS_WEBHOOK_SECRET }}
+        run: |
+          set -euo pipefail
+          PAYLOAD=$(jq -nc \
+            --arg ref "refs/heads/$BRANCH" \
+            --arg before "$BEFORE_SHA" \
+            --arg after "$HEAD_SHA" \
+            --arg full_name "$REPO_FULL_NAME" \
+            '{
+              ref: $ref,
+              before: $before,
+              after: $after,
+              repository: {
+                id: 273000293,
+                node_id: "MDEwOlJlcG9zaXRvcnkyNzMwMDAyOTM=",
+                name: "helm-charts",
+                full_name: $full_name,
+                private: false,
+                owner: {
+                  name: "hivemq",
+                  login: "hivemq",
+                  id: 4578332,
+                  node_id: "MDEyOk9yZ2FuaXphdGlvbjQ1NzgzMzI=",
+                  type: "Organization",
+                  html_url: "https://github.com/hivemq",
+                  url: "https://api.github.com/users/hivemq"
+                },
+                html_url: ("https://github.com/" + $full_name),
+                url: ("https://api.github.com/repos/" + $full_name),
+                clone_url: ("https://github.com/" + $full_name + ".git"),
+                git_url: ("git://github.com/" + $full_name + ".git"),
+                ssh_url: ("git@github.com:" + $full_name + ".git"),
+                svn_url: ("https://github.com/" + $full_name),
+                default_branch: "master",
+                master_branch: "master",
+                organization: "hivemq"
+              },
+              pusher: { name: "github-actions[bot]", email: "github-actions[bot]@users.noreply.github.com" },
+              sender: { login: "github-actions[bot]", id: 41898282, type: "Bot" },
+              organization: { login: "hivemq", id: 4578332 },
+              forced: false,
+              created: false,
+              deleted: false,
+              base_ref: null,
+              compare: ("https://github.com/" + $full_name + "/compare/" + ($before[0:7]) + "..." + ($after[0:7])),
+              commits: [],
+              head_commit: {
+                id: $after,
+                tree_id: $after,
+                distinct: true,
+                message: "GHA-dispatched build",
+                timestamp: (now | todateiso8601),
+                url: ("https://github.com/" + $full_name + "/commit/" + $after),
+                author: { name: "github-actions[bot]", email: "github-actions[bot]@users.noreply.github.com", username: "github-actions[bot]" },
+                committer: { name: "github-actions[bot]", email: "github-actions[bot]@users.noreply.github.com", username: "github-actions[bot]" },
+                added: [],
+                removed: [],
+                modified: []
+              }
+            }')
+          SIGNATURE_256="sha256=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$JENKINS_WEBHOOK_SECRET" -hex | awk '{print $NF}')"
+          echo "::add-mask::$SIGNATURE_256"
+          DELIVERY=$(cat /proc/sys/kernel/random/uuid)
+          echo "::add-mask::$DELIVERY"
+          echo "Delivery ID: $DELIVERY"
+          {
+            echo "body<<__END__"
+            echo "$PAYLOAD"
+            echo "__END__"
+            echo "signature=$SIGNATURE_256"
+            echo "delivery=$DELIVERY"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Jenkins composite build
+        id: trigger
+        if: steps.jenkins-build.outputs.needed == 'true'
+        uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
         with:
-          webhook_url: ${{ secrets.JENKINS_WEBHOOK_PAYLOAD_URL }}
-          webhook_secret: ${{ secrets.JENKINS_WEBHOOK_SECRET }}
+          url: ${{ secrets.JENKINS_WEBHOOK_PAYLOAD_URL }}
+          method: 'POST'
+          contentType: 'application/json'
+          data: ${{ steps.payload.outputs.body }}
+          customHeaders: |
+            {
+              "X-GitHub-Event": "push",
+              "X-Hub-Signature-256": "${{ steps.payload.outputs.signature }}",
+              "X-GitHub-Delivery": "${{ steps.payload.outputs.delivery }}",
+              "User-Agent": "GitHub-Hookshot/gha-dispatcher"
+            }
 
       - name: Skip Jenkins composite build
         if: steps.jenkins-build.outputs.needed == 'false'

--- a/charts/hivemq-edge/DEVELOPMENT.md
+++ b/charts/hivemq-edge/DEVELOPMENT.md
@@ -222,3 +222,6 @@ In order to run them, just simply execute the following Gradle command:
 ```bash
 ./gradlew integrationTest
 ```
+
+<!-- INT-185 trigger-path security verification (edge mixed) -->
+

--- a/charts/hivemq-platform/DEVELOPMENT.md
+++ b/charts/hivemq-platform/DEVELOPMENT.md
@@ -41,3 +41,6 @@ In order to run them, just simply execute the following Gradle command:
 ```bash
 ./gradlew integrationTest
 ```
+
+<!-- INT-185 trigger-path security verification (platform) -->
+


### PR DESCRIPTION
## Summary

Disposable draft PR verifying the dispatcher's **trigger path** after the security-hardening amend.

Diff: one-line markers in `charts/hivemq-platform/DEVELOPMENT.md` and `charts/hivemq-edge/DEVELOPMENT.md`. Expected flow:

- `Check whether Jenkins build is needed` → `needed=true`
- `Build Jenkins webhook payload` runs, constructs GitHub-shaped push payload, HMAC-SHA256 signs.
- `Trigger Jenkins composite build` POSTs via `fjogeleit/http-request-action`.

**Security verification on the new run log:**

- The action's input dump for `customHeaders` should show `"X-Hub-Signature-256": "sha256=***"` and `"X-GitHub-Delivery": "***"` (both masked via `::add-mask::`).
- `Delivery ID:` line should show `***` instead of the UUID.
- No redundant pretty-printed `Payload:` echo.
- `url: ***` still masked (no regression).

Verification on the Jenkins side: a fresh `hivemq-composite/verify%2Fint-185-trigger-path/<N>` should appear and post `continuous-integration/jenkins/branch` status.

Close + delete after observing.