### PR TITLE
PLT-1261: declare the ECR Public registry for the base image

### DIFF
--- a/tests-hivemq-edge/build.gradle.kts
+++ b/tests-hivemq-edge/build.gradle.kts
@@ -125,6 +125,15 @@ oci {
                 includeModule("hivemq", "helm-test-image")
             }
         }
+        registry("ecrPublic") {
+            url = uri("https://public.ecr.aws")
+            exclusiveContent { includeGroup("hivemq.library") }
+        }
+    }
+    imageMapping {
+        mapGroup("hivemq.library") {
+            toImage(nameSpec("hivemq/library/") + name)
+        }
     }
     imageDefinitions {
         register("main") {

--- a/tests-hivemq-edge/build.gradle.kts
+++ b/tests-hivemq-edge/build.gradle.kts
@@ -127,6 +127,7 @@ oci {
         }
         registry("ecrPublic") {
             url = uri("https://public.ecr.aws")
+            optionalCredentials()
             exclusiveContent { includeGroup("hivemq.library") }
         }
     }

--- a/tests-hivemq-platform-operator/build.gradle.kts
+++ b/tests-hivemq-platform-operator/build.gradle.kts
@@ -229,6 +229,7 @@ oci {
         }
         registry("ecrPublic") {
             url = uri("https://public.ecr.aws")
+            optionalCredentials()
             exclusiveContent { includeGroup("hivemq.library") }
         }
     }

--- a/tests-hivemq-platform-operator/build.gradle.kts
+++ b/tests-hivemq-platform-operator/build.gradle.kts
@@ -227,6 +227,10 @@ oci {
                 includeModule("hivemq", "helm-test-image")
             }
         }
+        registry("ecrPublic") {
+            url = uri("https://public.ecr.aws")
+            exclusiveContent { includeGroup("hivemq.library") }
+        }
     }
     imageMapping {
         mapModule("com.hivemq", "hivemq-enterprise") {
@@ -239,6 +243,9 @@ oci {
             mapModule(jreBaseImageGroup, variant) {
                 toImage(jreBaseImage.repository).withTag(version)
             }
+        }
+        mapGroup("hivemq.library") {
+            toImage(nameSpec("hivemq/library/") + name)
         }
     }
     imageDefinitions {


### PR DESCRIPTION
## What

Declares the ECR Public registry (and the matching image mapping) in this build's `oci {}` block.

## Why

The `eclipse-temurin` base image now comes from **ECR Public** instead of Docker Hub (PLT-941 / PLT-1261).

This build never references the base image directly. It depends on the platform-operator and edge test images, and **in the composite build that dependency is substituted with the local `hivemq-enterprise` project**, whose image is built on the base image. gradle-oci resolves image dependencies in the context of the *consuming* project, so the registry has to be declared here too. Without it the coordinate falls through to `dockerHub`:

```
Could not resolve hivemq.base-images:eclipse-temurin:sha256!...
  Required by: project ':helm-charts' > project :hivemq-enterprise
```

This was confirmed by running the composite with every component enabled — the failure is not hypothetical.

## Notes

- Literal values rather than the `ociImages` accessors: this build's catalog has no `eclipse-temurin` entry, since it does not consume the base image directly.
- `exclusiveContent` scopes the registry to the `hivemq.base-images` group, so every other image resolves exactly as before.
- Anonymous pulls — no credentials, OIDC or CI auth changes.
- Branch named to match the `hivemq-enterprise` PR branch so the composite resolves them together (`resolveComponentScm`: `BRANCH_NAME`, then `master`).

Verified locally in the composite: with this change the base image coordinate resolves against `public.ecr.aws` at the correct path, where it previously could not be resolved at all.
