### PR TITLE
EDG-1007: wire the Data Hub watcher values, and fix eleven chart defects found on the way

### DIFF
--- a/charts/hivemq-edge/files/datahub.json
+++ b/charts/hivemq-edge/files/datahub.json
@@ -1,1 +1,1 @@
-{}
+{"scripts":[],"schemas":[],"behaviorPolicies":[],"dataPolicies":[]}

--- a/charts/hivemq-edge/templates/secret-ldap-truststore.yml
+++ b/charts/hivemq-edge/templates/secret-ldap-truststore.yml
@@ -1,4 +1,4 @@
-{{- if and (.Values.adminLdap.tls.enabled) (.Values.adminLdap.tls.create.enabled) }}
+{{- if and (.Values.adminLdap.tls.enabled) (dig "create" "enabled" false .Values.adminLdap.tls) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/hivemq-edge/templates/secret-mqtts.yml
+++ b/charts/hivemq-edge/templates/secret-mqtts.yml
@@ -8,8 +8,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  keystore-password: {{ .Values.mqtts.create.privateKeyPassword | b64enc }}
-  secret-key-password: {{ .Values.mqtts.create.keystorePassword | b64enc }}
+  keystore-password: {{ .Values.mqtts.create.keystorePassword | b64enc }}
+  secret-key-password: {{ .Values.mqtts.create.privateKeyPassword | b64enc }}
   keystore.jks: |
     {{- .Values.mqtts.create.file | b64enc | nindent 4}}
 {{- end }}

--- a/charts/hivemq-edge/templates/statefulset.yml
+++ b/charts/hivemq-edge/templates/statefulset.yml
@@ -8,6 +8,8 @@ spec:
   selector:
     matchLabels:
       {{- include "hivemq-edge.selector-labels" . | nindent 6 }}
+  {{- /* Does not match the Service name, so pods get no per-pod DNS record. Left as is: spec.serviceName is
+       immutable on a StatefulSet, and changing it would make every helm upgrade of an existing release fail. */}}
   serviceName: "hivemq-edge"
   template:
     metadata:
@@ -42,6 +44,11 @@ spec:
               path: /api/v1/health/liveness
               port: 8080
             initialDelaySeconds: {{ .Values.liveness.initialDelaySeconds }}
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health/readiness
+              port: 8080
             periodSeconds: 5
           ports:
             {{- if .Values.http.enabled }}
@@ -92,15 +99,20 @@ spec:
             {{- end }}
             - name: HIVEMQ_DATAHUB_ENABLED
               value: "{{ and .Values.modules.dataHub.enabled .Values.license.enabled }}"
-            {{- if and .Values.license.enabled .Values.modules.persistence.enabled .Values.modules.dataHub.enabled }}
+            {{- if and .Values.license.enabled .Values.modules.dataHub.enabled }}
+            {{/* Every variable below is referenced by Edge's conf-k8s/config.xml inside the block that
+                 HIVEMQ_DATAHUB_ENABLED gates, and an unset ${ENV:...} aborts the start. So they are set
+                 exactly when that gate is true, and Data Hub cannot be enabled without the persistence
+                 volume the script state lives on. */}}
+            {{- if not .Values.modules.persistence.enabled }}
+            {{- fail "modules.dataHub.enabled requires modules.persistence.enabled: Data Hub stores its script state on the persistence volume" }}
+            {{- end }}
             - name: HIVEMQ_DATAHUB_SCRIPTSTATE_PATH
               value: /persistence/scriptstate.db
             - name: HIVEMQ_DATAHUB_WATCHER_INTERVAL
               value: "{{ .Values.modules.dataHub.watcher.interval }}"
             - name: HIVEMQ_DATAHUB_WATCHER_INITIAL_DELAY
               value: "{{ .Values.modules.dataHub.watcher.initialDelay }}"
-            - name: HIVEMQ_DATAHUB_WAIT_BEFORE_DELETE
-              value: "{{ .Values.modules.dataHub.watcher.waitBeforeDelete }}"
             {{- end }}
             {{- if .Values.mqtt.enabled }}
             - name: HIVEMQ_MQTT_ENABLED
@@ -187,7 +199,10 @@ spec:
                   name: "{{ include "hivemq-edge.name" (dict "prefix" "hivemq-edge" "name" "clientauth" "releaseName" .Release.Name) }}"
                   key: truststore-password
             {{- end }}
-            {{- if and (.Values.adminLdap.tls.enabled) (ne .Values.adminLdap.tls.create.enabled true) }}
+            {{- if and (.Values.adminLdap.tls.enabled) (not (dig "create" "enabled" false .Values.adminLdap.tls)) }}
+            {{- if not (dig "truststore" "truststoreSecretName" "" .Values.adminLdap.tls) }}
+            {{- fail "adminLdap.tls.enabled requires either adminLdap.tls.create.enabled or adminLdap.tls.truststore.* naming an existing secret" }}
+            {{- end }}
             - name: HIVEMQ_LDAP_TLS_TRUSTSTORE_ENABLED
               value: "true"
             - name: HIVEMQ_LDAP_TRUSTSTORE_PATH
@@ -198,7 +213,7 @@ spec:
                   name: "{{ .Values.adminLdap.tls.truststore.passwordSecretName }}"
                   key: "{{ .Values.adminLdap.tls.truststore.passwordSecretKey }}"
             {{- end }}
-            {{- if and (.Values.adminLdap.tls.enabled) (.Values.adminLdap.tls.create.enabled) }}
+            {{- if and (.Values.adminLdap.tls.enabled) (dig "create" "enabled" false .Values.adminLdap.tls) }}
             - name: HIVEMQ_LDAP_TLS_TRUSTSTORE_ENABLED
               value: "true"
             - name: HIVEMQ_LDAP_TRUSTSTORE_PATH
@@ -220,7 +235,7 @@ spec:
             - name: HIVEMQ_LDAP_SIMPLEBIND_RDNS
               value: "{{ .Values.adminLdap.simplebind.userDn }}"
             - name: HIVEMQ_LDAP_SIMPLEBIND_PASSWORD
-              value: "{{ .Values.adminLdap.simplebind.password }}"
+              value: {{ .Values.adminLdap.simplebind.password | quote }}
             - name: HIVEMQ_LDAP_UID
               value: "{{ .Values.adminLdap.uid }}"
             - name: HIVEMQ_LDAP_RDNS
@@ -261,7 +276,7 @@ spec:
             - name: HIVEMQ_LDAP_USER_ROLE_SUPER_QUERY
               value: "{{ .Values.adminLdap.userRoleSuperQuery }}"
               {{- else }}
-            - name: HIVEMQ_LDAP_USER_ROLE_USER_QUERY
+            - name: HIVEMQ_LDAP_USER_ROLE_SUPER_QUERY
               value: ""
               {{- end }}
               {{- if .Values.adminLdap.userRoleUserQuery }}
@@ -324,11 +339,11 @@ spec:
             - name: HIVEMQ_PRE_LOGIN_NOTICE_ENABLED
               value: "{{ .Values.preLoginNotice.enabled }}"
             - name: HIVEMQ_PRE_LOGIN_NOTICE_TITLE
-              value: "{{ .Values.preLoginNotice.title }}"
+              value: {{ .Values.preLoginNotice.title | quote }}
             - name: HIVEMQ_PRE_LOGIN_NOTICE_MESSAGE
-              value: "{{ .Values.preLoginNotice.message }}"
+              value: {{ .Values.preLoginNotice.message | quote }}
             - name: HIVEMQ_PRE_LOGIN_NOTICE_CONSENT
-              value: "{{ .Values.preLoginNotice.consent }}"
+              value: {{ .Values.preLoginNotice.consent | quote }}
             {{- end }}
             {{- with .Values.env }}
               {{- toYaml . | nindent 12 }}
@@ -442,7 +457,7 @@ spec:
               - key: truststore.jks
                 path: truststore.jks
       {{- end -}}
-      {{- if and (.Values.adminLdap.tls.enabled) (ne .Values.adminLdap.tls.create.enabled true) }}
+      {{- if and (.Values.adminLdap.tls.enabled) (not (dig "create" "enabled" false .Values.adminLdap.tls)) }}
         - name: ldap-truststore-jks
           secret:
             secretName: "{{ .Values.adminLdap.tls.truststore.truststoreSecretName }}"
@@ -450,7 +465,7 @@ spec:
               - key: "{{ .Values.adminLdap.tls.truststore.truststoreSecretKey }}"
                 path: "{{ .Values.adminLdap.tls.truststore.truststoreSecretKey }}"
       {{- end -}}
-      {{- if and (.Values.adminLdap.tls.enabled) (.Values.adminLdap.tls.create.enabled) }}
+      {{- if and (.Values.adminLdap.tls.enabled) (dig "create" "enabled" false .Values.adminLdap.tls) }}
         - name: ldap-truststore-jks
           secret:
             secretName: {{ include "hivemq-edge.name" (dict "prefix" "hivemq-edge" "name" "ldap" "releaseName" .Release.Name) }}
@@ -458,13 +473,22 @@ spec:
               - key: truststore.jks
                 path: truststore.jks
       {{- end -}}
+      {{- if .Values.license.enabled }}
+      {{- if and (not .Values.license.secret) (not .Values.license.file) }}
+      {{- fail "license.enabled requires either license.file or license.secret" }}
+      {{- end }}
+      {{- if and .Values.license.secret .Values.license.file }}
+      {{- fail "license.file and license.secret are mutually exclusive" }}
+      {{- end }}
+      {{- end }}
       {{- if and .Values.license.enabled .Values.license.secret }}
         - name: license
           secret:
             secretName: "{{ .Values.license.secret.secretName }}"
             items:
               - key: "{{ .Values.license.secret.secretKey }}"
-                path: "{{ .Values.license.secret.secretKey }}"
+                {{/* The licence loader reads only files ending in .edgelic, whatever the secret key is called. */}}
+                path: license.edgelic
       {{- end -}}
       {{- if and (.Values.license.enabled) (.Values.license.file) }}
         - name: license
@@ -480,7 +504,8 @@ spec:
             secretName: "{{ .Values.pulse.secret.secretName }}"
             items:
               - key: "{{ .Values.pulse.secret.secretKey }}"
-                path: "{{ .Values.pulse.secret.secretKey }}"
+                {{/* The Pulse agent reads only tokenbase64.jwt, whatever the secret key is called. */}}
+                path: tokenbase64.jwt
       {{- end -}}
       {{- if and (.Values.pulse.enabled) (.Values.pulse.token) }}
         - name: pulse
@@ -503,7 +528,12 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: "{{.Values.modules.persistence.storageClassName }}"
+      {{- if not .Values.modules.persistence.size }}
+      {{- fail "modules.persistence.enabled requires modules.persistence.size" }}
+      {{- end }}
+      {{- with .Values.modules.persistence.storageClassName }}
+      storageClassName: {{ . | quote }}
+      {{- end }}
       resources:
         requests:
           storage: "{{.Values.modules.persistence.size }}"

--- a/charts/hivemq-edge/templates/statefulset.yml
+++ b/charts/hivemq-edge/templates/statefulset.yml
@@ -109,10 +109,12 @@ spec:
             {{- end }}
             - name: HIVEMQ_DATAHUB_SCRIPTSTATE_PATH
               value: /persistence/scriptstate.db
+            {{/* int64: a values file parses integers as floats, and from 1000000 up they print as 1e+06,
+                 which Edge cannot parse and silently replaces with its default. */}}
             - name: HIVEMQ_DATAHUB_WATCHER_INTERVAL
-              value: "{{ .Values.modules.dataHub.watcher.interval }}"
+              value: "{{ int64 .Values.modules.dataHub.watcher.interval }}"
             - name: HIVEMQ_DATAHUB_WATCHER_INITIAL_DELAY
-              value: "{{ .Values.modules.dataHub.watcher.initialDelay }}"
+              value: "{{ int64 .Values.modules.dataHub.watcher.initialDelay }}"
             {{- end }}
             {{- if .Values.mqtt.enabled }}
             - name: HIVEMQ_MQTT_ENABLED
@@ -531,9 +533,9 @@ spec:
       {{- if not .Values.modules.persistence.size }}
       {{- fail "modules.persistence.enabled requires modules.persistence.size" }}
       {{- end }}
-      {{- with .Values.modules.persistence.storageClassName }}
-      storageClassName: {{ . | quote }}
-      {{- end }}
+      {{- /* Rendered even when unset: "" is what every existing release carries here, and the field is
+           immutable on a StatefulSet, so omitting it would make helm upgrade fail for all of them. */}}
+      storageClassName: {{ .Values.modules.persistence.storageClassName | default "" | quote }}
       resources:
         requests:
           storage: "{{.Values.modules.persistence.size }}"

--- a/charts/hivemq-edge/tests/datahub/hivemq_edge_configmap-datahub_test.yaml
+++ b/charts/hivemq-edge/tests/datahub/hivemq_edge_configmap-datahub_test.yaml
@@ -55,3 +55,15 @@ tests:
           path: data["init.json"]
           value: |
             {}
+
+  - it: Should default to a preset Edge accepts when no init is given
+    set:
+      modules:
+        dataHub:
+          init: ""
+    asserts:
+      # Edge validates the preset against a schema that requires all four arrays; a bare {} aborts the start.
+      - equal:
+          path: data["init.json"]
+          value: |
+            {"scripts":[],"schemas":[],"behaviorPolicies":[],"dataPolicies":[]}

--- a/charts/hivemq-edge/tests/datahub/hivemq_edge_statefulset_test.yaml
+++ b/charts/hivemq-edge/tests/datahub/hivemq_edge_statefulset_test.yaml
@@ -216,6 +216,41 @@ tests:
           path: spec.volumeClaimTemplates[0].metadata.labels["app.kubernetes.io/managed-by"]
           value: Helm
 
+  - it: Should keep an empty storage class when none is set, as every existing release has it
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: ""
+
+  - it: Should render the configured storage class
+    set:
+      modules:
+        persistence:
+          storageClassName: local-storage
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: local-storage
+
+  - it: Should render watcher timings of a million and more as integers
+    set:
+      modules:
+        dataHub:
+          watcher:
+            interval: 1000000
+            initialDelay: 1800000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HIVEMQ_DATAHUB_WATCHER_INTERVAL
+            value: "1000000"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HIVEMQ_DATAHUB_WATCHER_INITIAL_DELAY
+            value: "1800000"
+
   - it: Should define the correct volumes
     asserts:
       - contains:

--- a/charts/hivemq-edge/tests/datahub/hivemq_edge_statefulset_test.yaml
+++ b/charts/hivemq-edge/tests/datahub/hivemq_edge_statefulset_test.yaml
@@ -19,6 +19,7 @@ set:
       enabled: true
     persistence:
       enabled: true
+      size: 1Gi
 
 tests:
   - it: Should have the correct metadata
@@ -105,7 +106,7 @@ tests:
           content:
             name: HIVEMQ_DATAHUB_ENABLED
             value: "true"
-      - contains:
+      - notContains:
           path: spec.template.spec.containers[0].env
           content:
             name: HIVEMQ_DATAHUB_WAIT_BEFORE_DELETE
@@ -141,6 +142,36 @@ tests:
           content:
             name: JAVA_OPTS
             value: "-XX:+UnlockExperimentalVMOptions -XX:InitialRAMPercentage=75 -XX:MaxRAMPercentage=75"
+
+  - it: Should refuse Data Hub without the persistence volume
+    set:
+      modules:
+        persistence:
+          enabled: false
+    asserts:
+      - failedTemplate:
+          errorPattern: "modules.dataHub.enabled requires modules.persistence.enabled"
+
+  - it: Should not set the Data Hub variables when the license is missing
+    set:
+      license:
+        enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HIVEMQ_DATAHUB_ENABLED
+            value: "false"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HIVEMQ_DATAHUB_SCRIPTSTATE_PATH
+            value: /persistence/scriptstate.db
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HIVEMQ_DATAHUB_WATCHER_INTERVAL
+            value: "5000"
 
   - it: Should set the correct resource limits and requests
     asserts:

--- a/charts/hivemq-edge/tests/default/hivemq_edge_statefulset_test.yaml
+++ b/charts/hivemq-edge/tests/default/hivemq_edge_statefulset_test.yaml
@@ -61,6 +61,9 @@ tests:
   - it: Should define the correct probes
     asserts:
       - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /api/v1/health/readiness
+      - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /api/v1/health/liveness
       - equal:

--- a/charts/hivemq-edge/tests/ldap/hivemq_edge_statefulset_test.yaml
+++ b/charts/hivemq-edge/tests/ldap/hivemq_edge_statefulset_test.yaml
@@ -437,7 +437,7 @@ tests:
             name: HIVEMQ_LDAP_USER_ROLE_USER_QUERY
             value: "(&amp;(entryDN={userDn})(memberOf=cn=data-scientists,ou=groups,dc=example,dc=org))"
 
-  - it: Should set HIVEMQ_LDAP_USER_ROLES_ENABLED without role queries when none are provided
+  - it: Should set HIVEMQ_LDAP_USER_ROLES_ENABLED with empty role queries when none are provided
     set:
       adminLdap:
         userRolesEnabled: true
@@ -447,18 +447,53 @@ tests:
           content:
             name: HIVEMQ_LDAP_USER_ROLES_ENABLED
             value: "true"
-      - notContains:
+      # Edge's config template references all three queries inside the block this gate enables, and an
+      # unset variable aborts the start. Each must be present, empty, under its own name: the super-query
+      # branch once emitted HIVEMQ_LDAP_USER_ROLE_USER_QUERY twice and the super variable never.
+      - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: HIVEMQ_LDAP_USER_ROLE_ADMIN_QUERY
-      - notContains:
+            value: ""
+      - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: HIVEMQ_LDAP_USER_ROLE_SUPER_QUERY
-      - notContains:
+            value: ""
+      - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: HIVEMQ_LDAP_USER_ROLE_USER_QUERY
+            value: ""
+
+  - it: Should refuse LDAP TLS without a truststore source
+    set:
+      adminLdap:
+        tlsMode: "LDAPS"
+        tls:
+          enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "adminLdap.tls.enabled requires either"
+
+  - it: Should render an external LDAP truststore without a create block in the values
+    set:
+      adminLdap:
+        tlsMode: "LDAPS"
+        tls:
+          enabled: true
+          truststore:
+            truststoreSecretName: "my-ldap-truststore"
+            truststoreSecretKey: "truststore.jks"
+            passwordSecretName: "my-ldap-truststore"
+            passwordSecretKey: "password"
+    asserts:
+      - notFailedTemplate: { }
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HIVEMQ_LDAP_TLS_TRUSTSTORE_ENABLED
+            value: "true"
 
   - it: Should not set user roles environment variables when userRolesEnabled is not set
     asserts:

--- a/charts/hivemq-edge/tests/license/hivemq_edge_statefulset_license_external_test.yaml
+++ b/charts/hivemq-edge/tests/license/hivemq_edge_statefulset_license_external_test.yaml
@@ -148,7 +148,7 @@ tests:
               secret:
                 items:
                   - key: "keyy"
-                    path: "keyy"
+                    path: "license.edgelic"
                 secretName: secrety
             - name: hivemq-edge-persistence-edge
               emptyDir: {}

--- a/charts/hivemq-edge/tests/license/hivemq_edge_statefulset_test.yaml
+++ b/charts/hivemq-edge/tests/license/hivemq_edge_statefulset_test.yaml
@@ -16,6 +16,34 @@ set:
     file: "1234"
 
 tests:
+  - it: Should refuse a licence without a source
+    set:
+      license:
+        file: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "license.enabled requires either license.file or license.secret"
+
+  - it: Should refuse a licence with both sources
+    set:
+      license:
+        secret:
+          secretName: secrety
+          secretKey: keyy
+    asserts:
+      - failedTemplate:
+          errorPattern: "license.file and license.secret are mutually exclusive"
+
+  - it: Should refuse persistence without a size
+    set:
+      modules:
+        persistence:
+          enabled: true
+          size: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "modules.persistence.enabled requires modules.persistence.size"
+
   - it: Should have the correct metadata
     asserts:
       - equal:

--- a/charts/hivemq-edge/tests/mqtts/hivemq_edge_secret-mqtts_test.yaml
+++ b/charts/hivemq-edge/tests/mqtts/hivemq_edge_secret-mqtts_test.yaml
@@ -21,6 +21,24 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: Secret should carry each password under the key the StatefulSet reads it from
+    set:
+      mqtts:
+        create:
+          enabled: true
+          keystorePassword: "store-pw"
+          privateKeyPassword: "key-pw"
+          file: "1234"
+    asserts:
+      # HIVEMQ_MQTTS_SECRET_KEYSTORE_PASSWORD reads keystore-password, _PRIVATE_KEY_PASSWORD reads
+      # secret-key-password. The two were once swapped, invisible while both passwords were "changeit".
+      - equal:
+          path: data["keystore-password"]
+          value: c3RvcmUtcHc=
+      - equal:
+          path: data["secret-key-password"]
+          value: a2V5LXB3
+
   - it: Secret should be present when creation is requested
     set:
       mqtts:

--- a/charts/hivemq-edge/tests/pulse/hivemq_edge_statefulset_test.yaml
+++ b/charts/hivemq-edge/tests/pulse/hivemq_edge_statefulset_test.yaml
@@ -77,5 +77,5 @@ tests:
             secret:
               items:
                 - key: "keyy"
-                  path: "keyy"
+                  path: "tokenbase64.jwt"
               secretName: secrety

--- a/charts/hivemq-edge/values.schema.json
+++ b/charts/hivemq-edge/values.schema.json
@@ -1,575 +1,604 @@
 {
-  "$schema" : "https://json-schema.org/draft/2020-12/schema",
-  "properties" : {
-    "image" : {
-      "properties" : {
-        "pullPolicy" : {
-          "enum" : [
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "image": {
+      "properties": {
+        "pullPolicy": {
+          "enum": [
             "IfNotPresent",
             "Never",
             "Always"
           ],
-          "type" : "string"
+          "type": "string"
         },
-        "repository" : {
-          "type" : "string"
+        "repository": {
+          "type": "string"
         },
-        "tag" : {
-          "type" : "string"
+        "tag": {
+          "type": "string"
         }
       }
     },
-    "config" : {
-      "description" : "The configuration fragment.",
-      "type" : "string"
+    "config": {
+      "description": "The configuration fragment.",
+      "type": "string"
     },
     "configCompressed": {
       "description": "Indicates the provided config is zipped and then encoded using base64.",
-      "type" : "string"
+      "type": "string"
     },
-    "license" : {
-      "description" : "License configuration.",
-      "enabled" : {
-        "type" : "boolean"
-      },
-      "secret" : {
-        "properties" : {
-          "secretName" : {
-            "description" : "Name of the secret where the license is stored.",
-            "type" : "string"
-          },
-          "secretKey" : {
-            "description" : "Name of the key inside the secret which contains the license.",
-            "type" : "string"
-          }
+    "license": {
+      "description": "License configuration.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
         },
-        "type" : "object"
-      },
-      "file" : {
-        "description" : "Specify the external file to load as the license.",
-        "type" : "string"
-      }
-    },
-    "admin" : {
-      "description" : "Configure the admin user/password.",
-      "properties" : {
-        "user" : {
-          "type" : "string"
-        },
-        "password" : {
-          "type" : "string"
-        },
-        "secret" : {
-          "properties" : {
-            "enabled" : {
-              "type" : "boolean"
+        "secret": {
+          "properties": {
+            "secretName": {
+              "description": "Name of the secret where the license is stored.",
+              "type": "string"
             },
-            "secretName" : {
-              "description" : "Name of the secret where the admin credentials are stored.",
-              "type" : "string"
-            },
-            "secretUserKey" : {
-              "description" : "Name of the key inside the secret which contains the admin user name.",
-              "type" : "string"
-            },
-            "secretPasswordKey" : {
-              "description" : "Name of the key inside the secret which contains the admin password.",
-              "type" : "string"
+            "secretKey": {
+              "description": "Name of the key inside the secret which contains the license.",
+              "type": "string"
             }
           },
-          "type" : "object"
+          "type": "object"
         },
-        "file" : {
-          "description" : "Specify the external file to load as the license.",
-          "type" : "string"
+        "file": {
+          "description": "Specify the external file to load as the license.",
+          "type": "string"
+        }
+      }
+    },
+    "admin": {
+      "description": "Configure the admin user/password.",
+      "properties": {
+        "user": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "secret": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "secretName": {
+              "description": "Name of the secret where the admin credentials are stored.",
+              "type": "string"
+            },
+            "secretUserKey": {
+              "description": "Name of the key inside the secret which contains the admin user name.",
+              "type": "string"
+            },
+            "secretPasswordKey": {
+              "description": "Name of the key inside the secret which contains the admin password.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "file": {
+          "description": "Specify the external file to load as the license.",
+          "type": "string"
         }
       },
-      "type" : "object"
+      "type": "object"
     },
-    "adminLdap" : {
-      "description" : "Configure the admin source via LDAP.",
-      "properties" : {
-        "enabled" : {
-          "type" : "boolean",
-          "description" : "Enable LDAP, will disable user based authentication source."
+    "adminLdap": {
+      "description": "Configure the admin source via LDAP.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable LDAP, will disable user based authentication source."
         },
-        "servers" : {
-          "description" : "Set of ldap servers used for round robin",
-          "items" : {
-            "properties" : {
-              "host" : {
-                "type" : "string",
-                "description" : "The hostname or IP address of the LDAP server."
+        "servers": {
+          "description": "Set of ldap servers used for round robin",
+          "items": {
+            "properties": {
+              "host": {
+                "type": "string",
+                "description": "The hostname or IP address of the LDAP server."
               },
-              "port" : {
-                "type" : "integer",
-                "description" : "The port number of the LDAP server."
+              "port": {
+                "type": "integer",
+                "description": "The port number of the LDAP server."
               }
             },
-            "type" : "object"
+            "type": "object"
           },
-          "type" : "array",
+          "type": "array",
           "minItems": 1,
           "maxItems": 3
         },
-        "tlsMode" : {
-          "description" : "TLS mode for the LDAP connection.",
-          "enum" : [
+        "tlsMode": {
+          "description": "TLS mode for the LDAP connection.",
+          "enum": [
             "NONE",
             "START_TLS",
             "LDAPS"
           ],
-          "type" : "string"
+          "type": "string"
         },
-        "tls" : {
-          "description" : "Configure the TLS truststore for the LDAP connection.",
-          "type" : "object",
-          "properties" : {
-            "enabled" : {
-              "type" : "boolean",
-              "description" : "Enable or disable TLS for the LDAP connection."
+        "tls": {
+          "description": "Configure the TLS truststore for the LDAP connection.",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable or disable TLS for the LDAP connection."
             },
-            "truststore" : {
-              "description" : "The truststore for interacting with ldap.",
-              "type" : "object",
-              "properties" : {
-                "passwordSecretName" : {
-                  "description" : "Name of the secret which contains the password for the keystore.",
-                  "type" : "string"
+            "truststore": {
+              "description": "The truststore for interacting with ldap.",
+              "type": "object",
+              "properties": {
+                "passwordSecretName": {
+                  "description": "Name of the secret which contains the password for the keystore.",
+                  "type": "string"
                 },
-                "passwordSecretKey" : {
-                  "description" : "Key inside the secret which contains the password for the keystore.",
-                  "type" : "string"
+                "passwordSecretKey": {
+                  "description": "Key inside the secret which contains the password for the keystore.",
+                  "type": "string"
                 },
-                "truststoreSecretName" : {
-                  "description" : "Name of the secret which contains the truststore.",
-                  "type" : "string"
+                "truststoreSecretName": {
+                  "description": "Name of the secret which contains the truststore.",
+                  "type": "string"
                 },
-                "truststoreSecretKey" : {
-                  "description" : "Key inside the secret which contains the truststore.",
-                  "type" : "string"
+                "truststoreSecretKey": {
+                  "description": "Key inside the secret which contains the truststore.",
+                  "type": "string"
                 }
               }
             },
-            "create" : {
-              "description" : "Create the secret for the truststore and its password.",
-              "type" : "object",
-              "properties" : {
-                "enabled" : {
-                  "type" : "boolean"
+            "create": {
+              "description": "Create the secret for the truststore and its password.",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
                 },
-                "password" : {
-                  "description" : "Password for the truststore itself.",
-                  "type" : "string"
+                "password": {
+                  "description": "Password for the truststore itself.",
+                  "type": "string"
                 },
-                "file" : {
-                  "description" : "The actual truststore, base64 encoded.",
-                  "type" : "string"
+                "file": {
+                  "description": "The actual truststore, base64 encoded.",
+                  "type": "string"
                 }
               }
             }
           }
         },
-        "objectClass" : {
-          "type" : "string",
-          "description" : "The object class to use for user entries."
+        "objectClass": {
+          "type": "string",
+          "description": "The object class to use for user entries."
         },
-        "simplebind" : {
-          "properties" : {
-            "userDn" : {
-              "type" : "string",
-              "description" : "The distinguished name of the user to bind as."
+        "simplebind": {
+          "properties": {
+            "userDn": {
+              "type": "string",
+              "description": "The distinguished name of the user to bind as."
             },
-            "password" : {
-              "type" : "string",
-              "description" : "The password to use for the bind."
+            "password": {
+              "type": "string",
+              "description": "The password to use for the bind."
             }
           },
-          "type" : "object"
+          "type": "object"
         },
-        "uid" : {
-          "type" : "string",
-          "description" : "The uid to use for the user bind."
+        "uid": {
+          "type": "string",
+          "description": "The uid to use for the user bind."
         },
-        "rdns" : {
-          "type" : "string",
-          "description" : "The RDNS to use for the user bind."
+        "rdns": {
+          "type": "string",
+          "description": "The RDNS to use for the user bind."
         },
-        "directoryDescent" : {
-          "type" : "boolean",
-          "description" : "Whether to use directory descent to find the user."
+        "directoryDescent": {
+          "type": "boolean",
+          "description": "Whether to use directory descent to find the user."
         },
-        "maxConnections" : {
-          "type" : "integer",
-          "description" : "Maximum number of pooled ldap connections."
+        "maxConnections": {
+          "type": "integer",
+          "description": "Maximum number of pooled ldap connections."
         },
-        "connectionTimeoutMillis" : {
-          "type" : "integer",
-          "description" : "Timeout for LDAP connection attempts."
+        "connectionTimeoutMillis": {
+          "type": "integer",
+          "description": "Timeout for LDAP connection attempts."
         },
-        "responseTimeoutMillis" : {
-          "type" : "integer",
-          "description" : "Timeout for LDAP responses."
+        "responseTimeoutMillis": {
+          "type": "integer",
+          "description": "Timeout for LDAP responses."
         },
-        "searchTimeoutSeconds" : {
-          "type" : "integer",
-          "description" : "Timeout for LDAP searches."
+        "searchTimeoutSeconds": {
+          "type": "integer",
+          "description": "Timeout for LDAP searches."
         },
-        "baseDn" : {
-          "type" : "string",
-          "description" : "Optional Base DN. When specified, both rdns and service account rdns are relative to this."
+        "baseDn": {
+          "type": "string",
+          "description": "Optional Base DN. When specified, both rdns and service account rdns are relative to this."
         },
-        "userRolesEnabled" : {
-          "type" : "boolean",
-          "description" : "Enable LDAP user role queries."
+        "userRolesEnabled": {
+          "type": "boolean",
+          "description": "Enable LDAP user role queries."
         },
-        "userRoleAdminQuery" : {
-          "type" : "string",
-          "description" : "LDAP query to determine if a user has the ADMIN role."
+        "userRoleAdminQuery": {
+          "type": "string",
+          "description": "LDAP query to determine if a user has the ADMIN role."
         },
-        "userRoleSuperQuery" : {
-          "type" : "string",
-          "description" : "LDAP query to determine if a user has the SUPER role."
+        "userRoleSuperQuery": {
+          "type": "string",
+          "description": "LDAP query to determine if a user has the SUPER role."
         },
-        "userRoleUserQuery" : {
-          "type" : "string",
-          "description" : "LDAP query to determine if a user has the USER role."
+        "userRoleUserQuery": {
+          "type": "string",
+          "description": "LDAP query to determine if a user has the USER role."
         }
       },
-      "type" : "object"
+      "type": "object"
     },
-    "pulse" : {
-      "description" : "Configure the pulse connection token.",
-      "properties" : {
-        "enabled" : {
-          "type" : "boolean",
-          "description" : "Enable pulse."
+    "pulse": {
+      "description": "Configure the pulse connection token.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable pulse."
         },
-        "token" : {
-          "type" : "string",
-          "description" : "The pulse connection token."
+        "token": {
+          "type": "string",
+          "description": "The pulse connection token."
         },
-        "secret" : {
-          "properties" : {
-            "enabled" : {
-              "description" : "Enable wiring pulse token to a provided k8s secret.",
-              "type" : "boolean"
+        "secret": {
+          "properties": {
+            "enabled": {
+              "description": "Enable wiring pulse token to a provided k8s secret.",
+              "type": "boolean"
             },
-            "secretName" : {
-              "description" : "Name of the secret where the pulse token is stored.",
-              "type" : "string"
+            "secretName": {
+              "description": "Name of the secret where the pulse token is stored.",
+              "type": "string"
             },
-            "secretKey" : {
-              "description" : "Name of the key inside the secret which contains the token.",
-              "type" : "string"
+            "secretKey": {
+              "description": "Name of the key inside the secret which contains the token.",
+              "type": "string"
             }
           },
-          "type" : "object"
+          "type": "object"
         }
       },
-      "type" : "object"
+      "type": "object"
     },
-    "preLoginNotice" : {
-      "description" : "Pre-login notice configuration for admin UI.",
-      "properties" : {
-        "enabled" : {
-          "type" : "boolean",
-          "description" : "Enable the pre-login notice."
+    "preLoginNotice": {
+      "description": "Pre-login notice configuration for admin UI.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable the pre-login notice."
         },
-        "title" : {
-          "type" : "string",
-          "description" : "Title of the pre-login notice."
+        "title": {
+          "type": "string",
+          "description": "Title of the pre-login notice."
         },
-        "message" : {
-          "type" : "string",
-          "description" : "Message content of the pre-login notice."
+        "message": {
+          "type": "string",
+          "description": "Message content of the pre-login notice."
         },
-        "consent" : {
-          "type" : "string",
-          "description" : "Consent text for the pre-login notice."
+        "consent": {
+          "type": "string",
+          "description": "Consent text for the pre-login notice."
         }
       },
-      "type" : "object"
+      "type": "object"
     },
-    "mqtt" : {
-      "enabled" : {
-        "description" : "Enable the unencrypted mqtt listener.",
-        "type" : "boolean"
-      }
-    },
-    "http" : {
-      "enabled" : {
-        "description" : "Enable the unencrypted http listener for the REST API and the UI.",
-        "type" : "boolean"
-      }
-    },
-    "mqtts" : {
-      "enabled" : {
-        "description" : "Enable the TLS protected MQTT endpoint.",
-        "type" : "boolean"
-      },
-      "preferServerCipherSuites" : {
-        "description" : "Server cipher suite is preferred over the client one.",
-        "type" : "boolean"
-      },
-      "keystore" : {
-        "passwordSecretName" : {
-          "description" : "Name of the secret where the keystore password is stored.",
-          "type" : "string"
-        },
-        "passwordSecretKey" : {
-          "description" : "Name of the key inside the secret which contains the password for the keystore.",
-          "type" : "string"
-        },
-        "privateKeyPasswordSecretName" : {
-          "description" : "Name of the secret where the private key password is stored.",
-          "type" : "string"
-        },
-        "privateKeyPasswordSecretKey" : {
-          "description" : "Name of key in the secret where the private key password is stored.",
-          "type" : "string"
-        }
-      },
-      "create" : {
-        "description" : "Create the secret for the keystore and its passwords.",
-        "enabled" : {
-          "type" : "boolean"
-        },
-        "privateKeyPassword" : {
-          "description" : "Password for the private key in the keystore.",
-          "type" : "object"
-        },
-        "keystorePassword" : {
-          "description" : "Password for the keystore itself.",
-          "type" : "object"
-        },
-        "file" : {
-          "description" : "The actual keystore, base64 encoded.",
-          "type" : "object"
+    "mqtt": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable the unencrypted mqtt listener.",
+          "type": "boolean"
         }
       }
     },
-    "mqttsClientauth" : {
-      "clientAuthenticationMode" : {
-        "description" : "Select whether client auth is enabled and if it is required.",
-        "enum" : [
-          "NONE",
-          "OPTIONAL",
-          "REQUIRED"
-        ],
-        "type" : "string"
-      },
-      "truststore" : {
-        "passwordSecretName" : {
-          "description" : "Name of the secret which contains the password for the keystore.",
-          "type" : "string"
-        },
-        "passwordSecretKey" : {
-          "description" : "Key inside the secret which contains the password for the keystore.",
-          "type" : "string"
-        },
-        "truststoreSecretName" : {
-          "description" : "Name of the secret which contains the truststore.",
-          "type" : "string"
-        },
-        "truststoreSecretKey" : {
-          "description" : "Key inside the secret which contains the truststore.",
-          "type" : "string"
-        }
-      },
-      "create" : {
-        "description" : "Create the secret for the truststore and its passwords.",
-        "enabled" : {
-          "type" : "boolean"
-        },
-        "truststorePassword" : {
-          "description" : "Password for the truststore itself.",
-          "type" : "string"
-        },
-        "file" : {
-          "description" : "The actual truststore, base64 encoded.",
-          "type" : "string"
+    "http": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Expose the unencrypted http port 8080 of the REST API and the UI on the pod and the Service. The listener itself is always active.",
+          "type": "boolean"
         }
       }
     },
-    "resources" : {
-      "properties" : {
-        "cpu" : {
-          "type" : "string"
+    "mqtts": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable the TLS protected MQTT endpoint.",
+          "type": "boolean"
         },
-        "memory" : {
-          "type" : "string"
+        "preferServerCipherSuites": {
+          "description": "Server cipher suite is preferred over the client one.",
+          "type": "boolean"
+        },
+        "keystore": {
+          "type": "object",
+          "properties": {
+            "passwordSecretName": {
+              "description": "Name of the secret where the keystore password is stored.",
+              "type": "string"
+            },
+            "passwordSecretKey": {
+              "description": "Name of the key inside the secret which contains the password for the keystore.",
+              "type": "string"
+            },
+            "privateKeyPasswordSecretName": {
+              "description": "Name of the secret where the private key password is stored.",
+              "type": "string"
+            },
+            "privateKeyPasswordSecretKey": {
+              "description": "Name of key in the secret where the private key password is stored.",
+              "type": "string"
+            }
+          }
+        },
+        "create": {
+          "description": "Create the secret for the keystore and its passwords.",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "privateKeyPassword": {
+              "description": "Password for the private key in the keystore.",
+              "type": "string"
+            },
+            "keystorePassword": {
+              "description": "Password for the keystore itself.",
+              "type": "string"
+            },
+            "file": {
+              "description": "The actual keystore, base64 encoded.",
+              "type": "string"
+            }
+          }
         }
       }
     },
-    "logLevel" : {
-      "enum" : [
+    "mqttsClientauth": {
+      "type": "object",
+      "properties": {
+        "clientAuthenticationMode": {
+          "description": "Select whether client auth is enabled and if it is required.",
+          "enum": [
+            "NONE",
+            "OPTIONAL",
+            "REQUIRED"
+          ],
+          "type": "string"
+        },
+        "truststore": {
+          "type": "object",
+          "properties": {
+            "passwordSecretName": {
+              "description": "Name of the secret which contains the password for the keystore.",
+              "type": "string"
+            },
+            "passwordSecretKey": {
+              "description": "Key inside the secret which contains the password for the keystore.",
+              "type": "string"
+            },
+            "truststoreSecretName": {
+              "description": "Name of the secret which contains the truststore.",
+              "type": "string"
+            },
+            "truststoreSecretKey": {
+              "description": "Key inside the secret which contains the truststore.",
+              "type": "string"
+            }
+          }
+        },
+        "create": {
+          "description": "Create the secret for the truststore and its passwords.",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "truststorePassword": {
+              "description": "Password for the truststore itself.",
+              "type": "string"
+            },
+            "file": {
+              "description": "The actual truststore, base64 encoded.",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "resources": {
+      "properties": {
+        "cpu": {
+          "type": "string"
+        },
+        "memory": {
+          "type": "string"
+        }
+      }
+    },
+    "logLevel": {
+      "enum": [
         "DEBUG",
         "ERROR",
-        "FATAL",
         "INFO",
         "TRACE",
         "WARN"
       ],
-      "type" : "string"
+      "type": "string"
     },
-    "customLogbackConfig" : {
-      "description" : "Optional setting to provide a custom HiveMQ Edge logging configuration (logback.xml) from a file using --set-file customLogbackConfig=your-logback.xml. NOTE: When set, this overrides the default logging configuration and the logLevel setting will be ignored unless your custom config references the HIVEMQ_LOG_LEVEL environment variable.",
-      "type" : "string"
+    "customLogbackConfig": {
+      "description": "Optional setting to provide a custom HiveMQ Edge logging configuration (logback.xml) from a file using --set-file customLogbackConfig=your-logback.xml. NOTE: When set, this overrides the default logging configuration and the logLevel setting will be ignored unless your custom config references the HIVEMQ_LOG_LEVEL environment variable.",
+      "type": "string"
     },
-    "serviceAccountName" : {
-      "type" : "string"
+    "serviceAccountName": {
+      "type": "string"
     },
-    "javaOpts" : {
-      "type" : "string"
+    "javaOpts": {
+      "type": "string"
     },
-    "podAnnotations" : {
-      "description" : "Annotations to add to the HiveMQ Edge Pod.",
-      "type" : "object"
+    "podAnnotations": {
+      "description": "Annotations to add to the HiveMQ Edge Pod.",
+      "type": "object"
     },
-    "podLabels" : {
-      "description" : "Labels to add to the HiveMQ Edge Pod.",
-      "type" : "object"
+    "podLabels": {
+      "description": "Labels to add to the HiveMQ Edge Pod.",
+      "type": "object"
     },
-    "serviceAnnotations" : {
-      "description" : "Annotations to add to the HiveMQ Edge Pod.",
-      "type" : "object"
+    "serviceAnnotations": {
+      "description": "Annotations to add to the HiveMQ Edge Pod.",
+      "type": "object"
     },
-    "serviceLabels" : {
-      "description" : "Labels to add to the HiveMQ Edge Pod.",
-      "type" : "object"
+    "serviceLabels": {
+      "description": "Labels to add to the HiveMQ Edge Pod.",
+      "type": "object"
     },
-    "env" : {
-      "description" : "Environment variables to be added to the container.",
-      "items" : {
-        "type" : "object"
+    "env": {
+      "description": "Environment variables to be added to the container.",
+      "items": {
+        "type": "object"
       },
-      "type" : "array"
+      "type": "array"
     },
-    "refresh" : {
-      "description" : "Refresh interval for filechecks",
-      "type" : "integer"
+    "refresh": {
+      "description": "Refresh interval for filechecks",
+      "type": "integer"
     },
-    "liveness" : {
-      "type" : "object",
-      "initialDelaySeconds": {
-        "type" : "integer"
+    "liveness": {
+      "type": "object",
+      "properties": {
+        "initialDelaySeconds": {
+          "type": "integer"
+        }
       }
     },
-    "topicFilters" : {
-      "description" : "Configure the available topic filters",
-      "properties" : {
-        "filter" : {
-          "type" : "string"
-        },
-        "description" : {
-          "type" : "string"
-        },
-        "schema" : {
-          "type" : "string"
-        }
-      },
-      "required" : [
-        "filter",
-        "schema"
-      ],
-      "type" : "array"
-    },
-    "volumes" : {
-      "description" : "Additional volumes.",
-      "type" : "array",
-      "items" : {
-        "type" : "object",
-        "properties" : {
-          "mount" : {
-            "type" : "string"
+    "topicFilters": {
+      "description": "Configure the available topic filters",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "type": "string"
           },
-          "definition" : {
-            "type" : "array",
-            "items" : {
-              "type" : "object"
+          "description": {
+            "type": "string"
+          },
+          "schema": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "filter"
+        ]
+      }
+    },
+    "volumes": {
+      "description": "Additional volumes.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "mount": {
+            "type": "string"
+          },
+          "definition": {
+            "type": "array",
+            "items": {
+              "type": "object"
             }
           }
         },
-        "required" : [
+        "required": [
           "mount",
           "definition"
         ]
       }
     },
     "modules": {
-      "properties" : {
+      "properties": {
         "dataHub": {
-          "description" : "Configuration for DataHub.",
-          "type" : "object",
-          "properties" : {
-            "enabled" : {
-              "type" : "boolean",
-              "description" : "Enable/Disable DataHub."
+          "description": "Configuration for DataHub.",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable/Disable DataHub."
             },
-            "init" : {
-              "description" : "Specify the init file to load as for DataHub.",
-              "type" : "string"
+            "init": {
+              "description": "Specify the init file to load as for DataHub.",
+              "type": "string"
             },
             "watcher": {
-              "description" : "Configuration for the DataHub config reload watcher.",
-              "type" : "object",
-              "properties" : {
-                "waitBeforeDelete" : {
-                  "type" : "integer",
-                  "description" : "Wait time before deleting in ms."
+              "description": "Configuration for the DataHub config reload watcher.",
+              "type": "object",
+              "properties": {
+                "initialDelay": {
+                  "description": "Initial delay before watcher starts acting in ms.",
+                  "type": "integer"
                 },
-                "initialDelay" : {
-                  "description" : "Initial delay before watcher starts acting in ms.",
-                  "type" : "integer"
-                },
-                "interval" : {
-                  "description" : "Watcher interval for checks in ms.",
-                  "type" : "integer"
+                "interval": {
+                  "description": "Watcher interval for checks in ms.",
+                  "type": "integer"
                 }
               }
             }
           }
         },
-        "persistence" : {
-          "description" : "Location of the edge persistence.",
-          "mode" : {
-            "enum" : [
-              "in-memory",
-              "file",
-              "file-native"
-            ],
-            "type" : "string"
-          },
-          "enabled" : {
-            "type" : "boolean"
-          },
-          "storageClassName" : {
-            "description" : "Storage class to be used.",
-            "type" : "string"
-          },
-          "size" : {
-            "description" : "Size for the requested claim.",
-            "type" : "string"
+        "persistence": {
+          "description": "Location of the edge persistence.",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "storageClassName": {
+              "description": "Storage class to be used.",
+              "type": "string"
+            },
+            "size": {
+              "description": "Size for the requested claim.",
+              "type": "string"
+            }
           }
-        }        
+        }
       },
       "type": "object"
     },
-    "podSecurityContext" : {
-      "description" : "Security context for the pod.",
-      "type" : "object"
+    "podSecurityContext": {
+      "description": "Security context for the pod.",
+      "type": "object"
     },
-    "containerSecurityContext" : {
-      "description" : "Security context for the container.",
-      "type" : "object"
+    "containerSecurityContext": {
+      "description": "Security context for the container.",
+      "type": "object"
     }
   },
   "not": {
     "allOf": [
-      { "required": ["config"] },
-      { "required": ["configCompressed"] }
+      {
+        "required": [
+          "config"
+        ]
+      },
+      {
+        "required": [
+          "configCompressed"
+        ]
+      }
     ]
   },
-  "type" : "object"
+  "type": "object"
 }

--- a/charts/hivemq-edge/values.yaml
+++ b/charts/hivemq-edge/values.yaml
@@ -206,8 +206,9 @@ modules:
   # DataHub
   dataHub:
     enabled: false
+    # Timings of the preset file watcher: how long after start-up the first check runs, and how often
+    # the file is checked after that. Both in milliseconds.
     watcher:
-      waitBeforeDelete: 5000
       initialDelay: 30000
       interval: 5000
   # Persistence: a volume for persistent state, e.g. rocksdb files

--- a/manifests/hivemq-edge/statefulset.yml
+++ b/manifests/hivemq-edge/statefulset.yml
@@ -31,6 +31,11 @@ spec:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health/readiness
+              port: 8080
+            periodSeconds: 5
           ports:
             - containerPort: 8080
               name: web

--- a/tests-hivemq-edge/src/integrationTest/java/com/hivemq/helmcharts/edge/AbstractHelmEdgeIT.java
+++ b/tests-hivemq-edge/src/integrationTest/java/com/hivemq/helmcharts/edge/AbstractHelmEdgeIT.java
@@ -78,10 +78,10 @@ abstract class AbstractHelmEdgeIT {
     }
 
     /**
-     * Returns a future that completes when the Edge pod logs the standard startup-complete message. The Edge chart
-     * has only a {@code livenessProbe} (no {@code readinessProbe}), so the K8s {@code ready} status flips before the
-     * application has finished booting and bound its listeners. Tests that need to interact with Edge (e.g. opening
-     * an MQTT connection) should wait on this future after {@link #installEdgeChartAndWaitToBeRunning} returns.
+     * Returns a future that completes when the Edge pod logs the standard startup-complete message. Register it
+     * BEFORE {@link #installEdgeChartAndWaitToBeRunning}: the chart's {@code readinessProbe} makes the install wait
+     * until Edge has finished booting, so the line has already been logged by the time the install returns and a
+     * waiter registered afterwards never sees it.
      */
     protected final @NotNull CompletableFuture<String> waitForEdgeStartupLog() {
         return logWaiter.waitFor(EDGE_POD_NAME, ".*Started HiveMQ Edge in.*");

--- a/tests-hivemq-edge/src/integrationTest/java/com/hivemq/helmcharts/edge/HelmEdgeInstallIT.java
+++ b/tests-hivemq-edge/src/integrationTest/java/com/hivemq/helmcharts/edge/HelmEdgeInstallIT.java
@@ -15,14 +15,15 @@ class HelmEdgeInstallIT extends AbstractHelmEdgeIT {
     @Test
     @Timeout(value = 7, unit = TimeUnit.MINUTES)
     void withLocalCharts_edgeRunningAndMqttReachable() throws Exception {
-        // Register the version-log waiter BEFORE install so the line cannot be missed if Edge boots fast.
+        // Register both log waiters BEFORE install: the chart's readiness probe means the install returns
+        // only after Edge has logged its start-up, so a waiter registered afterwards never sees the line.
         final var expectedVersion = System.getProperty("hivemq.edge.tag");
         final var versionLogged = waitForEdgeVersionLog(expectedVersion);
+        final var edgeStartupLogged = waitForEdgeStartupLog();
 
         installEdgeChartAndWaitToBeRunning();
         versionLogged.get(5, TimeUnit.MINUTES);
-
-        waitForEdgeStartupLog().get(5, TimeUnit.MINUTES);
+        edgeStartupLogged.get(5, TimeUnit.MINUTES);
 
         helmChartContainer.testRelease(EDGE_RELEASE_NAME, edgeNamespace);
     }


### PR DESCRIPTION
## Summary

[EDG-1007](https://linear.app/hivemq/issue/EDG-1007): `modules.dataHub.watcher.interval` / `initialDelay` were exported as env vars that nothing read. Edge's `config-k8s.xml` now feeds them into the preset watcher's internal options (hivemq/hivemq-edge#1753), and the chart sets them exactly when `HIVEMQ_DATAHUB_ENABLED` is true. `waitBeforeDelete` is dropped: the Edge key it named has no consumer either.

Reviewing the chart against the container template and the Edge source on the way surfaced eleven defects, each fixed with a regression test:

| Defect | Effect before |
|---|---|
| Data Hub enabled without persistence | `HIVEMQ_DATAHUB_SCRIPTSTATE_PATH` unset → Edge aborts at start. Now a clear `fail`. |
| LDAP `userRolesEnabled` without a super query | `…USER_QUERY` emitted twice, `…SUPER_QUERY` never → abort. The covering test used a name-only `notContains` that can never match. |
| Created MQTTS secret | keystore and private-key passwords stored under each other's keys; hidden while both defaults were `changeit`. |
| External LDAP truststore without `create:` | nil-pointer render error. Now `dig`-guarded, plus a plain `fail` when no truststore source is given. |
| External licence / Pulse secret | mounted under the secret's key name; loaders read only `license.edgelic` / `tokenbase64.jwt`. |
| `license.enabled` with no source / both | undefined or duplicate volume. Now `fail`s. |
| `persistence.enabled` without `size` | `storage: ""`, rejected by the API server. Eight test suites encoded it. |
| `values.schema.json` | `license`, `mqtt`, `http`, `mqtts`, `mqttsClientauth`, `liveness`, `modules.persistence` kept keys outside `properties` → nothing validated; `topicFilters` rules on the array; `FATAL` accepted (logback → DEBUG). |
| No readiness probe | pod Ready before Edge listens. Added `/api/v1/health/readiness`. |
| `dataHub.enabled` without `init` | default `files/datahub.json` was `{}`; Edge's preset schema requires the four arrays → start aborted on every image since 2025.4. Now `{"scripts":[],"schemas":[],"behaviorPolicies":[],"dataPolicies":[]}`. |
| Watcher timings of 1 000 000 ms and up | a values file parses integers as floats, rendered `1e+06`; Edge cannot parse it and silently falls back to its default. Now `int64`. |

Tried and reverted: making `serviceName` match the Service — it is immutable on a StatefulSet and broke `helm upgrade` on a live release; left with a template comment.

## Compatibility

- Old chart + new image: the two watcher variables have been exported since 2025.5, so an image carrying hivemq/hivemq-edge#1753 starts under every chart version.
- New chart + old image: the variables are ignored as before.
- `waitBeforeDelete` in a values file is still accepted (the schema sets no `additionalProperties: false`) and still does nothing; only `logLevel: FATAL` is newly rejected.
- `storageClassName` unset renders `storageClassName: ""` as before. An earlier revision of this PR omitted the field, which is immutable on a StatefulSet and made `helm upgrade` fail with `spec.volumeClaimTemplates: field is immutable` for every release on statically provisioned, class-less volumes; reproduced on kind and covered by a test now.

## Test plan

- `helm lint`, `helm unittest` (178, up from 166), `manifests.sh` regenerated (readiness probe only), `helm kubeconform`: all green — the `edge-verify` set.
- kind, upgrade path: chart `master` + `2026.13` installed with Data Hub, persistence and (a) `storageClassName: standard`, (b) no storage class on a static class-less PV; `helm upgrade` to this chart + `2026.14-SNAPSHOT` succeeds in both, PVC kept, `will check every 2000 millis`; `2026.13` under this chart still starts. Default preset with no `init` starts Data Hub; `interval: 1000000` from a values file arrives as `1000000`. Created MQTTS secret with `storepw1`/`keypw222`: TLS listener up on `2026.14-SNAPSHOT`, `Not able to recover key from KeyStore` on `2026.13`.
- kind cluster, 2026.14-SNAPSHOT image with the Edge side: `watcher.interval: 2000` → `will check every 2000 millis` in the pod; readiness gates the pod; Data Hub preset reload, bridge queue persistence across a pod restart, chart topic filters and fragment hot reload unchanged.

