### PR TITLE
Update operator dashboard with concurrency-limit gauges

### DIFF
--- a/charts/hivemq-platform-operator/files/grafana-dashboard.json
+++ b/charts/hivemq-platform-operator/files/grafana-dashboard.json
@@ -1009,7 +1009,7 @@
               }
             ]
           },
-          "unit": "eps"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -1041,16 +1041,30 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (gate) (rate(hivemq_platform_operator_reconciliation_throttled_count{instance=\"$instance\"}[$__rate_interval]))",
+          "expr": "hivemq_platform_operator_concurrency_limit_active_count{instance=\"$instance\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{gate}}",
+          "legendFormat": "{{concurrency_limit}} active",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "hivemq_platform_operator_concurrency_limit_blocked_count{instance=\"$instance\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{concurrency_limit}} blocked",
+          "range": true,
+          "refId": "B"
         }
       ],
-      "title": "Concurrent Gate Throttled",
+      "title": "Concurrency limit (active / blocked)",
       "type": "timeseries"
     },
     {

--- a/charts/hivemq-platform-operator/tests/__snapshot__/hivemq_operator_configmap_dashboard_test.yaml.snap
+++ b/charts/hivemq-platform-operator/tests/__snapshot__/hivemq_operator_configmap_dashboard_test.yaml.snap
@@ -1012,7 +1012,7 @@ with monitoring enabled and default values, ConfigMap spec created with defaults
                     }
                   ]
                 },
-                "unit": "eps"
+                "unit": "short"
               },
               "overrides": []
             },
@@ -1044,16 +1044,30 @@ with monitoring enabled and default values, ConfigMap spec created with defaults
                   "uid": "prometheus"
                 },
                 "editorMode": "code",
-                "expr": "sum by (gate) (rate(hivemq_platform_operator_reconciliation_throttled_count{instance=\"$instance\"}[$__rate_interval]))",
+                "expr": "hivemq_platform_operator_concurrency_limit_active_count{instance=\"$instance\"}",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 2,
-                "legendFormat": "{{gate}}",
+                "legendFormat": "{{concurrency_limit}} active",
                 "range": true,
                 "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "prometheus"
+                },
+                "editorMode": "code",
+                "expr": "hivemq_platform_operator_concurrency_limit_blocked_count{instance=\"$instance\"}",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "{{concurrency_limit}} blocked",
+                "range": true,
+                "refId": "B"
               }
             ],
-            "title": "Concurrent Gate Throttled",
+            "title": "Concurrency limit (active / blocked)",
             "type": "timeseries"
           },
           {


### PR DESCRIPTION
Companion to hivemq/hivemq-platform-operator#962.

The operator dashboard's `Concurrent Gate Throttled` panel sourced `hivemq_platform_operator_reconciliation_throttled_count`, which is removed by the operator PR. Swaps the panel to the two replacement gauges:

- `hivemq_platform_operator_concurrency_limit_active_count{concurrency_limit=...}`
- `hivemq_platform_operator_concurrency_limit_blocked_count{concurrency_limit=...}`

Panel renamed to `Concurrency limit (active / blocked)`, unit `eps` -> `short`. Dashboard ConfigMap snapshot regenerated.