### PR TITLE
Ignore the Helm version of the setup-helm action in Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -49,6 +49,16 @@
             allowedVersions: '/^v3\\./',
         },
         {
+            description: 'The Helm version of the setup-helm action always comes from a workflow expression, the custom managers own the literal versions',
+            matchManagers: [
+                'github-actions',
+            ],
+            matchPackageNames: [
+                'helm/helm',
+            ],
+            enabled: false,
+        },
+        {
             description: 'OCI image dependency is not a real Maven package (gradle-oci plugin)',
             matchManagers: [
                 'gradle',


### PR DESCRIPTION
## Summary

* Disable the `helm/helm` dependency that the `github-actions` manager extracts from the `version` input of the `azure/setup-helm` action. All eight usages pass a workflow expression (`${{ matrix.helm-version }}` or `${{ steps.helm-version.outputs.version }}`), so Renovate logs an unversioned-value warning and runs a tag and digest lookup that cannot resolve, on every run:

```
Dependency helm/helm has unsupported/unversioned value ${{ matrix.helm-version }} (versioning=semver-coerced)
github/tags.findCommitOfTag: Tag ${{ matrix.helm-version }} not found for helm/helm
Could not determine new digest for update.
```

* The rule is scoped to the `github-actions` manager, so the custom managers that own the literal Helm versions in `.helm-version` and in the smoke test matrices keep working.
* The three `helm ${{ ... }}` entries drop off the dependency dashboard.
