### PR TITLE
Pin Helm to .helm-version in Edge release PR workflow

### DIFF
--- a/.github/workflows/edge-release-pr.yml
+++ b/.github/workflows/edge-release-pr.yml
@@ -50,6 +50,15 @@ jobs:
       - name: 🔧 Set up Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
 
+      - name: 📌 Read pinned Helm version
+        id: helm-version
+        run: echo "version=$(cat .helm-version)" >> "$GITHUB_OUTPUT"
+
+      - name: ⛵ Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        with:
+          version: ${{ steps.helm-version.outputs.version }}
+
       - name: 🔄 Update Edge chart version
         env:
           APP_VERSION: ${{ inputs.app_version }}


### PR DESCRIPTION
## Summary
- The `edge-release-pr.yml` workflow regenerated chart manifests using whatever Helm version was pre-installed on the runner, producing output that did not match `.helm-version` (v4.2.0). This caused the downstream verify job to fail on stale manifests ([failing run](https://github.com/hivemq/helm-charts/actions/runs/26515534497/job/78091524935)).
- Read the pinned version from `.helm-version` and install it via `azure/setup-helm` before running `updateEdgeChartVersion`, matching the pattern already used in `edge-verify.yml` and the other verify workflows.