### PR TITLE
Fail fast on stalled K3s containerd runtime

### DIFF
--- a/tests-hivemq-edge/src/integrationTest/java/com/hivemq/helmcharts/testcontainer/HelmChartContainer.java
+++ b/tests-hivemq-edge/src/integrationTest/java/com/hivemq/helmcharts/testcontainer/HelmChartContainer.java
@@ -67,6 +67,7 @@ public class HelmChartContainer extends K3sContainer {
     private final @NotNull Map<String, Watch> watches = new ConcurrentHashMap<>();
     private final @NotNull Map<String, LogWatch> logWatches = new ConcurrentHashMap<>();
     private final @NotNull LogWaiterUtil logWaiter = new LogWaiterUtil();
+    private final @NotNull K3sRuntimeStallDetector stallDetector = new K3sRuntimeStallDetector();
 
     private @Nullable KubernetesClient client;
 
@@ -84,6 +85,7 @@ public class HelmChartContainer extends K3sContainer {
         super.withStartupCheckStrategy(new K3sReadyStartupCheckStrategy(this));
         super.withLogConsumer(new K3sLogConsumer(LOG).withPrefix(LOG_PREFIX_K3S).withDebugging(withK3sDebugging));
         super.withLogConsumer(outputFrame -> logWaiter.accept(LOG_PREFIX_K3S, outputFrame.getUtf8String().trim()));
+        super.withLogConsumer(outputFrame -> stallDetector.accept(outputFrame.getUtf8String()));
         final var k3sCommands = new ArrayList<>(List.of("server",
                 "--etcd-arg=unsafe-no-fsync",
                 "--etcd-arg=snapshot-count=10000",

--- a/tests-hivemq-edge/src/integrationTest/java/com/hivemq/helmcharts/testcontainer/K3sRuntimeStallDetector.java
+++ b/tests-hivemq-edge/src/integrationTest/java/com/hivemq/helmcharts/testcontainer/K3sRuntimeStallDetector.java
@@ -1,0 +1,168 @@
+package com.hivemq.helmcharts.testcontainer;
+
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.IntConsumer;
+import java.util.function.LongSupplier;
+
+/**
+ * Watches the K3s container log stream for a stalled containerd runtime and hard-kills the JVM when detected.
+ * <p>
+ * When containerd inside the K3s container stalls (observed as {@code StopContainer ... DeadlineExceeded}), it leaks
+ * the sandbox name reservation and never recovers: every following {@code RunPodSandbox} fails with
+ * {@code failed to reserve sandbox name ... is reserved for <id>}. Pods never reach Ready, the test blocks in a
+ * fabric8 watch / Awaitility retry loop that does not honour {@link Thread#interrupt()}, and JUnit's interrupt-based
+ * {@code @Timeout} can therefore never fire. The test hangs until the CI step is force-killed at the 30-minute limit.
+ * <p>
+ * The runtime cannot self-heal from this state and the trigger (host CPU/IO starvation on the shared runner) is out of
+ * our control. The only remaining lever is to fail fast: once the unrecoverable signature repeats past a threshold
+ * within a sliding window, terminate the JVM with {@link Runtime#halt(int)} so the build fails in seconds instead of
+ * burning the full step timeout. {@code halt} is used over {@code System.exit} on purpose: shutdown hooks would block
+ * on the same stalled runtime.
+ */
+class K3sRuntimeStallDetector implements Consumer<String> {
+
+    static final int EXIT_CODE = 66;
+    static final int THRESHOLD = 30;
+    static final @NotNull Duration WINDOW = Duration.ofMinutes(2);
+    static final long WINDOW_NANOS = WINDOW.toNanos();
+
+    private static final @NotNull String STALL_MARKER = "failed to reserve sandbox name";
+
+    // resolved against the Gradle test worker working directory (the module project dir), matching where Gradle itself
+    // writes its reports, so the CI dorny/test-reporter step picks it up
+    private static final @NotNull String REPORT_CLASS_NAME = K3sRuntimeStallDetector.class.getName();
+    private static final @NotNull Path REPORT_FILE =
+            Path.of("build", "test-results", "integrationTest", "TEST-" + REPORT_CLASS_NAME + ".xml");
+
+    private static final @NotNull Logger LOG = LoggerFactory.getLogger(K3sRuntimeStallDetector.class);
+
+    private final @NotNull Deque<Long> hits = new ArrayDeque<>();
+    private final @NotNull AtomicBoolean halted = new AtomicBoolean();
+
+    // testcontainers delivers frames from a single docker log-stream thread, so the residual tail needs no guarding
+    private @NotNull String residual = "";
+
+    private final @NotNull IntConsumer exitHandler;
+    private final @NotNull Path reportFile;
+    private final @NotNull LongSupplier nanoClock;
+
+    K3sRuntimeStallDetector() {
+        this(code -> Runtime.getRuntime().halt(code), REPORT_FILE, System::nanoTime);
+    }
+
+    // package-private so the unit test can inject the exit action, report path, and clock without killing the JVM
+    K3sRuntimeStallDetector(
+            final @NotNull IntConsumer exitHandler,
+            final @NotNull Path reportFile,
+            final @NotNull LongSupplier nanoClock) {
+        this.exitHandler = exitHandler;
+        this.reportFile = reportFile;
+        this.nanoClock = nanoClock;
+    }
+
+    @Override
+    public void accept(final @NotNull String frame) {
+        // testcontainers may split a log line across frames or batch several into one; join with the retained tail and
+        // count every occurrence so a boundary split is not missed and a batched frame is not undercounted
+        final var text = residual + frame;
+        final var tailLength = STALL_MARKER.length() - 1;
+        residual = text.length() > tailLength ? text.substring(text.length() - tailLength) : text;
+        final var occurrences = countOccurrences(text);
+        if (occurrences == 0) {
+            return;
+        }
+        // nanoTime() is monotonic, so the sliding window is immune to wall-clock jumps (NTP, host time changes)
+        final var now = nanoClock.getAsLong();
+        final var count = new AtomicInteger();
+        synchronized (hits) {
+            for (var i = 0; i < occurrences; i++) {
+                hits.addLast(now);
+            }
+            while (!hits.isEmpty() && hits.peekFirst() < now - WINDOW_NANOS) {
+                hits.pollFirst();
+            }
+            count.set(hits.size());
+        }
+        if (count.get() < THRESHOLD || !halted.compareAndSet(false, true)) {
+            return;
+        }
+        LOG.error("""
+                        ============================================================
+                        K3s containerd runtime is stalled and cannot recover:
+                        '{}' repeated {} times within {} seconds.
+                        Hard-killing the JVM (exit code {}) to fail fast instead of \
+                        hanging until the CI step timeout.
+                        ============================================================""",
+                STALL_MARKER,
+                count.get(),
+                WINDOW.toSeconds(),
+                EXIT_CODE);
+        // halt() skips JUnit's lifecycle, so the stalled test never gets a report; write a synthetic one first, so the
+        // failure surfaces as a clear annotation instead of a silent worker crash
+        writeStallReport(count.get());
+        // halt() runs no shutdown hooks and logback may not flush its appenders, so print to stderr directly to keep the
+        // banner in the build log
+        System.err.printf(
+                "K3s containerd runtime stalled: '%s' repeated %d times within %d seconds; hard-killing JVM (exit code %d).%n",
+                STALL_MARKER,
+                count.get(),
+                WINDOW.toSeconds(),
+                EXIT_CODE);
+        System.err.flush();
+        // default exitHandler is halt() not exit(): exit() runs the testcontainers shutdown hook, which docker-stops the
+        // stalled K3s container and blocks on the same stalled containerd, re-hanging the very thing we are escaping.
+        // Ryuk reaps the abandoned container, so skipping the hook leaks nothing.
+        exitHandler.accept(EXIT_CODE);
+    }
+
+    private static int countOccurrences(final @NotNull String text) {
+        var count = 0;
+        var index = text.indexOf(STALL_MARKER);
+        while (index >= 0) {
+            count++;
+            index = text.indexOf(STALL_MARKER, index + STALL_MARKER.length());
+        }
+        return count;
+    }
+
+    private void writeStallReport(final int count) {
+        final var message =
+                "K3s containerd runtime stalled: '%s' repeated %d times within %d seconds. The runtime cannot recover; the JVM was hard-killed (exit code %d) to fail fast instead of hanging until the CI step timeout.".formatted(
+                        STALL_MARKER,
+                        count,
+                        WINDOW.toSeconds(),
+                        EXIT_CODE);
+        final var escaped = escapeXml(message);
+        final var xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <testsuite name="%s" tests="1" failures="0" errors="1" skipped="0" time="0">
+                  <testcase classname="%s" name="k3sContainerdRuntimeStalled" time="0">
+                    <error message="%s">%s</error>
+                  </testcase>
+                </testsuite>
+                """.formatted(REPORT_CLASS_NAME, REPORT_CLASS_NAME, escaped, escaped);
+        try {
+            Files.createDirectories(reportFile.getParent());
+            Files.writeString(reportFile, xml);
+            LOG.error("Wrote synthetic JUnit report for the K3s runtime stall to {}", reportFile.toAbsolutePath());
+        } catch (final IOException e) {
+            LOG.error("Could not write synthetic JUnit report for the K3s runtime stall", e);
+        }
+    }
+
+    private static @NotNull String escapeXml(final @NotNull String value) {
+        return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+    }
+}

--- a/tests-hivemq-edge/src/integrationTest/java/com/hivemq/helmcharts/testcontainer/K3sRuntimeStallDetectorTest.java
+++ b/tests-hivemq-edge/src/integrationTest/java/com/hivemq/helmcharts/testcontainer/K3sRuntimeStallDetectorTest.java
@@ -1,0 +1,139 @@
+package com.hivemq.helmcharts.testcontainer;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hivemq.helmcharts.testcontainer.K3sRuntimeStallDetector.THRESHOLD;
+import static com.hivemq.helmcharts.testcontainer.K3sRuntimeStallDetector.WINDOW_NANOS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class K3sRuntimeStallDetectorTest {
+
+    private static final @NotNull String STALL_LINE =
+            "RunPodSandbox from runtime service failed: failed to reserve sandbox name \"x\" is reserved for \"y\"\n";
+
+    @TempDir
+    private @NotNull Path tmp;
+
+    private final @NotNull AtomicInteger exitCalls = new AtomicInteger();
+    private final @NotNull AtomicInteger lastExitCode = new AtomicInteger(-1);
+    private final @NotNull AtomicLong clock = new AtomicLong();
+
+    @Test
+    @Timeout(10)
+    void accept_belowThreshold_doesNotExit() {
+        final var detector = newDetector();
+        for (var i = 0; i < THRESHOLD - 1; i++) {
+            detector.accept(STALL_LINE);
+        }
+        assertThat(exitCalls).hasValue(0);
+        assertThat(lastExitCode).hasValue(-1);
+    }
+
+    @Test
+    @Timeout(10)
+    void accept_atThreshold_exitsOnceWithExitCode() {
+        final var detector = newDetector();
+        for (var i = 0; i < THRESHOLD; i++) {
+            detector.accept(STALL_LINE);
+        }
+        assertThat(exitCalls).hasValue(1);
+        assertThat(lastExitCode).hasValue(K3sRuntimeStallDetector.EXIT_CODE);
+    }
+
+    @Test
+    @Timeout(10)
+    void accept_pastThreshold_exitsOnlyOnce() {
+        final var detector = newDetector();
+        for (var i = 0; i < THRESHOLD * 3; i++) {
+            detector.accept(STALL_LINE);
+        }
+        assertThat(exitCalls).hasValue(1);
+        assertThat(lastExitCode).hasValue(K3sRuntimeStallDetector.EXIT_CODE);
+    }
+
+    @Test
+    @Timeout(10)
+    void accept_nonStallFrames_areIgnored() {
+        final var detector = newDetector();
+        for (var i = 0; i < 1_000; i++) {
+            detector.accept("level=info msg=\"reconciling pod\" healthy\n");
+        }
+        assertThat(exitCalls).hasValue(0);
+        assertThat(lastExitCode).hasValue(-1);
+    }
+
+    @Test
+    @Timeout(10)
+    void accept_markerSplitAcrossFrames_isCounted() {
+        final var detector = newDetector();
+        // each stall line is delivered as two frames split in the middle of the marker
+        for (var i = 0; i < THRESHOLD; i++) {
+            detector.accept("RunPodSandbox failed: failed to reserve ");
+            detector.accept("sandbox name \"x\" is reserved for \"y\"\n");
+        }
+        assertThat(exitCalls).hasValue(1);
+        assertThat(lastExitCode).hasValue(K3sRuntimeStallDetector.EXIT_CODE);
+    }
+
+    @Test
+    @Timeout(10)
+    void accept_multipleMarkersInOneFrame_areCounted() {
+        final var detector = newDetector();
+        detector.accept(STALL_LINE.repeat(THRESHOLD));
+        assertThat(exitCalls).hasValue(1);
+        assertThat(lastExitCode).hasValue(K3sRuntimeStallDetector.EXIT_CODE);
+    }
+
+    @Test
+    @Timeout(10)
+    void accept_hitsOlderThanWindow_arePruned() {
+        final var detector = newDetector();
+        // 29 hits, then jump past the window so they all expire
+        for (var i = 0; i < THRESHOLD - 1; i++) {
+            detector.accept(STALL_LINE);
+        }
+        clock.addAndGet(WINDOW_NANOS + 1);
+        // another 29: without pruning the running total would be 58 and trip; with pruning only these 29 remain
+        for (var i = 0; i < THRESHOLD - 1; i++) {
+            detector.accept(STALL_LINE);
+        }
+        assertThat(exitCalls).hasValue(0);
+        assertThat(lastExitCode).hasValue(-1);
+    }
+
+    @Test
+    @Timeout(10)
+    void accept_atThreshold_writesSyntheticJUnitReport() throws Exception {
+        // nested path proves the detector creates the parent directories
+        final var reportFile = tmp.resolve("nested").resolve("TEST-stall.xml");
+        final var detector = newDetector(reportFile);
+        for (var i = 0; i < THRESHOLD; i++) {
+            detector.accept(STALL_LINE);
+        }
+        assertThat(reportFile).exists();
+        final var xml = Files.readString(reportFile);
+        assertThat(xml).contains("<testcase")
+                .contains("name=\"k3sContainerdRuntimeStalled\"")
+                .contains("<error message=")
+                .contains("K3s containerd runtime stalled");
+    }
+
+    private @NotNull K3sRuntimeStallDetector newDetector() {
+        return newDetector(tmp.resolve("report.xml"));
+    }
+
+    private @NotNull K3sRuntimeStallDetector newDetector(final @NotNull Path reportFile) {
+        return new K3sRuntimeStallDetector(code -> {
+            exitCalls.incrementAndGet();
+            lastExitCode.set(code);
+        }, reportFile, clock::get);
+    }
+}

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/testcontainer/HelmChartContainer.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/testcontainer/HelmChartContainer.java
@@ -78,6 +78,7 @@ public class HelmChartContainer extends K3sContainer {
     private final @NotNull Map<String, Watch> watches = new ConcurrentHashMap<>();
     private final @NotNull Map<String, LogWatch> logWatches = new ConcurrentHashMap<>();
     private final @NotNull LogWaiterUtil logWaiter = new LogWaiterUtil();
+    private final @NotNull K3sRuntimeStallDetector stallDetector = new K3sRuntimeStallDetector();
     private final @NotNull ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
 
     private @Nullable KubernetesClient client;
@@ -107,6 +108,7 @@ public class HelmChartContainer extends K3sContainer {
         super.withStartupCheckStrategy(new K3sReadyStartupCheckStrategy(this));
         super.withLogConsumer(new K3sLogConsumer(LOG).withPrefix(LOG_PREFIX_K3S).withDebugging(withK3sDebugging));
         super.withLogConsumer(outputFrame -> logWaiter.accept(LOG_PREFIX_K3S, outputFrame.getUtf8String().trim()));
+        super.withLogConsumer(outputFrame -> stallDetector.accept(outputFrame.getUtf8String()));
         final var k3sCommands = new ArrayList<>(List.of("server",
                 "--etcd-arg=unsafe-no-fsync",
                 "--etcd-arg=snapshot-count=10000",

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/testcontainer/K3sRuntimeStallDetector.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/testcontainer/K3sRuntimeStallDetector.java
@@ -1,0 +1,168 @@
+package com.hivemq.helmcharts.testcontainer;
+
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.IntConsumer;
+import java.util.function.LongSupplier;
+
+/**
+ * Watches the K3s container log stream for a stalled containerd runtime and hard-kills the JVM when detected.
+ * <p>
+ * When containerd inside the K3s container stalls (observed as {@code StopContainer ... DeadlineExceeded}), it leaks
+ * the sandbox name reservation and never recovers: every following {@code RunPodSandbox} fails with
+ * {@code failed to reserve sandbox name ... is reserved for <id>}. Pods never reach Ready, the test blocks in a
+ * fabric8 watch / Awaitility retry loop that does not honour {@link Thread#interrupt()}, and JUnit's interrupt-based
+ * {@code @Timeout} can therefore never fire. The test hangs until the CI step is force-killed at the 30-minute limit.
+ * <p>
+ * The runtime cannot self-heal from this state and the trigger (host CPU/IO starvation on the shared runner) is out of
+ * our control. The only remaining lever is to fail fast: once the unrecoverable signature repeats past a threshold
+ * within a sliding window, terminate the JVM with {@link Runtime#halt(int)} so the build fails in seconds instead of
+ * burning the full step timeout. {@code halt} is used over {@code System.exit} on purpose: shutdown hooks would block
+ * on the same stalled runtime.
+ */
+class K3sRuntimeStallDetector implements Consumer<String> {
+
+    static final int EXIT_CODE = 66;
+    static final int THRESHOLD = 30;
+    static final @NotNull Duration WINDOW = Duration.ofMinutes(2);
+    static final long WINDOW_NANOS = WINDOW.toNanos();
+
+    private static final @NotNull String STALL_MARKER = "failed to reserve sandbox name";
+
+    // resolved against the Gradle test worker working directory (the module project dir), matching where Gradle itself
+    // writes its reports, so the CI dorny/test-reporter step picks it up
+    private static final @NotNull String REPORT_CLASS_NAME = K3sRuntimeStallDetector.class.getName();
+    private static final @NotNull Path REPORT_FILE =
+            Path.of("build", "test-results", "integrationTest", "TEST-" + REPORT_CLASS_NAME + ".xml");
+
+    private static final @NotNull Logger LOG = LoggerFactory.getLogger(K3sRuntimeStallDetector.class);
+
+    private final @NotNull Deque<Long> hits = new ArrayDeque<>();
+    private final @NotNull AtomicBoolean halted = new AtomicBoolean();
+
+    // testcontainers delivers frames from a single docker log-stream thread, so the residual tail needs no guarding
+    private @NotNull String residual = "";
+
+    private final @NotNull IntConsumer exitHandler;
+    private final @NotNull Path reportFile;
+    private final @NotNull LongSupplier nanoClock;
+
+    K3sRuntimeStallDetector() {
+        this(code -> Runtime.getRuntime().halt(code), REPORT_FILE, System::nanoTime);
+    }
+
+    // package-private so the unit test can inject the exit action, report path, and clock without killing the JVM
+    K3sRuntimeStallDetector(
+            final @NotNull IntConsumer exitHandler,
+            final @NotNull Path reportFile,
+            final @NotNull LongSupplier nanoClock) {
+        this.exitHandler = exitHandler;
+        this.reportFile = reportFile;
+        this.nanoClock = nanoClock;
+    }
+
+    @Override
+    public void accept(final @NotNull String frame) {
+        // testcontainers may split a log line across frames or batch several into one; join with the retained tail and
+        // count every occurrence so a boundary split is not missed and a batched frame is not undercounted
+        final var text = residual + frame;
+        final var tailLength = STALL_MARKER.length() - 1;
+        residual = text.length() > tailLength ? text.substring(text.length() - tailLength) : text;
+        final var occurrences = countOccurrences(text);
+        if (occurrences == 0) {
+            return;
+        }
+        // nanoTime() is monotonic, so the sliding window is immune to wall-clock jumps (NTP, host time changes)
+        final var now = nanoClock.getAsLong();
+        final var count = new AtomicInteger();
+        synchronized (hits) {
+            for (var i = 0; i < occurrences; i++) {
+                hits.addLast(now);
+            }
+            while (!hits.isEmpty() && hits.peekFirst() < now - WINDOW_NANOS) {
+                hits.pollFirst();
+            }
+            count.set(hits.size());
+        }
+        if (count.get() < THRESHOLD || !halted.compareAndSet(false, true)) {
+            return;
+        }
+        LOG.error("""
+                        ============================================================
+                        K3s containerd runtime is stalled and cannot recover:
+                        '{}' repeated {} times within {} seconds.
+                        Hard-killing the JVM (exit code {}) to fail fast instead of \
+                        hanging until the CI step timeout.
+                        ============================================================""",
+                STALL_MARKER,
+                count.get(),
+                WINDOW.toSeconds(),
+                EXIT_CODE);
+        // halt() skips JUnit's lifecycle, so the stalled test never gets a report; write a synthetic one first, so the
+        // failure surfaces as a clear annotation instead of a silent worker crash
+        writeStallReport(count.get());
+        // halt() runs no shutdown hooks and logback may not flush its appenders, so print to stderr directly to keep the
+        // banner in the build log
+        System.err.printf(
+                "K3s containerd runtime stalled: '%s' repeated %d times within %d seconds; hard-killing JVM (exit code %d).%n",
+                STALL_MARKER,
+                count.get(),
+                WINDOW.toSeconds(),
+                EXIT_CODE);
+        System.err.flush();
+        // default exitHandler is halt() not exit(): exit() runs the testcontainers shutdown hook, which docker-stops the
+        // stalled K3s container and blocks on the same stalled containerd, re-hanging the very thing we are escaping.
+        // Ryuk reaps the abandoned container, so skipping the hook leaks nothing.
+        exitHandler.accept(EXIT_CODE);
+    }
+
+    private static int countOccurrences(final @NotNull String text) {
+        var count = 0;
+        var index = text.indexOf(STALL_MARKER);
+        while (index >= 0) {
+            count++;
+            index = text.indexOf(STALL_MARKER, index + STALL_MARKER.length());
+        }
+        return count;
+    }
+
+    private void writeStallReport(final int count) {
+        final var message =
+                "K3s containerd runtime stalled: '%s' repeated %d times within %d seconds. The runtime cannot recover; the JVM was hard-killed (exit code %d) to fail fast instead of hanging until the CI step timeout.".formatted(
+                        STALL_MARKER,
+                        count,
+                        WINDOW.toSeconds(),
+                        EXIT_CODE);
+        final var escaped = escapeXml(message);
+        final var xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <testsuite name="%s" tests="1" failures="0" errors="1" skipped="0" time="0">
+                  <testcase classname="%s" name="k3sContainerdRuntimeStalled" time="0">
+                    <error message="%s">%s</error>
+                  </testcase>
+                </testsuite>
+                """.formatted(REPORT_CLASS_NAME, REPORT_CLASS_NAME, escaped, escaped);
+        try {
+            Files.createDirectories(reportFile.getParent());
+            Files.writeString(reportFile, xml);
+            LOG.error("Wrote synthetic JUnit report for the K3s runtime stall to {}", reportFile.toAbsolutePath());
+        } catch (final IOException e) {
+            LOG.error("Could not write synthetic JUnit report for the K3s runtime stall", e);
+        }
+    }
+
+    private static @NotNull String escapeXml(final @NotNull String value) {
+        return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+    }
+}

--- a/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/testcontainer/K3sRuntimeStallDetectorTest.java
+++ b/tests-hivemq-platform-operator/src/integrationTest/java/com/hivemq/helmcharts/testcontainer/K3sRuntimeStallDetectorTest.java
@@ -1,0 +1,139 @@
+package com.hivemq.helmcharts.testcontainer;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hivemq.helmcharts.testcontainer.K3sRuntimeStallDetector.THRESHOLD;
+import static com.hivemq.helmcharts.testcontainer.K3sRuntimeStallDetector.WINDOW_NANOS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class K3sRuntimeStallDetectorTest {
+
+    private static final @NotNull String STALL_LINE =
+            "RunPodSandbox from runtime service failed: failed to reserve sandbox name \"x\" is reserved for \"y\"\n";
+
+    @TempDir
+    private @NotNull Path tmp;
+
+    private final @NotNull AtomicInteger exitCalls = new AtomicInteger();
+    private final @NotNull AtomicInteger lastExitCode = new AtomicInteger(-1);
+    private final @NotNull AtomicLong clock = new AtomicLong();
+
+    @Test
+    @Timeout(10)
+    void accept_belowThreshold_doesNotExit() {
+        final var detector = newDetector();
+        for (var i = 0; i < THRESHOLD - 1; i++) {
+            detector.accept(STALL_LINE);
+        }
+        assertThat(exitCalls).hasValue(0);
+        assertThat(lastExitCode).hasValue(-1);
+    }
+
+    @Test
+    @Timeout(10)
+    void accept_atThreshold_exitsOnceWithExitCode() {
+        final var detector = newDetector();
+        for (var i = 0; i < THRESHOLD; i++) {
+            detector.accept(STALL_LINE);
+        }
+        assertThat(exitCalls).hasValue(1);
+        assertThat(lastExitCode).hasValue(K3sRuntimeStallDetector.EXIT_CODE);
+    }
+
+    @Test
+    @Timeout(10)
+    void accept_pastThreshold_exitsOnlyOnce() {
+        final var detector = newDetector();
+        for (var i = 0; i < THRESHOLD * 3; i++) {
+            detector.accept(STALL_LINE);
+        }
+        assertThat(exitCalls).hasValue(1);
+        assertThat(lastExitCode).hasValue(K3sRuntimeStallDetector.EXIT_CODE);
+    }
+
+    @Test
+    @Timeout(10)
+    void accept_nonStallFrames_areIgnored() {
+        final var detector = newDetector();
+        for (var i = 0; i < 1_000; i++) {
+            detector.accept("level=info msg=\"reconciling pod\" healthy\n");
+        }
+        assertThat(exitCalls).hasValue(0);
+        assertThat(lastExitCode).hasValue(-1);
+    }
+
+    @Test
+    @Timeout(10)
+    void accept_markerSplitAcrossFrames_isCounted() {
+        final var detector = newDetector();
+        // each stall line is delivered as two frames split in the middle of the marker
+        for (var i = 0; i < THRESHOLD; i++) {
+            detector.accept("RunPodSandbox failed: failed to reserve ");
+            detector.accept("sandbox name \"x\" is reserved for \"y\"\n");
+        }
+        assertThat(exitCalls).hasValue(1);
+        assertThat(lastExitCode).hasValue(K3sRuntimeStallDetector.EXIT_CODE);
+    }
+
+    @Test
+    @Timeout(10)
+    void accept_multipleMarkersInOneFrame_areCounted() {
+        final var detector = newDetector();
+        detector.accept(STALL_LINE.repeat(THRESHOLD));
+        assertThat(exitCalls).hasValue(1);
+        assertThat(lastExitCode).hasValue(K3sRuntimeStallDetector.EXIT_CODE);
+    }
+
+    @Test
+    @Timeout(10)
+    void accept_hitsOlderThanWindow_arePruned() {
+        final var detector = newDetector();
+        // 29 hits, then jump past the window so they all expire
+        for (var i = 0; i < THRESHOLD - 1; i++) {
+            detector.accept(STALL_LINE);
+        }
+        clock.addAndGet(WINDOW_NANOS + 1);
+        // another 29: without pruning the running total would be 58 and trip; with pruning only these 29 remain
+        for (var i = 0; i < THRESHOLD - 1; i++) {
+            detector.accept(STALL_LINE);
+        }
+        assertThat(exitCalls).hasValue(0);
+        assertThat(lastExitCode).hasValue(-1);
+    }
+
+    @Test
+    @Timeout(10)
+    void accept_atThreshold_writesSyntheticJUnitReport() throws Exception {
+        // nested path proves the detector creates the parent directories
+        final var reportFile = tmp.resolve("nested").resolve("TEST-stall.xml");
+        final var detector = newDetector(reportFile);
+        for (var i = 0; i < THRESHOLD; i++) {
+            detector.accept(STALL_LINE);
+        }
+        assertThat(reportFile).exists();
+        final var xml = Files.readString(reportFile);
+        assertThat(xml).contains("<testcase")
+                .contains("name=\"k3sContainerdRuntimeStalled\"")
+                .contains("<error message=")
+                .contains("K3s containerd runtime stalled");
+    }
+
+    private @NotNull K3sRuntimeStallDetector newDetector() {
+        return newDetector(tmp.resolve("report.xml"));
+    }
+
+    private @NotNull K3sRuntimeStallDetector newDetector(final @NotNull Path reportFile) {
+        return new K3sRuntimeStallDetector(code -> {
+            exitCalls.incrementAndGet();
+            lastExitCode.set(code);
+        }, reportFile, clock::get);
+    }
+}


### PR DESCRIPTION
## Problem

Containerd inside the K3s testcontainer can stall (`StopContainer ... DeadlineExceeded`), leak the sandbox name reservation and never recover: every following `RunPodSandbox` fails with `failed to reserve sandbox name ... is reserved for <id>`. Pods never reach Ready and the test blocks in a fabric8 watch / Awaitility retry loop that does not honour `Thread.interrupt()`, so JUnit's interrupt-based `@Timeout` never fires. The test hangs until the CI step is force-killed at the step timeout.

The runtime cannot self-heal and the trigger (host CPU/IO starvation on the shared runner) is out of our control.

## Change

`K3sRuntimeStallDetector` watches the K3s log stream. Once `failed to reserve sandbox name` repeats past a threshold within a sliding window, it:

1. writes a synthetic JUnit report so the failure surfaces in `dorny/test-reporter` instead of a silent worker crash,
2. prints a banner to stderr (logback may not flush without shutdown hooks),
3. hard-kills the JVM via `Runtime.halt()`.

`halt()` not `exit()`: `exit()` runs the testcontainers shutdown hook, which docker-stops the stalled K3s container and blocks on the same stalled containerd, re-hanging what we are escaping. Ryuk reaps the abandoned container, so nothing leaks.

Wired into `HelmChartContainer` for both the `tests-hivemq-platform-operator` and `tests-hivemq-edge` integration test modules. Unit test covers threshold, idempotency, window pruning, split/batched frames, and synthetic-report output.