### PR TITLE
Add persistentVolumeClaimRetentionPolicy chart values

### DIFF
--- a/charts/hivemq-platform/templates/hivemq-custom-resource.yml
+++ b/charts/hivemq-platform/templates/hivemq-custom-resource.yml
@@ -304,6 +304,10 @@ spec:
           {{- with .Values.podScheduling.priorityClassName }}
           priorityClassName: {{ . }}
           {{- end }}
+      {{- with .Values.nodes.persistentVolumeClaimRetentionPolicy }}
+      persistentVolumeClaimRetentionPolicy:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.volumeClaimTemplates }}
       volumeClaimTemplates:
         {{- toYaml . | nindent 12 }}

--- a/charts/hivemq-platform/tests/statefulset/hivemq_pvc_retention_policy_test.yaml
+++ b/charts/hivemq-platform/tests/statefulset/hivemq_pvc_retention_policy_test.yaml
@@ -1,0 +1,41 @@
+suite: HiveMQ Platform - PVC Retention Policy tests
+templates:
+  - hivemq-custom-resource.yml
+tests:
+
+  - it: with defaults, persistentVolumeClaimRetentionPolicy is not rendered
+    asserts:
+      - notExists:
+          path: spec.statefulSet.spec.persistentVolumeClaimRetentionPolicy
+
+  - it: with whenScaled set to Delete, only whenScaled is rendered
+    set:
+      nodes.persistentVolumeClaimRetentionPolicy.whenScaled: Delete
+    asserts:
+      - equal:
+          path: spec.statefulSet.spec.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Delete
+      - notExists:
+          path: spec.statefulSet.spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+
+  - it: with whenDeleted set to Delete, only whenDeleted is rendered
+    set:
+      nodes.persistentVolumeClaimRetentionPolicy.whenDeleted: Delete
+    asserts:
+      - equal:
+          path: spec.statefulSet.spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Delete
+      - notExists:
+          path: spec.statefulSet.spec.persistentVolumeClaimRetentionPolicy.whenScaled
+
+  - it: with both whenDeleted and whenScaled set, both fields are rendered
+    set:
+      nodes.persistentVolumeClaimRetentionPolicy.whenDeleted: Retain
+      nodes.persistentVolumeClaimRetentionPolicy.whenScaled: Delete
+    asserts:
+      - equal:
+          path: spec.statefulSet.spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Retain
+      - equal:
+          path: spec.statefulSet.spec.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Delete

--- a/charts/hivemq-platform/values.schema.json
+++ b/charts/hivemq-platform/values.schema.json
@@ -963,6 +963,10 @@
             "WARN"
           ]
         },
+        "persistentVolumeClaimRetentionPolicy" : {
+          "description" : "Optional setting that defines the retention policy controlling the lifecycle of PersistentVolumeClaims created from `volumeClaimTemplates` for your HiveMQ Platform pods. Any valid `persistentVolumeClaimRetentionPolicy` Kubernetes configuration can be used.",
+          "type" : "object"
+        },
         "podSecurityContext" : {
           "description" : "Configures pod-level security for the HiveMQ Platform pod. Some fields are also present in container.securityContext. Field values of container.securityContext take precedence over field values of PodSecurityContext.",
           "properties" : {

--- a/charts/hivemq-platform/values.yaml
+++ b/charts/hivemq-platform/values.yaml
@@ -78,6 +78,15 @@ nodes:
   # If not set or empty, a default service account is created.
   serviceAccountName: ""
 
+  # Optional setting that defines the retention policy controlling the lifecycle of PersistentVolumeClaims created from `volumeClaimTemplates`
+  # for your HiveMQ Platform pods. Any valid `persistentVolumeClaimRetentionPolicy` Kubernetes configuration can be used.
+  # Note: on Kubernetes 1.24-1.26 the API server drops the StatefulSet `persistentVolumeClaimRetentionPolicy` field
+  # when the `StatefulSetAutoDeletePVC` feature gate is off, so the field has no effect on those versions.
+  persistentVolumeClaimRetentionPolicy: {}
+  # persistentVolumeClaimRetentionPolicy:
+  #   whenDeleted: Retain
+  #   whenScaled: Delete
+
 # Configuration options for the default provided HiveMQ configuration (config.xml)
 #
 # Control Center configuration

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/volumes/HelmPvcRetentionPolicyIT.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/volumes/HelmPvcRetentionPolicyIT.java
@@ -1,0 +1,123 @@
+package com.hivemq.helmcharts.volumes;
+
+import com.hivemq.helmcharts.AbstractHelmChartIT;
+import com.hivemq.helmcharts.util.K8sUtil;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+class HelmPvcRetentionPolicyIT extends AbstractHelmChartIT {
+
+    private static final @NotNull String PVC_NAME_PREFIX = "hivemq-pvc-data-";
+    private static final int REPLICAS = 1;
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.MINUTES)
+    @EnabledIfSystemProperty(named = "k3s.version.type",
+                             matches = "LATEST",
+                             disabledReason = "requires K8s >= 1.27 where persistentVolumeClaimRetentionPolicy is honored")
+    void platform_whenPvcRetentionPolicyAllDelete_thenAllPvcsCleanedUp() throws Exception {
+        installPlatformChartAndWaitToBeRunning("/files/pvc-retention-policy-values.yaml");
+
+        await().untilAsserted(() -> assertThat(listPlatformPvcs()).hasSize(REPLICAS));
+        await().untilAsserted(() -> {
+            final var statefulSet =
+                    client.apps().statefulSets().inNamespace(platformNamespace).withName(platformReleaseName).get();
+            assertThat(statefulSet).isNotNull();
+            final var retention = statefulSet.getSpec().getPersistentVolumeClaimRetentionPolicy();
+            assertThat(retention).isNotNull();
+            assertThat(retention.getWhenScaled()).isEqualTo("Delete");
+            assertThat(retention.getWhenDeleted()).isEqualTo("Delete");
+            assertThat(listPlatformPvcs()).hasSize(REPLICAS);
+        });
+
+        // trigger a rolling restart by updating the platform ConfigMap
+        K8sUtil.updateConfigMap(client,
+                platformNamespace,
+                "hivemq-config-map-update.yml",
+                "hivemq-configuration-" + platformReleaseName);
+        K8sUtil.waitForHiveMQPlatformStateRunningAfterRollingRestart(client, platformNamespace, platformReleaseName);
+
+        await().atMost(2, TimeUnit.MINUTES)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(listPlatformPvcs()).as(
+                        "surge PVC must be deleted by K8s on scale-down (whenScaled=Delete)").hasSize(REPLICAS));
+
+        helmChartContainer.uninstallRelease(platformReleaseName, platformNamespace, false);
+        // wait for the StatefulSet to be fully gone
+        await().atMost(1, TimeUnit.MINUTES)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .until(() -> client.apps()
+                        .statefulSets()
+                        .inNamespace(platformNamespace)
+                        .withName(platformReleaseName)
+                        .get() == null);
+
+        // data PVCs are cleaned up by K8s after StatefulSet deletion (whenDeleted: Delete).
+        await().atMost(2, TimeUnit.MINUTES)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(listPlatformPvcs()).as(
+                        "data PVCs must be deleted after StatefulSet deletion when whenDeleted is Delete").isEmpty());
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.MINUTES)
+    @EnabledIfSystemProperty(named = "k3s.version.type",
+                             matches = "MINIMUM",
+                             disabledReason = "requires K8s < 1.27 where the alpha field is dropped by the API server")
+    void platform_whenWhenScaledDelete_onAlphaK8s_thenSurgePvcRemains() throws Exception {
+        installPlatformChartAndWaitToBeRunning("/files/pvc-retention-policy-values.yaml");
+        await().untilAsserted(() -> assertThat(listPlatformPvcs()).hasSize(REPLICAS));
+
+        // trigger a rolling restart by updating the platform ConfigMap (same pattern as the LATEST test above)
+        K8sUtil.updateConfigMap(client,
+                platformNamespace,
+                "hivemq-config-map-update.yml",
+                "hivemq-configuration-" + platformReleaseName);
+        K8sUtil.waitForHiveMQPlatformStateRunningAfterRollingRestart(client, platformNamespace, platformReleaseName);
+
+        // during 30 seconds, ensure PVC for surge pod was not deleted
+        await().during(30, TimeUnit.SECONDS)
+                .atMost(2, TimeUnit.MINUTES)
+                .pollInterval(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(listPlatformPvcs()).as(
+                                "surge PVC should remain on K8s < 1.27 because StatefulSetAutoDeletePVC feature gate is off")
+                        .hasSize(REPLICAS + 1));
+
+        helmChartContainer.uninstallRelease(platformReleaseName, platformNamespace, false);
+        // wait for the StatefulSet to be fully gone
+        await().atMost(1, TimeUnit.MINUTES)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .until(() -> client.apps()
+                        .statefulSets()
+                        .inNamespace(platformNamespace)
+                        .withName(platformReleaseName)
+                        .get() == null);
+
+        // during 15 seconds, ensure all PVCs remain
+        await().during(15, TimeUnit.SECONDS)
+                .atMost(2, TimeUnit.MINUTES)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(listPlatformPvcs()).as(
+                                "all PVCs must remain after helm uninstall on alpha K8s (retention policy was dropped, K8s defaults to Retain)")
+                        .hasSize(REPLICAS + 1));
+    }
+
+    private @NotNull List<PersistentVolumeClaim> listPlatformPvcs() {
+        return client.persistentVolumeClaims()
+                .inNamespace(platformNamespace)
+                .list()
+                .getItems()
+                .stream()
+                .filter(pvc -> pvc.getMetadata().getName().startsWith(PVC_NAME_PREFIX))
+                .toList();
+    }
+}

--- a/tests-hivemq-platform-operator/src/integrationTest/resources/values/pvc-retention-policy-values.yaml
+++ b/tests-hivemq-platform-operator/src/integrationTest/resources/values/pvc-retention-policy-values.yaml
@@ -1,0 +1,24 @@
+nodes:
+  replicaCount: 1
+  podSecurityContext:
+    enabled: true
+    fsGroup: 0
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+additionalVolumes:
+  - type: persistentVolumeClaim
+    name: hivemq-pvc-data
+    path: /opt/hivemq/data
+volumeClaimTemplates:
+  - kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: hivemq-pvc-data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+      volumeMode: Filesystem


### PR DESCRIPTION
## Summary
- Expose `nodes.persistentVolumeClaimRetentionPolicy` on the `hivemq-platform` chart. Default is an empty map (`{}`) so existing customers see no change to their StatefulSet spec on upgrade; Kubernetes applies its own defaults (`Retain/Retain`) server-side as before.
- Setting `whenScaled: Delete` enables automatic cleanup of the surge pod's PVC after a rolling restart, eliminating the dangling-PV cost and re-scheduling issues. Setting `whenDeleted: Delete` additionally cleans up data PVCs on platform uninstall.
- Renders into the Platform CR's `spec.statefulSet.spec`; no operator change is required because the CR already accepts fabric8's `StatefulSetSpec` verbatim.
- Schema follows the chart's K8s-passthrough convention (`type: object` only, like `affinity` and `tolerations`); the upstream Kubernetes schema gates valid values.
- Helm-unittest covers four rendering scenarios: defaults (not rendered), `whenScaled` only, `whenDeleted` only, and both set.
- New `HelmPvcRetentionPolicyIT` encodes the supported-version contract end-to-end via helm install + rolling restart + helm uninstall:
  - **LATEST K8s lane** (>= 1.27, beta default-on; GA in 1.32): surge PVC is deleted after the rolling restart, and data PVCs are deleted after helm uninstall.
  - **MINIMUM K8s lane** (1.24, alpha feature gate off): the API server drops the field on write, so neither cleanup happens; both surge and data PVCs remain.

Closes INT-286.