### PR TITLE
check(INT-185): Mixed Platform+Edge final verification, do not merge

### DIFF
--- a/charts/hivemq-edge/DEVELOPMENT.md
+++ b/charts/hivemq-edge/DEVELOPMENT.md
@@ -222,3 +222,6 @@ In order to run them, just simply execute the following Gradle command:
 ```bash
 ./gradlew integrationTest
 ```
+
+<!-- INT-185 mixed-changes final check (edge) -->
+

--- a/charts/hivemq-platform/DEVELOPMENT.md
+++ b/charts/hivemq-platform/DEVELOPMENT.md
@@ -41,3 +41,6 @@ In order to run them, just simply execute the following Gradle command:
 ```bash
 ./gradlew integrationTest
 ```
+
+<!-- INT-185 mixed-changes final check (platform) -->
+


### PR DESCRIPTION
## Summary

Final disposable draft PR exercising the dispatcher's **trigger path** on the latest feature HEAD (after amend dropping the `Delivery ID:` echo).

Diff: one-line markers in `charts/hivemq-platform/DEVELOPMENT.md` and `charts/hivemq-edge/DEVELOPMENT.md`.

Expected on the dispatcher run log:

- `Check whether Jenkins build is needed` → `needed=true`
- `Build Jenkins webhook payload` runs. Output should show **only** the body in `customHeaders` masked: `"X-Hub-Signature-256": "sha256=***"` and `"X-GitHub-Delivery": "***"`. No `Delivery ID: ...` line. No redundant `Payload:` pretty-print.
- `Trigger Jenkins composite build` (`fjogeleit/http-request-action`) POSTs and returns `200` from Jenkins.

Then on the Jenkins side: a fresh `hivemq-composite/check%2Fint-185-mixed-changes/<N>` should appear and post `continuous-integration/jenkins/branch` on this PR head SHA.

Close + delete after observing.