### PR TITLE
Block major updates for the Java runtime base images

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -69,6 +69,21 @@
             allowedVersions: '/^v1\\.35\\./',
         },
         {
+            description: 'Stay on Java 21 and 25 for the Java runtime base images of the custom HiveMQ Platform image variants. Digest, minor and patch updates still apply',
+            matchFileNames: [
+                '**/gradle/oci.versions.toml',
+            ],
+            matchPackageNames: [
+                'library/amazoncorretto',
+                'library/eclipse-temurin',
+                'library/ibm-semeru-runtimes',
+            ],
+            matchUpdateTypes: [
+                'major',
+            ],
+            enabled: false,
+        },
+        {
             description: 'Stay on Cosign 2.x - Cosign 3.x signs exclusively via the OCI 1.1 referrers API, which our registry does not support',
             matchPackageNames: [
                 'sigstore/cosign',


### PR DESCRIPTION
## Summary

* Disable major updates for `library/amazoncorretto`, `library/eclipse-temurin` and `library/ibm-semeru-runtimes` in the OCI version catalogs, so the Java runtime base images of the custom HiveMQ Platform image variants stay on Java 21 and 25.
* Digest updates keep flowing, so the images still pick up the latest patch releases.
