### PR TITLE
[LATEST] Publish a prebuilt Helm image to ghcr and use it in the integration tests

### DIFF
--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -100,6 +100,29 @@ jobs:
               - 'tests-hivemq-platform-operator/**'
           list-files: csv
 
+  helm-image-changes:
+    name: Helm test image changes
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.changes.outputs.modified }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Check for relevant changes
+        id: changes
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
+        with:
+          filters: |
+            modified:
+              - '.github/workflows/dispatcher.yml'
+              - '.github/workflows/helm-image*.yml'
+              - 'helm-image/**'
+              - '.helm-version'
+          list-files: csv
+
   edge-verify-tests:
     name: Edge verify tests
     needs: edge-changes
@@ -162,6 +185,13 @@ jobs:
     uses: ./.github/workflows/platform-integration-tests.yml
     secrets: inherit
 
+  helm-image-verify-tests:
+    name: Helm test image verify tests
+    needs: helm-image-changes
+    if: needs.helm-image-changes.outputs.should-run == 'true'
+    uses: ./.github/workflows/helm-image-verify.yml
+    secrets: inherit
+
   tests-summary-report:
     name: Tests Summary Report
     runs-on: ubuntu-latest
@@ -174,6 +204,7 @@ jobs:
       - platform-verify-tests
       - platform-smoke-test
       - platform-integration-tests
+      - helm-image-verify-tests
     steps:
       - name: Tests results summary
         if: |
@@ -183,7 +214,8 @@ jobs:
           needs.swarm-verify-tests.result == 'failure' ||
           needs.platform-verify-tests.result == 'failure' ||
           needs.platform-smoke-test.result == 'failure' ||
-          needs.platform-integration-tests.result == 'failure'
+          needs.platform-integration-tests.result == 'failure' ||
+          needs.helm-image-verify-tests.result == 'failure'
         run: |
           echo "There are test failures."
           exit 1

--- a/.github/workflows/helm-image-verify.yml
+++ b/.github/workflows/helm-image-verify.yml
@@ -1,0 +1,46 @@
+name: Helm Test Image Verify Tests
+on:
+  workflow_call:
+jobs:
+  run-verify-tests:
+    name: Verify tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout HiveMQ Helm Charts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          cache: gradle
+          distribution: temurin
+          java-version: 25
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
+        with:
+          cache-disabled: true
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:cicd-harvester
+
+      - name: Build and verify the Helm test image
+        env:
+          CI_RUN: true
+          DEVELOCITY_SERVER_URL: ${{ secrets.DEVELOCITY_SERVER_URL }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+        run: ./gradlew :helm-image:integrationTest
+
+      - name: Upload test results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: "Helm test image - Verify test results"
+          path: |
+            helm-image/build/reports/tests/integrationTest/
+            helm-image/build/test-results/integrationTest/*.xml
+          retention-days: 5

--- a/.github/workflows/helm-image.yml
+++ b/.github/workflows/helm-image.yml
@@ -1,0 +1,40 @@
+name: Publish Helm test image to ghcr
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .helm-version
+      - helm-image/**
+  workflow_dispatch:
+concurrency:
+  group: publish-helm-image-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  helm-image:
+    name: Helm test image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout HiveMQ Helm Charts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          cache: gradle
+          distribution: temurin
+          java-version: 25
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
+        with:
+          cache-disabled: true
+
+      - name: Publish Helm test image
+        env:
+          ORG_GRADLE_PROJECT_ghcrUsername: ${{ github.actor }}
+          ORG_GRADLE_PROJECT_ghcrPassword: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew :helm-image:pushOciImage

--- a/helm-image/README.md
+++ b/helm-image/README.md
@@ -1,0 +1,96 @@
+# Helm test image
+
+Builds and publishes `ghcr.io/hivemq/helm-test-image`, a container image containing
+nothing but the Helm binary.
+
+## Disclaimer
+
+This image exists solely to provide Helm to the integration tests in this repository and in the
+HiveMQ Kubernetes test suite. It is not a HiveMQ product, it is not supported, and it carries no
+compatibility guarantees. Its contents, tags, and existence may change at any time without notice.
+Do not depend on it.
+
+Helm itself is unmodified and is downloaded from [get.helm.sh](https://get.helm.sh) under the
+Apache-2.0 license. Anyone looking for Helm should get it from [helm.sh](https://helm.sh).
+
+## Contents
+
+A single layer holding `/usr/local/bin/helm`, built for `linux/amd64` and `linux/arm64/v8`. There is
+no base image, no shell, and no entry point, so `docker run` on the image alone fails with
+`no command specified`. Naming the binary works, because Helm is statically linked:
+
+```bash
+docker run --rm --entrypoint helm ghcr.io/hivemq/helm-test-image:<version> version
+```
+
+The intended use is different: consumers merge the image into their own test image as a parent image
+dependency, which stacks the layer and leaves the other image's entry point in place.
+
+The Helm version is read from the `.helm-version` file in the repository root, the same pin the
+workflows and the manifest scripts use. The image tag is that version without the leading `v`.
+
+## Build
+
+```bash
+./gradlew :helm-image:ociImageLayout
+```
+
+The build downloads the Helm distribution for both architectures, verifies its SHA-256 checksum
+against the published sidecar file, and packs the binary into a layer. No container runtime and no
+package manager are involved.
+
+## Publish
+
+The `Publish Helm test image to ghcr` workflow pushes the image when `.helm-version` or anything
+under `helm-image/` changes on `master`, and on manual dispatch.
+
+To push from a local checkout, provide credentials for a GitHub account with `write:packages`:
+
+```bash
+ORG_GRADLE_PROJECT_ghcrUsername=<user> \
+ORG_GRADLE_PROJECT_ghcrPassword=<token> \
+./gradlew :helm-image:pushOciImage
+```
+
+## Consuming the image
+
+Consumers declare the registry and take the image as a parent image dependency:
+
+```kotlin
+oci {
+    registries {
+        dockerHub {
+            optionalCredentials()
+        }
+        gitHubContainerRegistry {
+            exclusiveContent {
+                includeModule("hivemq", "helm-test-image")
+            }
+        }
+    }
+    imageDefinitions {
+        register("main") {
+            allPlatforms {
+                dependencies {
+                    runtime("rancher:k3s:$k3sTag")
+                    runtime(ociImages.helm.oci)
+                }
+            }
+        }
+    }
+}
+```
+
+with the pinned reference in `gradle/oci.versions.toml`:
+
+```toml
+[[oci]]
+name = "helm"
+image = "ghcr.io/hivemq/helm-test-image"
+reference = "4.2.3@sha256:..."
+```
+
+`exclusiveContent` selects the single module rather than the whole `hivemq` group, so the Docker Hub
+`hivemq` images keep resolving from Docker Hub.
+
+Renovate updates that reference once a new tag is published.

--- a/helm-image/build.gradle.kts
+++ b/helm-image/build.gradle.kts
@@ -1,0 +1,181 @@
+import de.undercouch.gradle.tasks.download.Download
+import io.github.sgtsilvio.gradle.oci.OciCopySpec
+import io.github.sgtsilvio.gradle.oci.image.PushOciImageTask
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+import java.security.MessageDigest
+
+plugins {
+    java
+    alias(libs.plugins.download)
+    alias(libs.plugins.oci)
+}
+
+val helmVersion = providers.fileContents(layout.projectDirectory.dir("..").file(".helm-version")).asText.get().trim()
+
+group = "com.hivemq.helmcharts"
+version = helmVersion.removePrefix("v")
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+val imageAnnotations = mapOf(
+    "org.opencontainers.image.title" to "Helm",
+    "org.opencontainers.image.description" to
+            "Helm binary for the HiveMQ helm-charts integration tests. Not a supported HiveMQ artifact.",
+    "org.opencontainers.image.source" to "https://github.com/hivemq/helm-charts",
+    "org.opencontainers.image.url" to "https://helm.sh",
+    "org.opencontainers.image.version" to version.toString(),
+    "org.opencontainers.image.licenses" to "Apache-2.0",
+)
+
+val extractHelmLinuxAmd64 = registerHelmDistributionTasks("linux-amd64")
+val extractHelmLinuxArm64 = registerHelmDistributionTasks("linux-arm64")
+
+@Suppress("UnstableApiUsage")
+testing {
+    suites {
+        @Suppress("unused")
+        val integrationTest by registering(JvmTestSuite::class) {
+            useJUnitJupiter(libs.versions.junit.jupiter)
+            dependencies {
+                runtimeOnly(libs.junit.platform.launcher)
+                implementation(libs.assertj)
+                implementation(libs.gradleOci.junitJupiter)
+                implementation(libs.testcontainers)
+                runtimeOnly(libs.logback.classic)
+            }
+            targets.configureEach {
+                testTask {
+                    systemProperty("helm.version", helmVersion)
+                    systemProperty("helm.image.tag", version.toString())
+                    testLogging {
+                        events = setOf(
+                            TestLogEvent.STARTED,
+                            TestLogEvent.PASSED,
+                            TestLogEvent.SKIPPED,
+                            TestLogEvent.FAILED,
+                            TestLogEvent.STANDARD_ERROR,
+                        )
+                        exceptionFormat = TestExceptionFormat.FULL
+                        showStandardStreams = true
+                    }
+                }
+            }
+            oci.of(this) {
+                imageDependencies {
+                    runtime(project())
+                }
+                val linuxAmd64 = platformSelector(platform("linux", "amd64"))
+                val linuxArm64v8 = platformSelector(platform("linux", "arm64", "v8"))
+                platformSelector = if (System.getenv("CI_RUN") != null //
+                    || System.getProperty("os.arch", "").equals("amd64")
+                ) linuxAmd64 else linuxArm64v8
+            }
+        }
+    }
+}
+
+/* ******************** OCI images ******************** */
+
+val ghcr = oci.registries.gitHubContainerRegistry {
+    optionalCredentials()
+}
+
+oci {
+    imageDefinitions {
+        register("main") {
+            imageName = "hivemq/helm-test-image"
+            imageTag = version.toString()
+            indexAnnotations = imageAnnotations
+            specificPlatform(platform("linux", "amd64")) {
+                config {
+                    manifestAnnotations = imageAnnotations
+                }
+                layer("helm") {
+                    contents {
+                        helmBinary(extractHelmLinuxAmd64)
+                    }
+                }
+            }
+            specificPlatform(platform("linux", "arm64", "v8")) {
+                config {
+                    manifestAnnotations = imageAnnotations
+                }
+                layer("helm") {
+                    contents {
+                        helmBinary(extractHelmLinuxArm64)
+                    }
+                }
+            }
+        }
+    }
+}
+
+tasks.named<PushOciImageTask>("pushOciImage") {
+    registry {
+        from(ghcr)
+    }
+}
+
+fun registerHelmDistributionTasks(platform: String): TaskProvider<Sync> {
+    val taskSuffix = platform.split('-').joinToString("") { it.replaceFirstChar(Char::titlecase) }
+    val archiveName = "helm-$helmVersion-$platform.tar.gz"
+    val downloadDirectory = layout.buildDirectory.dir("helm/download/$platform")
+    val archiveFile = downloadDirectory.map { it.file(archiveName) }
+    val checksumFile = downloadDirectory.map { it.file("$archiveName.sha256sum") }
+
+    val download = tasks.register<Download>("downloadHelm$taskSuffix") {
+        group = "distribution"
+        description = "Downloads the Helm $helmVersion distribution for $platform."
+        src(
+            listOf(
+                "https://get.helm.sh/$archiveName",
+                "https://get.helm.sh/$archiveName.sha256sum",
+            )
+        )
+        dest(downloadDirectory)
+        overwrite(false)
+        retries(3)
+    }
+
+    return tasks.register<Sync>("extractHelm$taskSuffix") {
+        group = "distribution"
+        description = "Verifies and extracts the Helm $helmVersion binary for $platform."
+        dependsOn(download)
+        inputs.file(archiveFile)
+        inputs.file(checksumFile)
+        doFirst {
+            verifyChecksum(archiveFile.get().asFile, checksumFile.get().asFile)
+        }
+        from(tarTree(archiveFile)) {
+            include("*/helm")
+            eachFile {
+                relativePath = RelativePath(true, name)
+            }
+        }
+        includeEmptyDirs = false
+        into(layout.buildDirectory.dir("helm/bin/$platform"))
+    }
+}
+
+fun OciCopySpec.helmBinary(extractTask: TaskProvider<Sync>) {
+    from(extractTask) {
+        into("usr/local/bin")
+    }
+    permissions("usr/local/bin/helm", 0b111_101_101)
+}
+
+fun verifyChecksum(archive: File, checksum: File) {
+    val expected = checksum.readText().trim().substringBefore(' ')
+    val actual = MessageDigest.getInstance("SHA-256").digest(archive.readBytes())
+        .joinToString("") { "%02x".format(it) }
+    check(actual == expected) { "SHA-256 mismatch for ${archive.name}, expected $expected but was $actual" }
+}

--- a/helm-image/gradle.properties
+++ b/helm-image/gradle.properties
@@ -1,0 +1,7 @@
+#
+# options
+#
+org.gradle.caching=true
+org.gradle.configuration-cache=false
+org.gradle.daemon.idletimeout=57600000
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g

--- a/helm-image/gradle/libs.versions.toml
+++ b/helm-image/gradle/libs.versions.toml
@@ -1,0 +1,17 @@
+[versions]
+assertj = "3.27.7"
+gradleOci-junitJupiter = "0.8.0"
+junit-jupiter = "6.1.3"
+logback = "1.6.1"
+testcontainers = "2.0.5"
+
+[libraries]
+assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+gradleOci-junitJupiter = { module = "io.github.sgtsilvio:gradle-oci-junit-jupiter", version.ref = "gradleOci-junitJupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-jupiter" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
+
+[plugins]
+download = { id = "de.undercouch.download", version = "5.7.0" }
+oci = { id = "io.github.sgtsilvio.gradle.oci", version = "0.30.0" }

--- a/helm-image/settings.gradle.kts
+++ b/helm-image/settings.gradle.kts
@@ -3,12 +3,7 @@ plugins {
     id("com.gradle.develocity") version "4.5.0"
 }
 
-rootProject.name = "helm-charts"
-
-includeBuild("github-release-note-updater")
-includeBuild("helm-image")
-includeBuild("tests-hivemq-platform-operator")
-includeBuild("tests-hivemq-edge")
+rootProject.name = "helm-image"
 
 develocity {
     server = System.getenv("DEVELOCITY_SERVER_URL")

--- a/helm-image/src/integrationTest/java/com/hivemq/helmcharts/helmimage/HelmImageIT.java
+++ b/helm-image/src/integrationTest/java/com/hivemq/helmcharts/helmimage/HelmImageIT.java
@@ -1,0 +1,36 @@
+package com.hivemq.helmcharts.helmimage;
+
+import io.github.sgtsilvio.gradle.oci.junit.jupiter.OciImages;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the Helm test image before it is published, so that a broken image is caught on the pull request rather
+ * than after the publishing workflow has run on master.
+ */
+class HelmImageIT {
+
+    private static final String IMAGE_TAG = System.getProperty("helm.image.tag");
+    private static final String EXPECTED_VERSION = System.getProperty("helm.version");
+
+    @Test
+    @Timeout(value = 2, unit = TimeUnit.MINUTES)
+    void helmBinary_reportsThePinnedVersion() {
+        final var imageName = OciImages.getImageName("hivemq/helm-test-image:" + IMAGE_TAG);
+        try (final var container = new GenericContainer<>(imageName)) {
+            // the image has no entry point and no shell, so the binary is invoked directly and the container exits
+            container.withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("helm"));
+            container.withCommand("version", "--short");
+            container.withStartupCheckStrategy(new OneShotStartupCheckStrategy());
+            container.start();
+
+            assertThat(container.getLogs().trim()).startsWith(EXPECTED_VERSION);
+        }
+    }
+}

--- a/helm-image/src/integrationTest/resources/logback-test.xml
+++ b/helm-image/src/integrationTest/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-30(%d %level %logger{36}) - %msg%n%ex</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <!-- HiveMQ -->
+    <logger name="com.hivemq.helmcharts" level="DEBUG"/>
+
+    <!-- Gradle OCI plugin -->
+    <logger name="io.github.sgtsilvio.gradle.oci" level="INFO"/>
+</configuration>

--- a/tests-hivemq-edge/build.gradle.kts
+++ b/tests-hivemq-edge/build.gradle.kts
@@ -115,37 +115,15 @@ tasks.register("integrationTestPrepare") {
 
 /* ******************** OCI images ******************** */
 
-val helmOciLayerLinuxAmd64 by tasks.registering(oci.dockerLayerTaskClass) {
-    dependencies(oci.parentImageDependencies["noble"])
-    platform = oci.platform("linux", "amd64")
-    command =
-        "apt-get update && apt-get install --no-install-recommends curl apt-transport-https ca-certificates -yq && " +
-                "curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 && " +
-                "bash get_helm.sh && rm -rf /var/lib/apt/lists/* get_helm.sh"
-    destinationDirectory = layout.buildDirectory.dir("oci/layers")
-    classifier = "helm@linux,amd64"
-}
-
-val helmOciLayerLinuxArm64 by tasks.registering(oci.dockerLayerTaskClass) {
-    dependencies(oci.parentImageDependencies["noble"])
-    platform = oci.platform("linux", "arm64", "v8")
-    command =
-        "apt-get update && apt-get install --no-install-recommends curl apt-transport-https ca-certificates -yq && " +
-                "curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 && " +
-                "bash get_helm.sh && rm -rf /var/lib/apt/lists/* get_helm.sh"
-    destinationDirectory = layout.buildDirectory.dir("oci/layers")
-    classifier = "helm@linux,arm64,v8"
-}
-
 oci {
     registries {
         dockerHub {
             optionalCredentials()
         }
-    }
-    parentImageDependencies {
-        create("noble") {
-            runtime(ociImages.ubuntu.noble.oci)
+        gitHubContainerRegistry {
+            exclusiveContent {
+                includeModule("hivemq", "helm-test-image")
+            }
         }
     }
     imageDefinitions {
@@ -154,16 +132,7 @@ oci {
             allPlatforms {
                 dependencies {
                     runtime("rancher:k3s:$k3sTag")
-                }
-            }
-            specificPlatform(platform("linux", "amd64")) {
-                layer("helm") {
-                    contents(helmOciLayerLinuxAmd64)
-                }
-            }
-            specificPlatform(platform("linux", "arm64", "v8")) {
-                layer("helm") {
-                    contents(helmOciLayerLinuxArm64)
+                    runtime(ociImages.helm.oci)
                 }
             }
         }

--- a/tests-hivemq-edge/gradle/oci.versions.toml
+++ b/tests-hivemq-edge/gradle/oci.versions.toml
@@ -1,8 +1,8 @@
-# https://hub.docker.com/_/ubuntu/tags?name=noble
+# https://github.com/hivemq/helm-charts/pkgs/container/helm-test-image
 [[oci]]
-name = "ubuntu-noble"
-image = "library/ubuntu"
-reference = "noble@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea"
+name = "helm"
+image = "ghcr.io/hivemq/helm-test-image"
+reference = "4.2.3@sha256:a5253d700d434fad2ea783ab16271444ab936f4b5eb5e6bdb3876488530102da"
 
 # https://hub.docker.com/r/rancher/k3s/tags?page=1&name=v1.24
 [[oci]]

--- a/tests-hivemq-platform-operator/build.gradle.kts
+++ b/tests-hivemq-platform-operator/build.gradle.kts
@@ -190,28 +190,6 @@ tasks.register("integrationTestPrepare") {
 
 /* ******************** OCI images ******************** */
 
-val helmOciLayerLinuxAmd64 by tasks.registering(oci.dockerLayerTaskClass) {
-    dependencies(oci.parentImageDependencies["noble"])
-    platform = oci.platform("linux", "amd64")
-    command =
-        "apt-get update && apt-get install --no-install-recommends curl apt-transport-https ca-certificates -yq && " +
-                "curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 && " +
-                "bash get_helm.sh && rm -rf /var/lib/apt/lists/* get_helm.sh"
-    destinationDirectory = layout.buildDirectory.dir("oci/layers")
-    classifier = "helm@linux,amd64"
-}
-
-val helmOciLayerLinuxArm64 by tasks.registering(oci.dockerLayerTaskClass) {
-    dependencies(oci.parentImageDependencies["noble"])
-    platform = oci.platform("linux", "arm64", "v8")
-    command =
-        "apt-get update && apt-get install --no-install-recommends curl apt-transport-https ca-certificates -yq && " +
-                "curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 && " +
-                "bash get_helm.sh && rm -rf /var/lib/apt/lists/* get_helm.sh"
-    destinationDirectory = layout.buildDirectory.dir("oci/layers")
-    classifier = "helm@linux,arm64,v8"
-}
-
 val downloadPlatformDistribution by tasks.registering(Download::class) {
     group = "distribution"
     description = "Downloads the latest HiveMQ Platform distribution"
@@ -225,6 +203,11 @@ oci {
     registries {
         dockerHub {
             optionalCredentials()
+        }
+        gitHubContainerRegistry {
+            exclusiveContent {
+                includeModule("hivemq", "helm-test-image")
+            }
         }
     }
     imageMapping {
@@ -240,27 +223,13 @@ oci {
             }
         }
     }
-    parentImageDependencies {
-        create("noble") {
-            runtime(ociImages.ubuntu.noble.oci)
-        }
-    }
     imageDefinitions {
         register("main") {
             imageTag = provider { project.version.toString().lowercase() }
             allPlatforms {
                 dependencies {
                     runtime("rancher:k3s:$k3sTag")
-                }
-            }
-            specificPlatform(platform("linux", "amd64")) {
-                layer("helm") {
-                    contents(helmOciLayerLinuxAmd64)
-                }
-            }
-            specificPlatform(platform("linux", "arm64", "v8")) {
-                layer("helm") {
-                    contents(helmOciLayerLinuxArm64)
+                    runtime(ociImages.helm.oci)
                 }
             }
         }

--- a/tests-hivemq-platform-operator/gradle/oci.versions.toml
+++ b/tests-hivemq-platform-operator/gradle/oci.versions.toml
@@ -1,8 +1,8 @@
-# https://hub.docker.com/_/ubuntu/tags?name=noble
+# https://github.com/hivemq/helm-charts/pkgs/container/helm-test-image
 [[oci]]
-name = "ubuntu-noble"
-image = "library/ubuntu"
-reference = "noble@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea"
+name = "helm"
+image = "ghcr.io/hivemq/helm-test-image"
+reference = "4.2.3@sha256:a5253d700d434fad2ea783ab16271444ab936f4b5eb5e6bdb3876488530102da"
 
 # https://hub.docker.com/r/rancher/k3s/tags?page=1&name=v1.24
 [[oci]]


### PR DESCRIPTION
## Summary

* Add a `helm-image` build that publishes `ghcr.io/hivemq/helm-test-image`, a public multi-arch image containing only the Helm binary at `/usr/local/bin/helm`.
* Build the image by downloading the Helm distribution for `linux/amd64` and `linux/arm64/v8` from `get.helm.sh` and verifying the published SHA-256 checksum. No container is started and no package manager runs, at test time or at publish time.
* Take the Helm version from `.helm-version`, so the integration tests stop running an arbitrary Helm 4 release and use the same pin as the workflows and the manifest scripts.
* Add a workflow that publishes on a change to `.helm-version` or to `helm-image/`, and on manual dispatch.
* Consume the prebuilt image in the operator and edge test builds as a parent image dependency next to the k3s image, replacing the per-run Helm layer build.
* Remove the `apt-get` step that failed intermittently on unhealthy Ubuntu mirrors, along with the Ubuntu base image and the `library/ubuntu` catalog entries. Nothing used the packages it contributed; the tests execute `helm` and `kubectl` only, and `kubectl` ships in the k3s image.

The image carries an OCI description marking it as test tooling rather than a supported artifact, and `helm-image/README.md` states the same.

The matching change for the Kubernetes test suite is in hivemq/hivemq-k8s-testsuite.
