### PR TITLE
Update Grafana dashboard to version 7 with incoming bandwidth throttling panels

### DIFF
--- a/charts/hivemq-platform/files/grafana-dashboard.json
+++ b/charts/hivemq-platform/files/grafana-dashboard.json
@@ -3174,99 +3174,10 @@
         "x": 0,
         "y": 47
       },
-      "id": 39,
-      "panels": [],
-      "title": "HiveMQ Cluster",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Mixed --"
-      },
-      "description": "The number of nodes in the cluster.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisSoftMin": 0,
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 3,
-        "x": 0,
-        "y": 48
-      },
-      "id": 40,
-      "interval": "${intervalSeconds}s",
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Prometheus}"
-          },
-          "editorMode": "code",
-          "expr": "com_hivemq_cluster_nodes_count{namespace=~\"$namespace\"}",
-          "instant": false,
-          "legendFormat": "{{instance}} nodes",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Cluster Nodes",
-      "type": "timeseries"
+      "id": 129,
+      "title": "Overload Protection & Throttling",
+      "type": "row",
+      "panels": []
     },
     {
       "datasource": {
@@ -3323,7 +3234,7 @@
       "gridPos": {
         "h": 7,
         "w": 3,
-        "x": 3,
+        "x": 0,
         "y": 48
       },
       "id": 97,
@@ -3411,8 +3322,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 6,
-        "x": 6,
+        "w": 3,
+        "x": 3,
         "y": 48
       },
       "id": 100,
@@ -3444,7 +3355,185 @@
           "refId": "A"
         }
       ],
-      "title": "Overload Protection backpressure active",
+      "title": "Overload Protection Backpressure Active",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "The number of client connections whose reads are currently suspended because the configured incoming-bandwidth-throttling limit is being enforced. A value greater than 0 means incoming bandwidth throttling is currently active.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 6,
+        "y": 48
+      },
+      "id": 127,
+      "interval": "${intervalSeconds}s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "com_hivemq_networking_incoming_bandwidth_throttling_connections_current{namespace=~\"$namespace\"}",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Currently Throttled Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Counts each time a client connection's reads are suspended because the configured incoming-bandwidth-throttling limit is being enforced",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 9,
+        "y": 48
+      },
+      "id": 128,
+      "interval": "${intervalSeconds}s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "rate(com_hivemq_networking_incoming_bandwidth_throttling_connections_count{namespace=~\"$namespace\"}[${intervalSeconds}s])",
+          "instant": false,
+          "legendFormat": "{{job}} throttle-events",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Throttle Events/s",
       "type": "timeseries"
     },
     {
@@ -9495,6 +9584,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "HiveMQ Platform (Prometheus)",
-  "version": "6",
+  "version": "7",
   "weekStart": ""
 }

--- a/charts/hivemq-platform/tests/monitoring/__snapshot__/hivemq_grafana_dashboard_test.yaml.snap
+++ b/charts/hivemq-platform/tests/monitoring/__snapshot__/hivemq_grafana_dashboard_test.yaml.snap
@@ -3177,99 +3177,10 @@ with monitoring enabled and default values, ConfigMap spec created with defaults
               "x": 0,
               "y": 47
             },
-            "id": 39,
-            "panels": [],
-            "title": "HiveMQ Cluster",
-            "type": "row"
-          },
-          {
-            "datasource": {
-              "type": "datasource",
-              "uid": "-- Mixed --"
-            },
-            "description": "The number of nodes in the cluster.",
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisBorderShow": false,
-                  "axisCenteredZero": false,
-                  "axisColorMode": "text",
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "axisSoftMin": 0,
-                  "barAlignment": 0,
-                  "drawStyle": "line",
-                  "fillOpacity": 10,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "insertNulls": false,
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "never",
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": []
-                }
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 7,
-              "w": 3,
-              "x": 0,
-              "y": 48
-            },
-            "id": 40,
-            "interval": "${intervalSeconds}s",
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": false
-              },
-              "tooltip": {
-                "mode": "multi",
-                "sort": "none"
-              }
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "${Prometheus}"
-                },
-                "editorMode": "code",
-                "expr": "com_hivemq_cluster_nodes_count{namespace=~\"$namespace\"}",
-                "instant": false,
-                "legendFormat": "{{instance}} nodes",
-                "range": true,
-                "refId": "A"
-              }
-            ],
-            "title": "Cluster Nodes",
-            "type": "timeseries"
+            "id": 129,
+            "title": "Overload Protection & Throttling",
+            "type": "row",
+            "panels": []
           },
           {
             "datasource": {
@@ -3326,7 +3237,7 @@ with monitoring enabled and default values, ConfigMap spec created with defaults
             "gridPos": {
               "h": 7,
               "w": 3,
-              "x": 3,
+              "x": 0,
               "y": 48
             },
             "id": 97,
@@ -3414,8 +3325,8 @@ with monitoring enabled and default values, ConfigMap spec created with defaults
             },
             "gridPos": {
               "h": 7,
-              "w": 6,
-              "x": 6,
+              "w": 3,
+              "x": 3,
               "y": 48
             },
             "id": 100,
@@ -3447,7 +3358,185 @@ with monitoring enabled and default values, ConfigMap spec created with defaults
                 "refId": "A"
               }
             ],
-            "title": "Overload Protection backpressure active",
+            "title": "Overload Protection Backpressure Active",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Mixed --"
+            },
+            "description": "The number of client connections whose reads are currently suspended because the configured incoming-bandwidth-throttling limit is being enforced. A value greater than 0 means incoming bandwidth throttling is currently active.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "axisSoftMin": 0,
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": []
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 3,
+              "x": 6,
+              "y": 48
+            },
+            "id": 127,
+            "interval": "${intervalSeconds}s",
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": false
+              },
+              "tooltip": {
+                "mode": "multi",
+                "sort": "none"
+              }
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${Prometheus}"
+                },
+                "editorMode": "code",
+                "expr": "com_hivemq_networking_incoming_bandwidth_throttling_connections_current{namespace=~\"$namespace\"}",
+                "instant": false,
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Currently Throttled Connections",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Mixed --"
+            },
+            "description": "Counts each time a client connection's reads are suspended because the configured incoming-bandwidth-throttling limit is being enforced",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "axisSoftMin": 0,
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "normal"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": []
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 3,
+              "x": 9,
+              "y": 48
+            },
+            "id": 128,
+            "interval": "${intervalSeconds}s",
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": false
+              },
+              "tooltip": {
+                "mode": "multi",
+                "sort": "none"
+              }
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${Prometheus}"
+                },
+                "editorMode": "code",
+                "expr": "rate(com_hivemq_networking_incoming_bandwidth_throttling_connections_count{namespace=~\"$namespace\"}[${intervalSeconds}s])",
+                "instant": false,
+                "legendFormat": "{{job}} throttle-events",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Throttle Events/s",
             "type": "timeseries"
           },
           {
@@ -9498,6 +9587,6 @@ with monitoring enabled and default values, ConfigMap spec created with defaults
         "timepicker": {},
         "timezone": "",
         "title": "HiveMQ Platform (Prometheus)",
-        "version": "6",
+        "version": "7",
         "weekStart": ""
       }


### PR DESCRIPTION
## Summary

- Updates the HiveMQ Platform Grafana dashboard to version 7, copied verbatim from the Prometheus variant rendered by hivemq/hivemq-grafana-dashboards#14
- Adds the new Overload Protection & Throttling row with the Currently Throttled Connections and Throttle Events/s panels (broker 4.55.0 metrics), removes the redundant HiveMQ Cluster row
- Updates the Grafana dashboard ConfigMap test snapshot
- Validated end to end in a local Minikube with kube-prometheus-stack and broker 4.55.0: dashboard imports, all panels resolve, both throttling metrics are scraped

Depends on hivemq/hivemq-grafana-dashboards#14 and should be merged once release 7 of the Grafana dashboards is published.

Part of [INT-411](https://linear.app/hivemq/issue/INT-411/align-grafana-dashboards-between-hivemq-grafana-dashboards-and-helm)