### PR TITLE
Bump Helm to 3.21.2

### DIFF
--- a/.github/workflows/edge-smoke-test.yml
+++ b/.github/workflows/edge-smoke-test.yml
@@ -14,7 +14,7 @@ jobs:
           - helm-label: 'minimum'
             helm-version: 'v3.10.0'
           - helm-label: 'latest-3'
-            helm-version: 'v3.21.1'
+            helm-version: 'v3.21.2'
           - helm-label: 'latest-4'
             helm-version: 'v4.2.2'
     steps:

--- a/.github/workflows/platform-smoke-test.yml
+++ b/.github/workflows/platform-smoke-test.yml
@@ -15,7 +15,7 @@ jobs:
           - helm-label: 'minimum'
             helm-version: 'v3.10.0'
           - helm-label: 'latest-3'
-            helm-version: 'v3.21.1'
+            helm-version: 'v3.21.2'
           - helm-label: 'latest-4'
             helm-version: 'v4.2.2'
     steps:


### PR DESCRIPTION
## Summary

- Bumps the smoke-test `latest-3` matrix entries to `v3.21.2` in `edge-smoke-test.yml` and `platform-smoke-test.yml`.
- No `.helm-version` change (v4 line already pinned at `v4.2.2`, the latest v4).
- No `manifests/` regeneration needed (local Helm already matches the v4 pin, so no rendered diff).

Keeps the v3 smoke-test row tracking the latest v3 patch so regressions on the v3 line surface in CI.