### PR TITLE
Let Renovate manage the pinned Helm version and the smoke test matrix

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -11,7 +11,43 @@
     addLabels: [
         'integrations-team-coordination',
     ],
+    customManagers: [
+        {
+            customType: 'regex',
+            description: 'Pinned Helm version used by the verify, harbor, release and edge release PR workflows',
+            datasourceTemplate: 'github-releases',
+            depNameTemplate: 'helm/helm',
+            versioningTemplate: 'semver',
+            managerFilePatterns: [
+                '/^\\.helm-version$/',
+            ],
+            matchStrings: [
+                '^(?<currentValue>v\\d+\\.\\d+\\.\\d+)',
+            ],
+        },
+        {
+            customType: 'regex',
+            description: 'Helm versions of the latest-3 and latest-4 smoke test matrix entries',
+            datasourceTemplate: 'github-releases',
+            depNameTemplate: 'helm/helm',
+            versioningTemplate: 'semver',
+            managerFilePatterns: [
+                '/^\\.github/workflows/(edge|platform)-smoke-test\\.yml$/',
+            ],
+            matchStrings: [
+                "helm-label: 'latest-\\d+'\\s+helm-version: '(?<currentValue>v\\d+\\.\\d+\\.\\d+)'",
+            ],
+        },
+    ],
     packageRules: [
+        {
+            description: 'Keep the latest-3 smoke test matrix entry on the Helm v3 line. The pinned version and the latest-4 entry stay unconstrained, so a new Helm major surfaces on the dependency dashboard',
+            matchPackageNames: [
+                'helm/helm',
+            ],
+            matchCurrentValue: '/^v3\\./',
+            allowedVersions: '/^v3\\./',
+        },
         {
             description: 'OCI image dependency is not a real Maven package (gradle-oci plugin)',
             matchManagers: [


### PR DESCRIPTION
## Summary

* Add Renovate custom regex managers for the pinned Helm version in `.helm-version` and for the `latest-3` and `latest-4` entries of the edge and platform smoke test matrices, resolved against the `helm/helm` GitHub releases
* Add a package rule keyed on the current value so the `latest-3` entry stays on the Helm v3 line
* Leave `.helm-version` and the `latest-4` entry unconstrained, so minor and patch updates schedule as usual and a future Helm major reaches the dependency dashboard for manual approval
* The `minimum` matrix entry sits outside the manager file patterns and stays pinned at `v3.10.0`

`helm/helm` publishes both release lines to one feed, so all five sites extract as the same dependency. The split comes from `matchCurrentValue`, which is evaluated against the raw extracted value before the datasource lookup and therefore composes with `allowedVersions`. Renovate's branch topic includes the new major, so the two lines land on separate branches.

Constraining the v4 side symmetrically would filter a future v5 out of the lookup entirely, leaving no PR and no dependency dashboard entry. Without the constraint, `major.dependencyDashboardApproval` from the shared config holds it on the dashboard until someone approves it.

Verified with `renovate --platform=local` against downgraded values: the v3 site resolved to `v3.21.3` on `renovate/helm-charts/helm-helm-3.x` and the v4 sites to `v4.2.3` on `renovate/helm-charts/helm-helm-4.x`, with the `minimum` entry not extracted.

Manifest regeneration is left manual. Every Helm bump within a line since `.helm-version` was introduced touched only the version files; the one bump that changed `manifests/` was the move from the v3 to the v4 line, which is now gated behind dashboard approval. The existing manifest freshness check in the verify workflows catches the case if it ever occurs.
