### PR TITLE
pr-test(INT-185): Platform+Edge changes, do not merge

### DIFF
--- a/charts/hivemq-edge/DEVELOPMENT.md
+++ b/charts/hivemq-edge/DEVELOPMENT.md
@@ -222,3 +222,6 @@ In order to run them, just simply execute the following Gradle command:
 ```bash
 ./gradlew integrationTest
 ```
+
+<!-- INT-185 mixed post-Copilot review (edge) -->
+

--- a/charts/hivemq-platform/DEVELOPMENT.md
+++ b/charts/hivemq-platform/DEVELOPMENT.md
@@ -41,3 +41,6 @@ In order to run them, just simply execute the following Gradle command:
 ```bash
 ./gradlew integrationTest
 ```
+
+<!-- INT-185 mixed post-Copilot review (platform) -->
+


### PR DESCRIPTION
## Summary

Disposable draft PR — **Platform+Edge changes** — verifying the trigger path with a mixed diff against the dynamic-payload feature HEAD.

Expected: `needed=true` (platform wins despite Edge presence), `Trigger Jenkins composite build` POSTs to Jenkins. Jenkins should trigger `hivemq-composite/pr-test%2Fint-185-mixed/<N>`.