### PR TITLE
Bump Helm to 4.2.0/3.21.0

### DIFF
--- a/.github/workflows/edge-smoke-test.yml
+++ b/.github/workflows/edge-smoke-test.yml
@@ -14,9 +14,9 @@ jobs:
           - helm-label: 'minimum'
             helm-version: 'v3.10.0'
           - helm-label: 'latest-3'
-            helm-version: 'v3.20.0'
+            helm-version: 'v3.21.0'
           - helm-label: 'latest-4'
-            helm-version: 'v4.1.1'
+            helm-version: 'v4.2.0'
     steps:
       - name: Checkout HiveMQ Helm Charts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/edge-verify.yml
+++ b/.github/workflows/edge-verify.yml
@@ -11,6 +11,8 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        with:
+          version: 'v4.2.0'
 
       - name: Set up Kubeconform
         run: |

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        with:
+          version: 'v4.2.0'
 
       - name: Login to Harbor
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4

--- a/.github/workflows/platform-smoke-test.yml
+++ b/.github/workflows/platform-smoke-test.yml
@@ -17,9 +17,9 @@ jobs:
           - helm-label: 'minimum'
             helm-version: 'v3.10.0'
           - helm-label: 'latest-3'
-            helm-version: 'v3.20.0'
+            helm-version: 'v3.21.0'
           - helm-label: 'latest-4'
-            helm-version: 'v4.1.1'
+            helm-version: 'v4.2.0'
     steps:
       - name: Checkout HiveMQ Helm Charts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/platform-verify.yml
+++ b/.github/workflows/platform-verify.yml
@@ -11,6 +11,8 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        with:
+          version: 'v4.2.0'
 
       - name: Set up Kubeconform
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        with:
+          version: 'v4.2.0'
 
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/swarm-verify.yml
+++ b/.github/workflows/swarm-verify.yml
@@ -11,6 +11,8 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        with:
+          version: 'v4.2.0'
 
       - name: Set up Kubeconform
         run: |

--- a/manifests/hivemq-edge/configmap-configuration.yml
+++ b/manifests/hivemq-edge/configmap-configuration.yml
@@ -15,3 +15,5 @@ data:
     </mqtt-bridges>
     <protocol-adapters>
     </protocol-adapters>
+    
+

--- a/manifests/hivemq-edge/configmap-topicfilters.yml
+++ b/manifests/hivemq-edge/configmap-topicfilters.yml
@@ -16,3 +16,4 @@ data:
       <topicFilters>
       </topicFilters>
     </topic-filters-persistence>
+

--- a/manifests/hivemq-edge/secret-admin.yml
+++ b/manifests/hivemq-edge/secret-admin.yml
@@ -13,3 +13,4 @@ type: Opaque
 data:
   user: YWRtaW4=
   password: aGl2ZW1x
+

--- a/manifests/hivemq-edge/service.yml
+++ b/manifests/hivemq-edge/service.yml
@@ -18,3 +18,4 @@ spec:
   selector:
     app.kubernetes.io/name: "hivemq-edge"
     app.kubernetes.io/instance: "my-edge"
+

--- a/manifests/hivemq-edge/statefulset.yml
+++ b/manifests/hivemq-edge/statefulset.yml
@@ -92,3 +92,4 @@ spec:
         - name: topicfilters
           configMap:
             name: hivemq-edge-topicfilters-my-edge
+

--- a/manifests/hivemq-platform-operator/deployment.yml
+++ b/manifests/hivemq-platform-operator/deployment.yml
@@ -119,3 +119,4 @@ spec:
               cpu: 1000m
               memory: 1Gi
       serviceAccountName: hivemq-platform-operator-my-operator
+

--- a/manifests/hivemq-platform-operator/service-account.yml
+++ b/manifests/hivemq-platform-operator/service-account.yml
@@ -8,3 +8,4 @@ metadata:
     app.kubernetes.io/name: "hivemq-platform-operator"
     app.kubernetes.io/instance: "my-operator"
     app.kubernetes.io/version: "2.1.4"
+

--- a/manifests/hivemq-platform-operator/service.yml
+++ b/manifests/hivemq-platform-operator/service.yml
@@ -22,3 +22,4 @@ spec:
     app.kubernetes.io/name: "hivemq-platform-operator"
     app.kubernetes.io/instance: "my-operator"
   type: ClusterIP
+

--- a/manifests/hivemq-platform/hivemq-configuration.yml
+++ b/manifests/hivemq-platform/hivemq-configuration.yml
@@ -64,3 +64,4 @@ data:
         </publish-sampling>
       </sampling>
     </tracing>
+

--- a/manifests/hivemq-platform/hivemq-custom-resource.yml
+++ b/manifests/hivemq-platform/hivemq-custom-resource.yml
@@ -69,3 +69,4 @@ spec:
       enabled: true
       supportsHotReload: false
       extensionUri: "preinstalled"
+

--- a/manifests/hivemq-swarm/deployment_agents.yaml
+++ b/manifests/hivemq-swarm/deployment_agents.yaml
@@ -65,3 +65,4 @@ spec:
             requests:
               cpu: 500m
               memory: 1G
+

--- a/manifests/hivemq-swarm/service_agents_headless.yaml
+++ b/manifests/hivemq-swarm/service_agents_headless.yaml
@@ -27,3 +27,4 @@ spec:
     hivemq.com/swarm-role: agent
     app.kubernetes.io/name: hivemq-swarm
     app.kubernetes.io/instance: my-swarm
+

--- a/manifests/hivemq-swarm/service_commander_api.yaml
+++ b/manifests/hivemq-swarm/service_commander_api.yaml
@@ -21,3 +21,4 @@ spec:
     hivemq.com/swarm-role: commander
     app.kubernetes.io/name: hivemq-swarm
     app.kubernetes.io/instance: my-swarm
+

--- a/manifests/hivemq-swarm/serviceaccount.yaml
+++ b/manifests/hivemq-swarm/serviceaccount.yaml
@@ -9,3 +9,4 @@ metadata:
     app.kubernetes.io/name: hivemq-swarm
     app.kubernetes.io/instance: my-swarm
     app.kubernetes.io/version: "4.51.0"
+

--- a/manifests/hivemq-swarm/statefulset_commander.yaml
+++ b/manifests/hivemq-swarm/statefulset_commander.yaml
@@ -83,3 +83,4 @@ spec:
           
         - emptyDir: {}
           name: scenario-persistence
+


### PR DESCRIPTION
## Summary

- Pins Helm to `v4.2.0` on every `azure/setup-helm` invocation in this repo (verify, harbor, release; smoke tests already pin via matrix).
- Bumps the smoke-test `latest-*` matrix entries to `v3.21.0` and `v4.2.0`.
- Regenerates `manifests/` to match `helm template` output under v4.2.0.

Eliminates the `Check manifests are up-to-date` flake driven by `azure/setup-helm@latest` resolving inconsistently after the Helm v4.2.0 release.