### PR TITLE
Add Develocity build scans and test retry for integration tests

### DIFF
--- a/.github/workflows/edge-integration-tests.yml
+++ b/.github/workflows/edge-integration-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 env:
   check-prefix: 'Test #'
-  split-total: 1
+  split-total: 2
   CI_RUN: true
 jobs:
   generate-split-index-json:

--- a/.github/workflows/edge-integration-tests.yml
+++ b/.github/workflows/edge-integration-tests.yml
@@ -40,12 +40,21 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:cicd-harvester
+
       - name: Warmup Gradle cache
         if: steps.setup-java.outputs.cache-hit == 'false'
         working-directory: helm-charts
         env:
           ORG_GRADLE_PROJECT_dockerHubUsername: ${{ secrets.DOCKER_USERNAME }}
           ORG_GRADLE_PROJECT_dockerHubPassword: ${{ secrets.DOCKER_TOKEN }}
+          DEVELOCITY_SERVER_URL: ${{ secrets.DEVELOCITY_SERVER_URL }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: ./gradlew :tests-hivemq-edge:integrationTestPrepare
 
   run-integration-tests:
@@ -54,7 +63,7 @@ jobs:
     needs:
       - generate-split-index-json
       - compile-integration-test
-    timeout-minutes: 25
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -89,11 +98,20 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:cicd-harvester
+
       - name: Compile integration tests
         working-directory: helm-charts
         env:
           ORG_GRADLE_PROJECT_dockerHubUsername: ${{ secrets.DOCKER_USERNAME }}
           ORG_GRADLE_PROJECT_dockerHubPassword: ${{ secrets.DOCKER_TOKEN }}
+          DEVELOCITY_SERVER_URL: ${{ secrets.DEVELOCITY_SERVER_URL }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: ./gradlew :tests-hivemq-edge:integrationTestPrepare
 
       - name: Split tests
@@ -117,6 +135,8 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_TOKEN }}
           K8S_VERSION_TYPE: ${{ matrix.k8s-version-type }}
+          DEVELOCITY_SERVER_URL: ${{ secrets.DEVELOCITY_SERVER_URL }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: ./gradlew :tests-hivemq-edge:integrationTest ${{ steps.split-tests.outputs.test-suite }}
 
       - name: Upload test results

--- a/.github/workflows/platform-integration-tests.yml
+++ b/.github/workflows/platform-integration-tests.yml
@@ -50,12 +50,21 @@ jobs:
         with:
           cache-disabled: true
 
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:cicd-harvester
+
       - name: Warmup Gradle cache
         if: steps.setup-java.outputs.cache-hit == 'false'
         working-directory: helm-charts
         env:
           ORG_GRADLE_PROJECT_dockerHubUsername: ${{ secrets.DOCKER_USERNAME }}
           ORG_GRADLE_PROJECT_dockerHubPassword: ${{ secrets.DOCKER_TOKEN }}
+          DEVELOCITY_SERVER_URL: ${{ secrets.DEVELOCITY_SERVER_URL }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: ./gradlew :tests-hivemq-platform-operator:integrationTestPrepare
 
   run-integration-tests:
@@ -64,7 +73,7 @@ jobs:
     needs:
       - generate-split-index-json
       - compile-integration-test
-    timeout-minutes: 25
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -110,12 +119,21 @@ jobs:
         with:
           cache-disabled: true
 
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:cicd-harvester
+
       - name: Compile integration tests
         working-directory: helm-charts
         env:
           ORG_GRADLE_PROJECT_dockerHubUsername: ${{ secrets.DOCKER_USERNAME }}
           ORG_GRADLE_PROJECT_dockerHubPassword: ${{ secrets.DOCKER_TOKEN }}
           K8S_VERSION_TYPE: ${{ matrix.k8s-version-type }}
+          DEVELOCITY_SERVER_URL: ${{ secrets.DEVELOCITY_SERVER_URL }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: ./gradlew :tests-hivemq-platform-operator:integrationTestPrepare
 
       - name: Split tests
@@ -139,6 +157,8 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_TOKEN }}
           K8S_VERSION_TYPE: ${{ matrix.k8s-version-type }}
+          DEVELOCITY_SERVER_URL: ${{ secrets.DEVELOCITY_SERVER_URL }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: ./gradlew :tests-hivemq-platform-operator:integrationTest ${{ steps.split-tests.outputs.test-suite }}
 
       - name: Upload test results

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,18 @@
+plugins {
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "2.6.0"
+    id("com.gradle.develocity") version "4.4.3"
+}
+
 rootProject.name = "helm-charts"
 
 includeBuild("github-release-note-updater")
 includeBuild("tests-hivemq-platform-operator")
 includeBuild("tests-hivemq-edge")
+
+develocity {
+    server = System.getenv("DEVELOCITY_SERVER_URL")
+    buildScan {
+        publishing.onlyIf { System.getenv("CI_RUN") == "true" }
+        uploadInBackground = false
+    }
+}

--- a/tests-hivemq-edge/build.gradle.kts
+++ b/tests-hivemq-edge/build.gradle.kts
@@ -82,6 +82,13 @@ testing {
                     reports {
                         junitXml.isOutputPerTestCase = true
                     }
+                    if (System.getenv("CI_RUN") == "true") {
+                        develocity.testRetry {
+                            maxRetries = 2
+                            maxFailures = 6
+                            failOnPassedAfterRetry = false
+                        }
+                    }
                     maxHeapSize = "3g"
                 }
             }

--- a/tests-hivemq-edge/settings.gradle.kts
+++ b/tests-hivemq-edge/settings.gradle.kts
@@ -1,1 +1,14 @@
+plugins {
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "2.6.0"
+    id("com.gradle.develocity") version "4.4.3"
+}
+
 rootProject.name = "tests-hivemq-edge"
+
+develocity {
+    server = System.getenv("DEVELOCITY_SERVER_URL")
+    buildScan {
+        publishing.onlyIf { System.getenv("CI_RUN") == "true" }
+        uploadInBackground = false
+    }
+}

--- a/tests-hivemq-platform-operator/build.gradle.kts
+++ b/tests-hivemq-platform-operator/build.gradle.kts
@@ -94,6 +94,13 @@ testing {
                     reports {
                         junitXml.isOutputPerTestCase = true
                     }
+                    if (System.getenv("CI_RUN") == "true") {
+                        develocity.testRetry {
+                            maxRetries = 2
+                            maxFailures = 6
+                            failOnPassedAfterRetry = false
+                        }
+                    }
                     maxHeapSize = "3g"
                 }
             }

--- a/tests-hivemq-platform-operator/settings.gradle.kts
+++ b/tests-hivemq-platform-operator/settings.gradle.kts
@@ -1,4 +1,17 @@
+plugins {
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "2.6.0"
+    id("com.gradle.develocity") version "4.4.3"
+}
+
 rootProject.name = "tests-hivemq-platform-operator"
+
+develocity {
+    server = System.getenv("DEVELOCITY_SERVER_URL")
+    buildScan {
+        publishing.onlyIf { System.getenv("CI_RUN") == "true" }
+        uploadInBackground = false
+    }
+}
 
 if (file("../../hivemq-platform-operator/hivemq-platform-operator-init").exists()) {
     includeBuild("../../hivemq-platform-operator/hivemq-platform-operator-init")


### PR DESCRIPTION
Apply the Develocity and common-custom-user-data plugins in the root build and the tests-hivemq-edge and tests-hivemq-platform-operator included builds, and publish build scans on CI to the server from DEVELOCITY_SERVER_URL. Connect to Tailscale in the edge and platform integration-test jobs so the runners can reach the Develocity endpoint. Enable test retry on CI to surface flaky tests separately from real failures: max 20 failures for the edge tests (run together) and max 6 for the platform operator tests (run in 25 splits).