### PR TITLE
Align the values documentation with the reviewed HiveMQ documentation wording

### DIFF
--- a/charts/hivemq-platform/values.schema.json
+++ b/charts/hivemq-platform/values.schema.json
@@ -304,7 +304,7 @@
       "properties" : {
         "server" : {
           "additionalProperties" : false,
-          "description" : "Configures the connection to the HiveMQ Data Intelligence server. Without a connection string configured here, the connection string of the HiveMQ Platform license is used.",
+          "description" : "Configures the connection to the HiveMQ Data Intelligence server. A connection string configured here will take precedence. The connection string can also be automatically set via a self-serve license.",
           "properties" : {
             "connectionStringSecretKey" : {
               "description" : "The key within the Secret (`connection-string` by default).",
@@ -313,7 +313,7 @@
               "type" : "string"
             },
             "connectionStringSecretName" : {
-              "description" : "The name of an existing Kubernetes Secret containing the connection string. The connection string is never stored in the HiveMQ configuration, and content changes trigger a rolling restart of the HiveMQ Platform cluster.",
+              "description" : "The name of an existing Kubernetes Secret containing the connection string. The connection string is never stored in the HiveMQ configuration, and content changes trigger a rolling restart of the HiveMQ cluster.",
               "maxLength" : 253,
               "minLength" : 1,
               "pattern" : "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
@@ -324,23 +324,23 @@
         },
         "clustering" : {
           "additionalProperties" : false,
-          "description" : "Configures HiveMQ Data Intelligence log-based clustering.",
+          "description" : "Configures the log-based clustering for HiveMQ Data Intelligence.",
           "properties" : {
             "dataLayerEnabled" : {
               "description" : "Enables the log-based clustering data layer (`true` by default). Set to `false` to disable it.",
               "type" : "boolean"
             },
             "enabled" : {
-              "description" : "Enables log-based clustering.",
+              "description" : "Enables log-based clustering. This is required for a connection to HiveMQ Data Intelligence.",
               "type" : "boolean"
             },
             "initialMemberCount" : {
-              "description" : "The number of nodes that form the initial cluster. Required when clustering is enabled and must not exceed the `nodes.replicaCount` value. Cannot be changed on an existing installation. A value of `1` permanently limits the installation to a single replica.",
+              "description" : "The number of nodes that form the initial cluster. Required when log-based clustering is enabled and must not exceed the `nodes.replicaCount` value. Cannot be changed for an existing deployment. A value of `1` permanently limits the deployment to a single replica, because running more than one replica requires at least 2 initial members.",
               "minimum" : 1,
               "type" : "integer"
             },
             "initialMembersConnectTimeoutSeconds" : {
-              "description" : "The time in seconds that a cluster formation attempt waits for the other initial members before it retries (`60` by default).",
+              "description" : "The time in seconds that a log-based cluster formation attempt waits for the other initial members before it retries (`60` by default).",
               "minimum" : 1,
               "type" : "integer"
             },
@@ -1151,7 +1151,7 @@
     },
     "persistence" : {
       "additionalProperties" : false,
-      "description" : "Stores the HiveMQ data, log and audit folders, and by default the backup folder, on a PersistentVolumeClaim per HiveMQ Platform pod, so their content survives pod restarts. The `storageClass` and `storageSize` values are required and cannot be changed on an existing installation.",
+      "description" : "Stores the HiveMQ data, log and audit folders, and by default the backup folder, on a PersistentVolumeClaim per HiveMQ Platform pod, so their content survives pod restarts. The `storageClass` and `storageSize` values are required and cannot be changed for an existing deployment.",
       "properties" : {
         "backupFolder" : {
           "description" : "Stores the HiveMQ backup folder on the PersistentVolumeClaim (`true` by default). Set to `false` to keep the backup folder on the ephemeral storage of the HiveMQ container; a previously stored backup folder remains on the PersistentVolumeClaim.",

--- a/charts/hivemq-platform/values.yaml
+++ b/charts/hivemq-platform/values.yaml
@@ -854,8 +854,8 @@ volumeClaimTemplates: []
 
 # Stores the HiveMQ data, log and audit folders, and by default the backup folder, on a
 # PersistentVolumeClaim per HiveMQ Platform pod, so their content survives pod restarts. The
-# `storageClass` and `storageSize` values are required and cannot be changed on an existing
-# installation, as Kubernetes does not allow changing the PersistentVolumeClaims of an existing
+# `storageClass` and `storageSize` values are required and cannot be changed for an existing
+# deployment, as Kubernetes does not allow changing the PersistentVolumeClaims of an existing
 # StatefulSet. This check needs cluster access with `get` permission on the `hivemqplatforms`
 # custom resources in the release namespace, so client-side rendering (`helm template`, as used by
 # GitOps tools) cannot run it. For a custom setup, use the `additionalVolumes` and
@@ -872,43 +872,45 @@ persistence: {}
   #storageSize: ""
   # Stores the HiveMQ backup folder on the PersistentVolumeClaim (`true` by default). Set to `false`
   # to keep the backup folder on the ephemeral storage of the HiveMQ container; a previously stored
-  # backup folder remains on the PersistentVolumeClaim. Unlike the values above, changing this value
-  # on an existing installation is allowed and triggers a rolling restart of the HiveMQ Platform
-  # cluster.
+  # backup folder remains on the PersistentVolumeClaim. Unlike the `storageClass` and `storageSize`
+  # values, changing this value for an existing deployment is allowed and triggers a rolling restart
+  # of the HiveMQ Broker cluster.
   #backupFolder: true
 
 # Defines the HiveMQ Data Intelligence configuration options.
-# Changing any of these options triggers a rolling restart of the HiveMQ Platform cluster.
+# Changing any of these options triggers a rolling restart of the HiveMQ Broker cluster.
 dataIntelligence:
-  # Configures HiveMQ Data Intelligence log-based clustering.
+  # Configures the log-based clustering for HiveMQ Data Intelligence.
   # To keep the clustering state when all pods restart at the same time, configure the `persistence`
-  # value when first installing the HiveMQ Platform, as it cannot be added to an existing installation.
-  # Disabling clustering or changing the `initialMemberCount` value on an existing installation is
+  # value when first installing the HiveMQ Platform, as it cannot be added to an existing deployment.
+  # Disabling log-based clustering or changing the `initialMemberCount` value for an existing deployment is
   # rejected. This check needs cluster access with `get` permission on ConfigMaps and Secrets in the
   # release namespace, so client-side rendering (`helm template`, as used by GitOps tools) cannot
   # run it.
   clustering:
-    # Enables log-based clustering.
+    # Enables log-based clustering. This is required for a connection to HiveMQ Data Intelligence.
     enabled: false
-    # The number of nodes that form the initial cluster. Required when clustering is enabled and must
-    # not exceed the `nodes.replicaCount` value. Cannot be changed on an existing installation. A
-    # value of `1` permanently limits the installation to a single replica.
+    # The number of nodes that form the initial cluster. Required when log-based clustering is enabled
+    # and must not exceed the `nodes.replicaCount` value. Cannot be changed for an existing deployment.
+    # A value of `1` permanently limits the deployment to a single replica, because running more than
+    # one replica requires at least 2 initial members.
     #initialMemberCount: 2
     # The port for the log-based clustering communication between the cluster nodes (`7557` by default).
     #port: 7557
     # Enables the log-based clustering data layer (true by default). Set to false to disable it.
     #dataLayerEnabled: false
-    # The time in seconds that a cluster formation attempt waits for the other initial members before
+    # The time in seconds that a log-based cluster formation attempt waits for the other initial members before
     # it retries (`60` by default, deliberately lower than the HiveMQ default of `600`). A timeout only
     # retries the formation and never forms a smaller cluster, so a low value surfaces configuration
     # problems faster without any risk.
     #initialMembersConnectTimeoutSeconds: 60
-  # Configures the connection to the HiveMQ Data Intelligence server. Without a connection string
-  # configured here, the connection string of the HiveMQ Platform license is used.
+  # Configures the connection to the HiveMQ Data Intelligence server. A connection string configured
+  # here will take precedence. The connection string can also be automatically set via a self-serve
+  # license.
   server: {}
     # The name of an existing Kubernetes Secret containing the connection string. The connection string
     # is never stored in the HiveMQ configuration, and content changes trigger a rolling restart of the
-    # HiveMQ Platform cluster.
+    # HiveMQ cluster.
     #connectionStringSecretName: ""
     # The key within the Secret (`connection-string` by default).
     #connectionStringSecretKey: "connection-string"


### PR DESCRIPTION
Aligns the `values.yaml` comments and `values.schema.json` descriptions of the `dataIntelligence` and `persistence` values with the wording established in the documentation review of hivemq/hivemq4-documentation#2953 (HiveMQ Broker cluster, existing deployment, log-based clustering qualifiers, server connection string, the single-replica explanation).