### PR TITLE
pr-test(INT-185): Platform-only changes, do not merge

### DIFF
--- a/charts/hivemq-platform/DEVELOPMENT.md
+++ b/charts/hivemq-platform/DEVELOPMENT.md
@@ -41,3 +41,6 @@ In order to run them, just simply execute the following Gradle command:
 ```bash
 ./gradlew integrationTest
 ```
+
+<!-- INT-185 platform-only post-Copilot review -->
+


### PR DESCRIPTION
## Summary

Disposable draft PR — **Platform-only changes** — verifying the trigger path against the dynamic-payload feature HEAD.

Expected: `needed=true`, `Build Jenkins webhook payload` constructs payload using `github.event.repository` / `github.event.organization` (no hardcoded IDs), `Trigger Jenkins composite build` POSTs to Jenkins. Jenkins should trigger `hivemq-composite/pr-test%2Fint-185-platform/<N>`.