### PR TITLE
Support image digest overrides

### DIFF
--- a/charts/hivemq-platform-operator/templates/_helpers.tpl
+++ b/charts/hivemq-platform-operator/templates/_helpers.tpl
@@ -44,7 +44,7 @@ app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{/*
 Creates the name of the service account to use for the HiveMQ Platform Operator
 */}}
-{{- define "hivemq-platform-operator.serviceAccountName" -}}
+{{- define "hivemq-platform-operator.service-account-name" -}}
 {{- if .Values.serviceAccount.name }}
 {{- printf "%s" .Values.serviceAccount.name }}
 {{- else }}

--- a/charts/hivemq-platform-operator/templates/_helpers.tpl
+++ b/charts/hivemq-platform-operator/templates/_helpers.tpl
@@ -53,6 +53,27 @@ Creates the name of the service account to use for the HiveMQ Platform Operator
 {{- end -}}
 
 {{/*
+Builds a container image reference.
+Params:
+- repository: The image repository path.
+- name:       The image name.
+- tag:        The image tag.
+- digest:     The optional image digest.
+Usage: {{ include "hivemq-platform-operator.image-reference" (dict "repository" .Values.image.repository "name" .Values.image.name "tag" .Values.image.tag "digest" .Values.image.digest) }}
+*/}}
+{{- define "hivemq-platform-operator.image-reference" -}}
+{{- if not .repository -}}
+{{- fail (printf "\n`repository` is required to build the HiveMQ Platform Operator container image reference.") -}}
+{{- end -}}
+{{- if not .name -}}
+{{- fail (printf "\n`name` is required to build the HiveMQ Platform Operator container image reference.") -}}
+{{- end -}}
+{{- printf "%s/%s" .repository .name -}}
+{{- with .tag }}:{{ . }}{{- end -}}
+{{- with .digest }}@{{ . }}{{- end -}}
+{{- end -}}
+
+{{/*
 Creates the HiveMQ Platform Operator HTTP service port name.
 Usage: {{ include "hivemq-platform-operator.http-service-port-name" . }}
 */}}

--- a/charts/hivemq-platform-operator/templates/bindings.yml
+++ b/charts/hivemq-platform-operator/templates/bindings.yml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create -}}
 {{- $labels := include "hivemq-platform-operator.labels" . }}
-{{- $serviceAccountName := include "hivemq-platform-operator.serviceAccountName" . }}
+{{- $serviceAccountName := include "hivemq-platform-operator.service-account-name" . }}
 {{- $roleBindingName := include "hivemq-platform-operator.name" (dict "prefix" "hivemq-platform-operator" "name" "role-binding" "releaseName" .Release.Name) }}
 {{- $roleName := include "hivemq-platform-operator.name" (dict "prefix" "hivemq-platform-operator" "name" "role" "releaseName" .Release.Name) }}
 ---

--- a/charts/hivemq-platform-operator/templates/deployment.yml
+++ b/charts/hivemq-platform-operator/templates/deployment.yml
@@ -77,7 +77,7 @@ spec:
             - name: HIVEMQ_PLATFORM_OPERATOR_CRD_WAIT_UNTIL_READY_TIMEOUT
               value: "{{ .Values.crd.waitTimeout }}"
             - name: HIVEMQ_PLATFORM_OPERATOR_INIT_IMAGE
-              value: "{{ .Values.image.repository}}/{{ .Values.image.initImageName}}:{{.Values.image.tag}}"
+              value: "{{ include "hivemq-platform-operator.image-reference" (dict "repository" .Values.image.repository "name" .Values.image.initImageName "tag" .Values.image.tag "digest" .Values.image.initImageDigest) }}"
             - name: HIVEMQ_PLATFORM_OPERATOR_INIT_IMAGE_PULL_POLICY
               value: "{{ .Values.image.pullPolicy }}"
             {{- with .Values.hivemqPlatformInitContainer }}
@@ -165,7 +165,7 @@ spec:
             {{- with .Values.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-          image: "{{ .Values.image.repository}}/{{ .Values.image.name }}:{{.Values.image.tag}}"
+          image: "{{ include "hivemq-platform-operator.image-reference" (dict "repository" .Values.image.repository "name" .Values.image.name "tag" .Values.image.tag "digest" .Values.image.digest) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}

--- a/charts/hivemq-platform-operator/templates/deployment.yml
+++ b/charts/hivemq-platform-operator/templates/deployment.yml
@@ -235,7 +235,7 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.image.pullSecretName }}
       {{- end }}
-      serviceAccountName: {{ include "hivemq-platform-operator.serviceAccountName" . }}
+      serviceAccountName: {{ include "hivemq-platform-operator.service-account-name" . }}
       {{- /* `nil` check needed for backward compatibility */ -}}
       {{- if and (ne .Values.tls.secretName "nil") (.Values.tls.secretName) }}
       volumes:

--- a/charts/hivemq-platform-operator/templates/service-account.yml
+++ b/charts/hivemq-platform-operator/templates/service-account.yml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "hivemq-platform-operator.serviceAccountName" . }}
+  name: {{ include "hivemq-platform-operator.service-account-name" . }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/hivemq-platform-operator/tests/hivemq_operator_deployment_test.yaml
+++ b/charts/hivemq-platform-operator/tests/hivemq_operator_deployment_test.yaml
@@ -179,6 +179,87 @@ tests:
       - exists:
           path: spec.template.spec.containers[0].resources
 
+  - it: with image digest overrides
+    set:
+      image.repository: test-repo
+      image.name: test-image
+      image.tag: test-tag
+      image.digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+      image.initImageName: test-init-image
+      image.initImageDigest: sha256:2222222222222222222222222222222222222222222222222222222222222222
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "test-repo/test-image:test-tag@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HIVEMQ_PLATFORM_OPERATOR_INIT_IMAGE
+            value: "test-repo/test-init-image:test-tag@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+  - it: with image digest overrides and empty tag
+    set:
+      image.repository: test-repo
+      image.name: test-image
+      image.tag: ""
+      image.digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+      image.initImageName: test-init-image
+      image.initImageDigest: sha256:2222222222222222222222222222222222222222222222222222222222222222
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "test-repo/test-image@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HIVEMQ_PLATFORM_OPERATOR_INIT_IMAGE
+            value: "test-repo/test-init-image@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+  - it: with empty image repository, validation fails
+    set:
+      image.repository: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: '`repository` is required to build the HiveMQ Platform Operator container image reference'
+
+  - it: with empty image name, validation fails
+    set:
+      image.name: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: '`name` is required to build the HiveMQ Platform Operator container image reference'
+
+  - it: with empty image init image name, validation fails
+    set:
+      image.initImageName: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: '`name` is required to build the HiveMQ Platform Operator container image reference'
+
+  - it: with invalid image digest type, schema validation fails
+    set:
+      image.digest: 123
+    asserts:
+      - failedTemplate: {}
+
+  - it: with image digest not matching OCI format, schema validation fails
+    set:
+      image.digest: not-a-valid-digest
+    asserts:
+      - failedTemplate: {}
+
+  - it: with invalid image init digest type, schema validation fails
+    set:
+      image.initImageDigest: 123
+    asserts:
+      - failedTemplate: {}
+
+  - it: with image init digest not matching OCI format, schema validation fails
+    set:
+      image.initImageDigest: not-a-valid-digest
+    asserts:
+      - failedTemplate: {}
+
   - it: with custom concurrentRollingRestartLimit, operator container EnvVar created
     set:
       concurrentRollingRestartLimit: 5

--- a/charts/hivemq-platform-operator/values.schema.json
+++ b/charts/hivemq-platform-operator/values.schema.json
@@ -135,14 +135,28 @@
       "type" : "object"
     },
     "image" : {
+      "description" : "Defines which container image is used for the operator. Images are available on DockerHub as multi-architecture images supporting ARM and AMD hardware.",
       "properties" : {
+        "digest" : {
+          "description" : "Optional image digest for the HiveMQ Platform Operator image. When set, the rendered image reference is `<repository>/<name>:<tag>@<digest>`, or `<repository>/<name>@<digest>` when `tag` is empty. Must be in the form `<algorithm>:<hex>`, e.g. `sha256:<64 hex chars>`.",
+          "pattern" : "^$|^[a-z0-9]+(?:[+._-][a-z0-9]+)*:[0-9a-fA-F]{32,}$",
+          "type" : "string"
+        },
+        "initImageDigest" : {
+          "description" : "Optional image digest for the HiveMQ Platform Operator init image. When set, the rendered image reference is `<repository>/<initImageName>:<tag>@<initImageDigest>`, or `<repository>/<initImageName>@<initImageDigest>` when `tag` is empty. Must be in the form `<algorithm>:<hex>`, e.g. `sha256:<64 hex chars>`.",
+          "pattern" : "^$|^[a-z0-9]+(?:[+._-][a-z0-9]+)*:[0-9a-fA-F]{32,}$",
+          "type" : "string"
+        },
         "initImageName" : {
+          "description" : "The name of the HiveMQ Platform Operator initContainer image to be pulled.",
           "type" : "string"
         },
         "name" : {
+          "description" : "The name of the HiveMQ Platform Operator container image to be pulled.",
           "type" : "string"
         },
         "pullPolicy" : {
+          "description" : "The Kubernetes imagePullPolicy setting that is used. The default setting is `IfNotPresent`.",
           "enum" : [
             "IfNotPresent",
             "Never",
@@ -151,18 +165,19 @@
           "type" : "string"
         },
         "pullSecretName" : {
+          "description" : "The name of the ImagePullSecret the operator uses to authenticate against the selected repository.",
           "type" : "string"
         },
         "repository" : {
+          "description" : "The repository from which the HiveMQ Platform Operator container image is pulled.",
           "type" : "string"
         },
         "tag" : {
+          "description" : "The identifier of the HiveMQ Platform Operator container image variant to be pulled.",
           "type" : "string"
         }
       },
       "required" : [
-        "repository",
-        "name",
         "tag",
         "initImageName"
       ],

--- a/charts/hivemq-platform-operator/values.yaml
+++ b/charts/hivemq-platform-operator/values.yaml
@@ -6,7 +6,15 @@ image:
   repository: docker.io/hivemq
   name: hivemq-platform-operator
   tag: 2.1.4
+  # Optional digest for the HiveMQ Platform Operator image.
+  # If set, the rendered image reference is <repository>/<name>:<tag>@<digest>,
+  # or <repository>/<name>@<digest> when tag is empty.
+  digest: ""
   initImageName: hivemq-platform-operator-init
+  # Optional digest for the HiveMQ Platform Operator Init image.
+  # If set, the rendered image reference is <repository>/<initImageName>:<tag>@<initImageDigest>,
+  # or <repository>/<initImageName>@<initImageDigest> when tag is empty.
+  initImageDigest: ""
   pullPolicy: IfNotPresent
   pullSecretName: ""
 

--- a/charts/hivemq-platform/templates/_helpers.tpl
+++ b/charts/hivemq-platform/templates/_helpers.tpl
@@ -22,6 +22,27 @@ Usage: {{ include "hivemq-platform.name" (dict "name" "my-custom-name" "releaseN
 {{- end -}}
 
 {{/*
+Builds a container image reference.
+Params:
+- repository: The image repository path.
+- name:       The image name.
+- tag:        The image tag.
+- digest:     The optional image digest.
+Usage: {{ include "hivemq-platform.image-reference" (dict "repository" .Values.image.repository "name" .Values.image.name "tag" .Values.image.tag "digest" .Values.image.digest) }}
+*/}}
+{{- define "hivemq-platform.image-reference" -}}
+{{- if not .repository -}}
+{{- fail (printf "\n`repository` is required to build the HiveMQ Platform container image reference.") -}}
+{{- end -}}
+{{- if not .name -}}
+{{- fail (printf "\n`name` is required to build the HiveMQ Platform container image reference.") -}}
+{{- end -}}
+{{- printf "%s/%s" .repository .name -}}
+{{- with .tag }}:{{ . }}{{- end -}}
+{{- with .digest }}@{{ . }}{{- end -}}
+{{- end -}}
+
+{{/*
 Returns a string containing the HiveMQ configuration ConfigMap or Secret name, depending on the `.Values.config.create` value.
 It will return the default ConfigMap or Secret name for the HiveMQ Platform configuration or will reuse the ConfigMap or Secret name defined in the `.Values.config.name` if present.
 Otherwise, an validation error will displayed.

--- a/charts/hivemq-platform/templates/hivemq-custom-resource.yml
+++ b/charts/hivemq-platform/templates/hivemq-custom-resource.yml
@@ -192,7 +192,7 @@ spec:
                       key: {{ .passwordKey }}
                 {{- end }}
                 {{- end }}
-              image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+              image: "{{ include "hivemq-platform.image-reference" (dict "repository" .Values.image.repository "name" .Values.image.name "tag" .Values.image.tag "digest" .Values.image.digest) }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               ports:
                 {{- $containerPortNameList := list }}

--- a/charts/hivemq-platform/tests/hivemq_platform_test.yaml
+++ b/charts/hivemq-platform/tests/hivemq_platform_test.yaml
@@ -115,6 +115,54 @@ tests:
           path: spec.statefulSet.spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent
 
+  - it: with image digest override, container image rendered with tag and digest
+    set:
+      image.repository: test-repo
+      image.name: test-image
+      image.tag: snapshot
+      image.digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+    asserts:
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].image
+          value: "test-repo/test-image:snapshot@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+  - it: with image digest override and empty tag, container image rendered with digest only
+    set:
+      image.repository: test-repo
+      image.name: test-image
+      image.tag: ""
+      image.digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+    asserts:
+      - equal:
+          path: spec.statefulSet.spec.template.spec.containers[0].image
+          value: "test-repo/test-image@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+  - it: with empty image repository, validation fails
+    set:
+      image.repository: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: '`repository` is required to build the HiveMQ Platform container image reference'
+
+  - it: with empty image name, validation fails
+    set:
+      image.name: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: '`name` is required to build the HiveMQ Platform container image reference'
+
+  - it: with invalid image digest type, schema validation fails
+    set:
+      image.digest: 123
+    asserts:
+      - failedTemplate: {}
+
+  - it: with image digest not matching OCI format, schema validation fails
+    set:
+      image.digest: not-a-valid-digest
+    asserts:
+      - failedTemplate: {}
+
   - it: with override init containers
     set:
       config.overrideInitContainers: |-

--- a/charts/hivemq-platform/values.schema.json
+++ b/charts/hivemq-platform/values.schema.json
@@ -718,11 +718,19 @@
       "type" : "object"
     },
     "image" : {
+      "description" : "Configures the container image details for the HiveMQ Platform.",
       "properties" : {
+        "digest" : {
+          "description" : "Optional image digest for the HiveMQ Platform image. When set, the rendered image reference is `<repository>/<name>:<tag>@<digest>`, or `<repository>/<name>@<digest>` when `tag` is empty. Must be in the form `<algorithm>:<hex>`, e.g. `sha256:<64 hex chars>`.",
+          "pattern" : "^$|^[a-z0-9]+(?:[+._-][a-z0-9]+)*:[0-9a-fA-F]{32,}$",
+          "type" : "string"
+        },
         "name" : {
+          "description" : "The name of the HiveMQ Platform container image to be used.",
           "type" : "string"
         },
         "pullPolicy" : {
+          "description" : "Defines the imagePullPolicy that Kubernetes uses to download the HiveMQ Platform container image. Possible values: `IfNotPresent`, `Never`, or `Always`. Default: `IfNotPresent`.",
           "type" : "string",
           "enum" : [
             "Always",
@@ -731,19 +739,18 @@
           ]
         },
         "pullSecretName" : {
+          "description" : "Configures the name of the ImagePullSecret Kubernetes uses to authenticate against the selected repository. Applies to all containers in HiveMQ Platform pods including init and sidecar containers.",
           "type" : "string"
         },
         "repository" : {
+          "description" : "Configures from which repository the HiveMQ Platform image is pulled.",
           "type" : "string"
         },
         "tag" : {
+          "description" : "The identifier of the HiveMQ Platform container image variant to be pulled.",
           "type" : "string"
         }
       },
-      "required" : [
-        "name",
-        "repository"
-      ],
       "type" : "object"
     },
     "license" : {

--- a/charts/hivemq-platform/values.yaml
+++ b/charts/hivemq-platform/values.yaml
@@ -6,6 +6,10 @@ image:
   repository: docker.io/hivemq
   name: hivemq4
   tag: 4.52.0
+  # Optional digest for the HiveMQ Platform image.
+  # If set, the rendered image reference is <repository>/<name>:<tag>@<digest>,
+  # or <repository>/<name>@<digest> when tag is empty.
+  digest: ""
   pullPolicy: IfNotPresent
   pullSecretName: ""
 


### PR DESCRIPTION
## Summary
- Adds first-class image digest pinning to both the `hivemq-platform-operator` and `hivemq-platform` charts.
- Recreates external contribution #942 from @sjentzsch as a maintainer-managed branch so the review concerns are folded into the feat commit; @sjentzsch's authorship is preserved.

### hivemq-platform-operator chart
- New optional `image.digest` and `image.initImageDigest` values.
- Schema entries with OCI-format pattern (`<algorithm>:<hex>`) validation, plus descriptions matching the public docs.
- New `hivemq-platform-operator.image-reference` helper that renders `<repo>/<name>[:tag][@digest]`, called from the deployment template for both operator and init images.

### hivemq-platform chart
- New optional `image.digest` value.
- Schema entry with the same OCI-format pattern and descriptions matching the public docs.

Closes #937.
Supersedes #942.