### PR TITLE
[LATEST] Resolve the Helm and platform distributions as dependencies

### DIFF
--- a/.github/workflows/custom-platform-image-tests.yml
+++ b/.github/workflows/custom-platform-image-tests.yml
@@ -19,6 +19,11 @@ concurrency:
   group: custom-platform-image-tests
 env:
   CI_RUN: true
+  # the same set of files in every job, so the warmup job and the matrix jobs share one Gradle cache entry
+  cache-dependency-path: |
+    helm-charts/**/*.gradle*
+    helm-charts/**/gradle-wrapper.properties
+    helm-charts/**/*.versions.toml
 permissions:
   contents: read
   checks: write
@@ -31,11 +36,14 @@ jobs:
     steps:
       - name: Checkout HiveMQ Helm Charts
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: helm-charts
 
       - name: Set up JDK 25
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           cache: gradle
+          cache-dependency-path: ${{ env.cache-dependency-path }}
           distribution: temurin
           java-version: 25
 
@@ -44,10 +52,27 @@ jobs:
         with:
           cache-disabled: true
 
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:cicd-harvester
+
+      - name: Warmup Gradle cache
+        working-directory: helm-charts
+        env:
+          DEVELOCITY_SERVER_URL: ${{ secrets.DEVELOCITY_SERVER_URL }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+        run: ./gradlew :tests-hivemq-platform-operator:resolvePlatformDistribution
+
       - name: Generate variant list
         id: generate
+        working-directory: helm-charts
         env:
           VARIANT: ${{ inputs.variant }}
+          DEVELOCITY_SERVER_URL: ${{ secrets.DEVELOCITY_SERVER_URL }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |
           variants=$(./gradlew :tests-hivemq-platform-operator:printCustomPlatformImageVariants -q --console=plain | grep -oE '^\[.*\]$' | tail -1)
           if [[ -n "$VARIANT" ]]; then
@@ -86,6 +111,7 @@ jobs:
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           cache: gradle
+          cache-dependency-path: ${{ env.cache-dependency-path }}
           distribution: temurin
           java-version: 25
 

--- a/.github/workflows/custom-platform-image-tests.yml
+++ b/.github/workflows/custom-platform-image-tests.yml
@@ -117,15 +117,10 @@ jobs:
       - name: Add the tested HiveMQ Platform version to the summary
         if: ${{ !cancelled() }}
         env:
-          DISTRIBUTION_ZIP: helm-charts/tests-hivemq-platform-operator/build/platform/hivemq-latest.zip
+          VERSION_CATALOG: helm-charts/tests-hivemq-platform-operator/gradle/libs.versions.toml
         run: |
-          if [[ -f "$DISTRIBUTION_ZIP" ]]; then
-            # the distribution unpacks into a hivemq-<version> directory, which is the version that was tested
-            version=$(unzip -Z1 "$DISTRIBUTION_ZIP" | head -1 | sed 's|^hivemq-||;s|/$||')
-            echo "${{ matrix.variant }}: HiveMQ Platform $version" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "${{ matrix.variant }}: the HiveMQ Platform distribution was not downloaded" >> "$GITHUB_STEP_SUMMARY"
-          fi
+          version=$(sed -n 's/^hivemq-platform = "\(.*\)"$/\1/p' "$VERSION_CATALOG")
+          echo "${{ matrix.variant }}: HiveMQ Platform ${version:-unknown}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/helm-image/build.gradle.kts
+++ b/helm-image/build.gradle.kts
@@ -1,4 +1,3 @@
-import de.undercouch.gradle.tasks.download.Download
 import io.github.sgtsilvio.gradle.oci.OciCopySpec
 import io.github.sgtsilvio.gradle.oci.image.PushOciImageTask
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
@@ -7,7 +6,6 @@ import java.security.MessageDigest
 
 plugins {
     java
-    alias(libs.plugins.download)
     alias(libs.plugins.oci)
 }
 
@@ -24,6 +22,15 @@ java {
 
 repositories {
     mavenCentral()
+    exclusiveContent {
+        forRepository {
+            ivy("https://get.helm.sh") {
+                patternLayout { artifact("[module]-[revision]-[classifier].[ext]") }
+                metadataSources { artifact() }
+            }
+        }
+        filter { includeModule("sh.helm", "helm") }
+    }
 }
 
 val imageAnnotations = mapOf(
@@ -127,29 +134,22 @@ tasks.named<PushOciImageTask>("pushOciImage") {
 
 fun registerHelmDistributionTasks(platform: String): TaskProvider<Sync> {
     val taskSuffix = platform.split('-').joinToString("") { it.replaceFirstChar(Char::titlecase) }
-    val archiveName = "helm-$helmVersion-$platform.tar.gz"
-    val downloadDirectory = layout.buildDirectory.dir("helm/download/$platform")
-    val archiveFile = downloadDirectory.map { it.file(archiveName) }
-    val checksumFile = downloadDirectory.map { it.file("$archiveName.sha256sum") }
-
-    val download = tasks.register<Download>("downloadHelm$taskSuffix") {
-        group = "distribution"
-        description = "Downloads the Helm $helmVersion distribution for $platform."
-        src(
-            listOf(
-                "https://get.helm.sh/$archiveName",
-                "https://get.helm.sh/$archiveName.sha256sum",
-            )
-        )
-        dest(downloadDirectory)
-        overwrite(false)
-        retries(3)
+    val archive = configurations.create("helmDistribution$taskSuffix") {
+        isCanBeConsumed = false
+        isCanBeResolved = true
     }
+    val checksum = configurations.create("helmChecksum$taskSuffix") {
+        isCanBeConsumed = false
+        isCanBeResolved = true
+    }
+    dependencies.add(archive.name, "sh.helm:helm:$helmVersion:$platform@tar.gz")
+    dependencies.add(checksum.name, "sh.helm:helm:$helmVersion:$platform@tar.gz.sha256sum")
+    val archiveFile = archive.elements.map { it.single() }
+    val checksumFile = checksum.elements.map { it.single() }
 
     return tasks.register<Sync>("extractHelm$taskSuffix") {
         group = "distribution"
         description = "Verifies and extracts the Helm $helmVersion binary for $platform."
-        dependsOn(download)
         inputs.file(archiveFile)
         inputs.file(checksumFile)
         doFirst {

--- a/helm-image/gradle/libs.versions.toml
+++ b/helm-image/gradle/libs.versions.toml
@@ -13,5 +13,4 @@ logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "lo
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 
 [plugins]
-download = { id = "de.undercouch.download", version = "5.7.0" }
 oci = { id = "io.github.sgtsilvio.gradle.oci", version = "0.30.0" }

--- a/tests-hivemq-platform-operator/README.md
+++ b/tests-hivemq-platform-operator/README.md
@@ -53,7 +53,7 @@ Set the `customPlatformImageVariant` property to build such an image and run the
 ./gradlew integrationTest -PcustomPlatformImageVariant=temurin21-ubi9
 ```
 
-The image is built from the latest platform distribution (`https://www.hivemq.com/releases/hivemq-latest.zip`) on top of the Java runtime base image of the variant. It is only served to the K3s cluster of the test run and is never published to a registry.
+The image is built from the platform distribution of the `hivemq-platform` version in `gradle/libs.versions.toml` on top of the Java runtime base image of the variant. It is only served to the K3s cluster of the test run and is never published to a registry.
 
 The following variants are available:
 

--- a/tests-hivemq-platform-operator/build.gradle.kts
+++ b/tests-hivemq-platform-operator/build.gradle.kts
@@ -1,10 +1,8 @@
-import de.undercouch.gradle.tasks.download.Download
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     java
-    alias(libs.plugins.download)
     alias(libs.plugins.hivemq.oci.version.catalog)
     alias(libs.plugins.oci)
 }
@@ -19,6 +17,15 @@ java {
 
 repositories {
     mavenCentral()
+    exclusiveContent {
+        forRepository {
+            ivy("https://www.hivemq.com/releases") {
+                patternLayout { artifact("[module]-[revision].[ext]") }
+                metadataSources { artifact() }
+            }
+        }
+        filter { includeModule("com.hivemq", "hivemq") }
+    }
 }
 
 configurations.all {
@@ -31,9 +38,10 @@ val k3sTag = resolveK3sTag()
 /*
  * Tests the HiveMQ Platform on a Java runtime other than the one of the official image.
  *
- * When the `customPlatformImageVariant` property is set, a HiveMQ Platform image is built from the latest platform
- * distribution on top of the Java runtime base image of that variant, and the integration tests run against that image
- * instead of the official one. Only the tests tagged with `custom-platform-image` are executed.
+ * When the `customPlatformImageVariant` property is set, a HiveMQ Platform image is built from the platform
+ * distribution of the `hivemq-platform` version on top of the Java runtime base image of that variant, and the
+ * integration tests run against that image instead of the official one. Only the tests tagged with
+ * `custom-platform-image` are executed.
  *
  * Without the property, the build behaves as it does for every regular test run.
  */
@@ -190,13 +198,13 @@ tasks.register("integrationTestPrepare") {
 
 /* ******************** OCI images ******************** */
 
-val downloadPlatformDistribution by tasks.registering(Download::class) {
-    group = "distribution"
-    description = "Downloads the latest HiveMQ Platform distribution"
-    src("https://www.hivemq.com/releases/hivemq-latest.zip")
-    dest(layout.buildDirectory.file("platform/hivemq-latest.zip"))
-    onlyIfModified(true)
-    retries(3)
+val platformDistribution: Configuration by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
+dependencies {
+    platformDistribution("com.hivemq:hivemq:$hivemqVersion@zip")
 }
 
 oci {
@@ -283,7 +291,7 @@ oci {
                             permissions("opt/hivemq/license/", 0b111_111_101)
                             permissions("opt/hivemq/log/", 0b111_111_101)
                             into("opt") {
-                                from(zipTree(downloadPlatformDistribution.map { it.outputFiles.first() })) {
+                                from(zipTree(platformDistribution.elements.map { it.single() })) {
                                     // the tools are not used by any test
                                     filter { exclude("*/tools/**") }
                                     move("", "hivemq-.*", "hivemq")

--- a/tests-hivemq-platform-operator/build.gradle.kts
+++ b/tests-hivemq-platform-operator/build.gradle.kts
@@ -207,6 +207,16 @@ dependencies {
     platformDistribution("com.hivemq:hivemq:$hivemqVersion@zip")
 }
 
+@Suppress("unused")
+val resolvePlatformDistribution by tasks.registering {
+    group = "distribution"
+    description = "Resolves the HiveMQ Platform distribution into the Gradle dependency cache"
+    val distribution = platformDistribution.elements
+    doLast {
+        logger.lifecycle("Resolved {}", distribution.get().single())
+    }
+}
+
 oci {
     registries {
         dockerHub {

--- a/tests-hivemq-platform-operator/gradle/libs.versions.toml
+++ b/tests-hivemq-platform-operator/gradle/libs.versions.toml
@@ -42,6 +42,5 @@ testcontainers-k3s = { module = "org.testcontainers:testcontainers-k3s", version
 testcontainers-selenium = { module = "org.testcontainers:testcontainers-selenium", version.ref = "testcontainers" }
 
 [plugins]
-download = { id = "de.undercouch.download", version = "5.7.0" }
 hivemq-oci-version-catalog = { id = "com.hivemq.tools.oci-version-catalog", version = "0.4.0" }
 oci = { id = "io.github.sgtsilvio.gradle.oci", version = "0.30.0" }


### PR DESCRIPTION
## Summary

- `helm-image` fetched the Helm distribution and its `.sha256sum` with `de.undercouch.download` tasks, and `tests-hivemq-platform-operator` fetched the HiveMQ Platform distribution the same way. `Download` is not a cacheable task type and the destinations live in `build/`, so a clean build downloaded them again and no cache could carry them.
- Both are resolved through ivy repositories with a pattern layout now, over `get.helm.sh` and `www.hivemq.com/releases`. The artifacts land in `~/.gradle/caches/modules-2`, which persists on Jenkins agents and is restored across GitHub Actions jobs.
- The platform distribution moves from `hivemq-latest.zip` to the `hivemq-platform` version of the version catalog, which is the version the tests already use for `hivemq.tag` and the image tags. `updatePlatformVersion` rewrites that entry on every platform release, so the custom platform image keeps tracking releases while the build stays reproducible.
- The manual SHA-256 verification of the Helm archive is unchanged.
- With the last `Download` tasks gone, `de.undercouch.download` is removed from both modules and both version catalogs.

Verified by building `:helm-image:ociImageLayout` and the custom platform image layer: the Helm binary extracts and verifies, the platform layer holds the same 317 entries with the tools excluded and the distribution directory renamed, and a second run is up to date offline.
