### PR TITLE
feat(hivemq-platform-operator): support image digest overrides

### DIFF
--- a/charts/hivemq-platform-operator/templates/_helpers.tpl
+++ b/charts/hivemq-platform-operator/templates/_helpers.tpl
@@ -27,7 +27,7 @@ Usage: {{ include "hivemq-platform-operator.name" (dict "prefix" "my-custom-pref
 Common labels
 */}}
 {{- define "hivemq-platform-operator.labels" -}}
-helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{ include "hivemq-platform-operator.selector-labels" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -50,6 +50,25 @@ Creates the name of the service account to use for the HiveMQ Platform Operator
 {{- else }}
 {{- include "hivemq-platform-operator.name" (dict "prefix" "hivemq-platform-operator" "releaseName" .Release.Name) }}
 {{- end }}
+{{- end -}}
+
+{{/*
+Builds a container image reference.
+Params:
+- repository: The image repository path.
+- name:       The image name.
+- tag:        The image tag.
+- digest:     The optional image digest.
+Usage: {{ include "hivemq-platform-operator.imageReference" (dict "repository" .Values.image.repository "name" .Values.image.name "tag" .Values.image.tag "digest" .Values.image.digest) }}
+*/}}
+{{- define "hivemq-platform-operator.imageReference" -}}
+{{- $repository := required "image repository is required" .repository -}}
+{{- $name := required "image name is required" .name -}}
+{{- $tag := .tag | default "" -}}
+{{- $digest := .digest | default "" -}}
+{{- printf "%s/%s" $repository $name -}}
+{{- if $tag -}}:{{ $tag }}{{- end -}}
+{{- if $digest -}}@{{ $digest }}{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/hivemq-platform-operator/templates/deployment.yml
+++ b/charts/hivemq-platform-operator/templates/deployment.yml
@@ -77,7 +77,7 @@ spec:
             - name: HIVEMQ_PLATFORM_OPERATOR_CRD_WAIT_UNTIL_READY_TIMEOUT
               value: "{{ .Values.crd.waitTimeout }}"
             - name: HIVEMQ_PLATFORM_OPERATOR_INIT_IMAGE
-              value: "{{ .Values.image.repository}}/{{ .Values.image.initImageName}}:{{.Values.image.tag}}"
+              value: "{{ include "hivemq-platform-operator.imageReference" (dict "repository" .Values.image.repository "name" .Values.image.initImageName "tag" .Values.image.tag "digest" .Values.image.initImageDigest) }}"
             - name: HIVEMQ_PLATFORM_OPERATOR_INIT_IMAGE_PULL_POLICY
               value: "{{ .Values.image.pullPolicy }}"
             {{- with .Values.hivemqPlatformInitContainer }}
@@ -163,7 +163,7 @@ spec:
             {{- with .Values.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-          image: "{{ .Values.image.repository}}/{{ .Values.image.name }}:{{.Values.image.tag}}"
+          image: "{{ include "hivemq-platform-operator.imageReference" (dict "repository" .Values.image.repository "name" .Values.image.name "tag" .Values.image.tag "digest" .Values.image.digest) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             failureThreshold: 3

--- a/charts/hivemq-platform-operator/tests/hivemq_operator_deployment_test.yaml
+++ b/charts/hivemq-platform-operator/tests/hivemq_operator_deployment_test.yaml
@@ -177,6 +177,42 @@ tests:
       - exists:
           path: spec.template.spec.containers[0].resources
 
+  - it: with image digest overrides
+    set:
+      image.repository: test-repo
+      image.name: test-image
+      image.tag: test-tag
+      image.digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+      image.initImageName: test-init-image
+      image.initImageDigest: sha256:2222222222222222222222222222222222222222222222222222222222222222
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "test-repo/test-image:test-tag@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HIVEMQ_PLATFORM_OPERATOR_INIT_IMAGE
+            value: "test-repo/test-init-image:test-tag@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+  - it: with image digest overrides and empty tag
+    set:
+      image.repository: test-repo
+      image.name: test-image
+      image.tag: ""
+      image.digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+      image.initImageName: test-init-image
+      image.initImageDigest: sha256:2222222222222222222222222222222222222222222222222222222222222222
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "test-repo/test-image@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HIVEMQ_PLATFORM_OPERATOR_INIT_IMAGE
+            value: "test-repo/test-init-image@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
   - it: with custom concurrentRollingRestartLimit, operator container EnvVar created
     set:
       concurrentRollingRestartLimit: 5

--- a/charts/hivemq-platform-operator/values.schema.json
+++ b/charts/hivemq-platform-operator/values.schema.json
@@ -131,6 +131,12 @@
     },
     "image" : {
       "properties" : {
+        "digest" : {
+          "type" : "string"
+        },
+        "initImageDigest" : {
+          "type" : "string"
+        },
         "initImageName" : {
           "type" : "string"
         },

--- a/charts/hivemq-platform-operator/values.yaml
+++ b/charts/hivemq-platform-operator/values.yaml
@@ -6,7 +6,13 @@ image:
   repository: docker.io/hivemq
   name: hivemq-platform-operator
   tag: 2.1.4
+  # Optional digest for the HiveMQ Platform Operator image.
+  # If set, the rendered image reference is <repository>/<name>:<tag>@<digest>.
+  digest: ""
   initImageName: hivemq-platform-operator-init
+  # Optional digest for the HiveMQ Platform Operator Init image.
+  # If set, the rendered image reference is <repository>/<initImageName>:<tag>@<initImageDigest>.
+  initImageDigest: ""
   pullPolicy: IfNotPresent
   pullSecretName: ""
 


### PR DESCRIPTION
- Add optional digest values for the operator and init images
- Render image references through a shared helper so digests can be appended with or without a tag.
- Update the values schema and deployment tests to cover digest rendering.
- Normalize the `helm.sh/chart` label to stay within Kubernetes label constraints.

Closes #937 