### PR TITLE
pr-test(INT-185): Edge-only changes, do not merge

### DIFF
--- a/charts/hivemq-edge/DEVELOPMENT.md
+++ b/charts/hivemq-edge/DEVELOPMENT.md
@@ -222,3 +222,6 @@ In order to run them, just simply execute the following Gradle command:
 ```bash
 ./gradlew integrationTest
 ```
+
+<!-- INT-185 edge-only post-Copilot review -->
+


### PR DESCRIPTION
## Summary

Disposable draft PR — **Edge-only changes** — verifying the skip path against the dynamic-payload feature HEAD.

Expected: `needed=false`, `Skip Jenkins composite build` posts `continuous-integration/jenkins/branch = success` directly. No Jenkins activity.